### PR TITLE
spellchecks suggests search phrase instead of individual words

### DIFF
--- a/app/views/catalog/_did_you_mean.html.erb
+++ b/app/views/catalog/_did_you_mean.html.erb
@@ -1,0 +1,5 @@
+<% if should_show_spellcheck_suggestions? @response and  !@response.spelling.collation.nil? %>
+  <div id="spell">
+    <h4 class="suggest"><em><%= t('blacklight.did_you_mean', :options => link_to_query(@response.spelling.collation)).html_safe %></em></h4>
+  </div>
+<% end %>

--- a/config/initializers/blacklight_initializer.rb
+++ b/config/initializers/blacklight_initializer.rb
@@ -10,7 +10,7 @@ module Blacklight::Solr::Document::Marc
   def marc_record_from_marcxml
     id = fetch(_marc_source_field)
     record = Faraday.get("http://bibdata.princeton.edu/bibliographic/#{id}").body
-    MARC::XMLReader.new(StringIO.new( record )).to_a.first
+    MARC::XMLReader.new(StringIO.new( record )).to_a.first || MARC::Record.new
   end
 
   def export_as_openurl_ctx_kev(format = nil)  
@@ -59,4 +59,82 @@ module Blacklight::Solr::Document::Marc
      export_text.html_safe unless export_text.blank?
   end
 
+end
+
+
+# Override until this behavior is part of next Blacklight release
+module Blacklight::SolrResponse::Spelling
+  class Base
+    # returns an array of spelling suggestion for specific query words,
+    # as provided in the solr response.  Only includes words with higher
+    # frequency of occurrence than word in original query.
+    # can't do a full query suggestion because we only get info for each word;
+    # combination of words may not have results.
+    # Thanks to Naomi Dushay!
+    def words
+      @words ||= (
+        word_suggestions = []
+        spellcheck = self.response[:spellcheck]
+        if spellcheck && spellcheck[:suggestions]
+          suggestions = spellcheck[:suggestions]
+          unless suggestions.nil?
+            # suggestions is an array:
+            #    (query term)
+            #    (hash of term info and term suggestion)
+            #    ...
+            #    (query term)
+            #    (hash of term info and term suggestion)
+            #    'correctlySpelled'
+            #    true/false
+            #    collation
+            #    (suggestion for collation)
+            if suggestions.index("correctlySpelled") #if extended results
+              i_stop = suggestions.index("correctlySpelled")
+            elsif suggestions.index("collation")
+              i_stop = suggestions.index("collation")
+            else
+              i_stop = suggestions.length
+            end
+              # step through array in 2s to get info for each term
+              0.step(i_stop-1, 2) do |i|
+                term = suggestions[i]
+                term_info = suggestions[i+1]
+                # term_info is a hash:
+                #   numFound =>
+                #   startOffset =>
+                #   endOffset =>
+                #   origFreq =>
+                #   suggestion =>  [{ frequency =>, word => }] # for extended results
+                #   suggestion => ['word'] # for non-extended results
+                origFreq = term_info['origFreq']
+                if term_info['suggestion'].first.is_a?(Hash) or suggestions.index("correctlySpelled")
+                  word_suggestions << term_info['suggestion'].map do |suggestion|
+                    suggestion['word'] if suggestion['freq'] > origFreq
+                  end
+                else
+                  # only extended suggestions have frequency so we just return all suggestions
+                  word_suggestions << term_info['suggestion']
+                end
+              end
+          end
+        end
+        word_suggestions.flatten.compact.uniq
+      )
+    end
+
+    def collation
+      # FIXME: DRY up with words
+      spellcheck = self.response[:spellcheck]
+        if spellcheck && spellcheck[:suggestions]
+          suggestions = spellcheck[:suggestions]
+          unless suggestions.nil?
+            if suggestions.index("collation")
+              suggestions[suggestions.index("collation") + 1]
+            elsif spellcheck.key?("collations")
+              spellcheck['collations'].last
+            end
+          end
+        end
+    end
+  end
 end

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -278,7 +278,8 @@
       <str name="spellcheck.dictionary">default</str>
       <str name="spellcheck.onlyMorePopular">true</str>
       <str name="spellcheck.extendedResults">true</str>
-      <str name="spellcheck.collate">false</str>
+      <str name="spellcheck.collate">true</str>
+      <str name="spellcheck.maxCollationTries">5</str>
       <str name="spellcheck.count">5</str>
 
     </lst>

--- a/spec/features/search_suggestions_spec.rb
+++ b/spec/features/search_suggestions_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+describe "Spelling a search term incorrectly" do
+  it "provides a search term suggestion that returns results" do
+    visit  "/catalog?search_field=all_fields&q=serching+modern+esthetic"
+    expect(page.all('.document').length).to eq 0
+    expect(page.has_content?("Did you mean to type: searching modern aesthetic?")).to eq true
+    click_link "searching modern aesthetic"
+    expect(page.all('.document').length).to eq 1        
+  end
+end


### PR DESCRIPTION
 - Allows records to be retrieved when bibdata (which pulls in the live Marc data) goes down.
 - Fixes bug in Blacklight spelling suggestions feature, which returns a funky hash when using Solr 5. Submitted PR to Blacklight (https://github.com/projectblacklight/blacklight/pull/1235) so we won't have to override the Gem.
 - Using the collate feature which suggests a new search phrase rather than spelling suggestions for individual words.