### PR TITLE
Add basic integration with umlaut.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
       activerecord (>= 3.0)
     addressable (2.3.8)
     arel (6.0.2)
-    autoprefixer-rails (5.2.1)
+    autoprefixer-rails (5.2.1.1)
       execjs
       json
     bcrypt (3.1.10)
@@ -218,7 +218,6 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     rdoc (4.2.0)
-      json (~> 1.4)
     ref (2.0.0)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)

--- a/app/assets/stylesheets/components/record--sidebar.scss
+++ b/app/assets/stylesheets/components/record--sidebar.scss
@@ -2,3 +2,7 @@
 .holding-info .holding-info--heading {
     margin-top: 0;
 }
+
+.availability .info-url {
+  display: none;
+}

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -12,6 +12,32 @@
        // COinS, for Zotero among others.
        // This document_partial_name(@document) business is not quite right,
        // but has been there for a while.
+       // If we add non-MARC doc types to the project they need to respond to this
+       // method with a valid ctx object.
   -->
   <span class="Z3988" title="<%= @document.export_as_openurl_ctx_kev(document_partial_name(@document)) %>"></span>
+  <script type="text/javascript">
+    jQuery(document).ready(function(){
+      var ctx = $("span.Z3988").attr("title");
+      var umlaut_base = "https://getit-dev.princeton.edu";
+      var updater = new Umlaut.HtmlUpdater(umlaut_base, ctx );
+      updater.add_section_target({ 
+        umlaut_section_id: "fulltext", 
+        selector:"#full_text",
+        before_update: function(html, count) {
+          //hide the section heading on the snippet, we don't want it
+          //$(html).find(".section_heading h3").hide();
+          return (count != 0);
+        }
+      });
+      updater.add_section_target({ 
+        umlaut_section_id: "holding", 
+        selector:"#holding",
+        before_update: function(html, count) {
+          $(html).find(".section_heading h3").hide();
+        }
+      });
+      updater.update();
+    });
+  </script>
 <% end %>

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -6,10 +6,14 @@
     <h2 class="availability--heading panel-heading">Availability</h2>
     <ul class="panel-body">
         <li class="holding-info">
-            <h3 class="holding-info holding-info--heading">Firestone Library</h3>
+            <div id="full_text"></div>
+            <h3 class="holding-info holding-info--heading">Copies in Library</h3>
+            <!--
             <span class="is-available">Available</span><br>
             <span class="holding-info">Call Number: PS3539.A74 Z93 2000</span><br>
             <button class="request">Request</button>
+            -->
+            <div id="holding"></div>
         </li>
     </ul>
 </div>

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -21,6 +21,7 @@
     <%= favicon_link_tag 'favicon.ico' %>
     <%= stylesheet_link_tag "application", media: "all" %>
     <%= javascript_include_tag "application" %>
+    <%= javascript_include_tag "https://getit-dev.princeton.edu/assets/umlaut/update_html.js" %>
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>
 

--- a/config/initializers/blacklight_initializer.rb
+++ b/config/initializers/blacklight_initializer.rb
@@ -12,4 +12,51 @@ module Blacklight::Solr::Document::Marc
     record = Faraday.get("http://bibdata.princeton.edu/bibliographic/#{id}").body
     MARC::XMLReader.new(StringIO.new( record )).to_a.first
   end
+
+  def export_as_openurl_ctx_kev(format = nil)  
+    title = to_marc.find{|field| field.tag == '245'}
+    author = to_marc.find{|field| field.tag == '100'}
+    corp_author = to_marc.find{|field| field.tag == '110'}
+    publisher_info = to_marc.find{|field| field.tag == '260'}
+    edition = to_marc.find{|field| field.tag == '250'}
+    isbn = to_marc.find{|field| field.tag == '020'}
+    issn = to_marc.find{|field| field.tag == '022'}
+    id = to_marc.find{|field| field.tag == '001'}
+    unless format.nil?
+      format.is_a?(Array) ? format = format[0].downcase.strip : format = format.downcase.strip
+    end
+      export_text = ""
+      if format == 'book'
+        export_text << "ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Abook&amp;rfr_id=info%3Asid%2Fblacklight.rubyforge.org%3Agenerator&amp;rft.genre=book&amp;"
+        export_text << "rft.btitle=#{(title.nil? or title['a'].nil?) ? "" : CGI::escape(title['a'])}+#{(title.nil? or title['b'].nil?) ? "" : CGI::escape(title['b'])}&amp;"
+        export_text << "rft.title=#{(title.nil? or title['a'].nil?) ? "" : CGI::escape(title['a'])}+#{(title.nil? or title['b'].nil?) ? "" : CGI::escape(title['b'])}&amp;"
+        export_text << "rft.au=#{(author.nil? or author['a'].nil?) ? "" : CGI::escape(author['a'])}&amp;"
+        export_text << "rft.aucorp=#{CGI::escape(corp_author['a']) if corp_author['a']}+#{CGI::escape(corp_author['b']) if corp_author['b']}&amp;" unless corp_author.blank?
+        export_text << "rft.date=#{(publisher_info.nil? or publisher_info['c'].nil?) ? "" : CGI::escape(publisher_info['c'])}&amp;"
+        export_text << "rft.place=#{(publisher_info.nil? or publisher_info['a'].nil?) ? "" : CGI::escape(publisher_info['a'])}&amp;"
+        export_text << "rft.pub=#{(publisher_info.nil? or publisher_info['b'].nil?) ? "" : CGI::escape(publisher_info['b'])}&amp;"
+        export_text << "rft.edition=#{(edition.nil? or edition['a'].nil?) ? "" : CGI::escape(edition['a'])}&amp;"
+        export_text << "rft.isbn=#{(isbn.nil? or isbn['a'].nil?) ? "" : isbn['a']}"
+      elsif (format =~ /journal/i) # checking using include because institutions may use formats like Journal or Journal/Magazine
+        export_text << "ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&amp;rfr_id=info%3Asid%2Fblacklight.rubyforge.org%3Agenerator&amp;rft.genre=article&amp;"
+        export_text << "rft.title=#{(title.nil? or title['a'].nil?) ? "" : CGI::escape(title['a'])}+#{(title.nil? or title['b'].nil?) ? "" : CGI::escape(title['b'])}&amp;"
+        export_text << "rft.atitle=#{(title.nil? or title['a'].nil?) ? "" : CGI::escape(title['a'])}+#{(title.nil? or title['b'].nil?) ? "" : CGI::escape(title['b'])}&amp;"
+        export_text << "rft.aucorp=#{CGI::escape(corp_author['a']) if corp_author['a']}+#{CGI::escape(corp_author['b']) if corp_author['b']}&amp;" unless corp_author.blank?
+        export_text << "rft.date=#{(publisher_info.nil? or publisher_info['c'].nil?) ? "" : CGI::escape(publisher_info['c'])}&amp;"
+        export_text << "rft.issn=#{(issn.nil? or issn['a'].nil?) ? "" : issn['a']}"
+      else
+         export_text << "ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Adc&amp;rfr_id=info%3Asid%2Fblacklight.rubyforge.org%3Agenerator&amp;"
+         export_text << "rft.title=" + ((title.nil? or title['a'].nil?) ? "" : CGI::escape(title['a']))
+         export_text <<  ((title.nil? or title['b'].nil?) ? "" : CGI.escape(" ") + CGI::escape(title['b']))
+         export_text << "&amp;rft.creator=" + ((author.nil? or author['a'].nil?) ? "" : CGI::escape(author['a']))
+         export_text << "&amp;rft.aucorp=#{CGI::escape(corp_author['a']) if corp_author['a']}+#{CGI::escape(corp_author['b']) if corp_author['b']}" unless corp_author.blank?
+         export_text << "&amp;rft.date=" + ((publisher_info.nil? or publisher_info['c'].nil?) ? "" : CGI::escape(publisher_info['c']))
+         export_text << "&amp;rft.place=" + ((publisher_info.nil? or publisher_info['a'].nil?) ? "" : CGI::escape(publisher_info['a']))
+         export_text << "&amp;rft.pub=" + ((publisher_info.nil? or publisher_info['b'].nil?) ? "" : CGI::escape(publisher_info['b']))
+         export_text << "&amp;rft.format=" + (format.nil? ? "" : CGI::escape(format))
+     end
+     export_text << "&amp;rft_id=" + (id.nil? ? "" : CGI::escape("pul_"+id.value))
+     export_text.html_safe unless export_text.blank?
+  end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,7 @@ ActiveRecord::Schema.define(version: 20150612212656) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "blacklight_folders_folder_items", force: true do |t|
+  create_table "blacklight_folders_folder_items", force: :cascade do |t|
     t.integer  "folder_id",   null: false
     t.integer  "bookmark_id", null: false
     t.integer  "position"
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 20150612212656) do
   add_index "blacklight_folders_folder_items", ["bookmark_id"], name: "index_blacklight_folders_folder_items_on_bookmark_id", using: :btree
   add_index "blacklight_folders_folder_items", ["folder_id"], name: "index_blacklight_folders_folder_items_on_folder_id", using: :btree
 
-  create_table "blacklight_folders_folders", force: true do |t|
+  create_table "blacklight_folders_folders", force: :cascade do |t|
     t.string   "name"
     t.integer  "user_id",                       null: false
     t.string   "user_type",                     null: false
@@ -37,72 +37,72 @@ ActiveRecord::Schema.define(version: 20150612212656) do
     t.datetime "updated_at"
   end
 
-  add_index "blacklight_folders_folders", ["user_id", "user_type"], name: "index_blacklight_folders_folders_on_user_id_and_user_type", using: :btree
+  add_index "blacklight_folders_folders", ["user_type", "user_id"], name: "index_blacklight_folders_folders_on_user_type_and_user_id", using: :btree
 
-  create_table "bookmarks", force: true do |t|
-    t.integer  "user_id",       null: false
-    t.string   "user_type"
-    t.string   "document_id"
-    t.string   "title"
+  create_table "bookmarks", force: :cascade do |t|
+    t.integer  "user_id",                   null: false
+    t.string   "user_type",     limit: 255
+    t.string   "document_id",   limit: 255
+    t.string   "title",         limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "document_type"
+    t.string   "document_type", limit: 255
   end
 
   add_index "bookmarks", ["user_id"], name: "index_bookmarks_on_user_id", using: :btree
 
-  create_table "orangelight_call_numbers", force: true do |t|
-    t.string "label"
-    t.string "dir"
-    t.string "scheme"
-    t.string "sort"
+  create_table "orangelight_call_numbers", force: :cascade do |t|
+    t.string "label",  limit: 255
+    t.string "dir",    limit: 255
+    t.string "scheme", limit: 255
+    t.string "sort",   limit: 255
     t.text   "title"
     t.text   "author"
     t.text   "date"
-    t.string "bibid"
+    t.string "bibid",  limit: 255
   end
 
-  create_table "orangelight_names", force: true do |t|
+  create_table "orangelight_names", force: :cascade do |t|
     t.text    "label"
     t.integer "count"
     t.text    "sort"
-    t.string  "dir"
+    t.string  "dir",   limit: 255
   end
 
-  create_table "orangelight_subjects", force: true do |t|
+  create_table "orangelight_subjects", force: :cascade do |t|
     t.text    "label"
     t.integer "count"
     t.text    "sort"
-    t.string  "dir"
+    t.string  "dir",   limit: 255
   end
 
-  create_table "searches", force: true do |t|
+  create_table "searches", force: :cascade do |t|
     t.text     "query_params"
     t.integer  "user_id"
-    t.string   "user_type"
+    t.string   "user_type",    limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
   end
 
   add_index "searches", ["user_id"], name: "index_searches_on_user_id", using: :btree
 
-  create_table "users", force: true do |t|
-    t.string   "email",                  default: "",    null: false
-    t.string   "encrypted_password",     default: "",    null: false
-    t.string   "reset_password_token"
+  create_table "users", force: :cascade do |t|
+    t.string   "email",                  limit: 255, default: "",    null: false
+    t.string   "encrypted_password",     limit: 255, default: "",    null: false
+    t.string   "reset_password_token",   limit: 255
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,     null: false
+    t.integer  "sign_in_count",                      default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
+    t.string   "current_sign_in_ip",     limit: 255
+    t.string   "last_sign_in_ip",        limit: 255
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "provider"
-    t.string   "uid"
-    t.string   "username"
-    t.boolean  "guest",                  default: false
+    t.string   "provider",               limit: 255
+    t.string   "uid",                    limit: 255
+    t.string   "username",               limit: 255
+    t.boolean  "guest",                              default: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
@tampakis don't merge yet. Let's discuss how or if we want to do integration tests for the umlaut responses. This will embed full-text links where appropriate and add a holdings display for every record. We should think of the placeholder we want while results load in the holdings area. Perhaps some representation of the known holding locations for the record. 