### PR TITLE
Add placeholder my account page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,3 +353,6 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   yajl-ruby
+
+BUNDLED WITH
+   1.10.4

--- a/app/assets/stylesheets/blacklight.css.scss
+++ b/app/assets/stylesheets/blacklight.css.scss
@@ -1,3 +1,6 @@
+//bootstrap variables override
+$table-bg-accent: #f5f4f1;
+
 @import 'bootstrap-sprockets';
 @import 'bootstrap';
 

--- a/app/assets/stylesheets/components/ribbon.scss
+++ b/app/assets/stylesheets/components/ribbon.scss
@@ -1,3 +1,7 @@
+.placeholder-container {
+  position: relative;
+}
+
 .ribbon {
   position: absolute;
   right: -5px; top: -5px;

--- a/app/assets/stylesheets/components/user.scss
+++ b/app/assets/stylesheets/components/user.scss
@@ -1,0 +1,4 @@
+address .name, address .street {
+  display: block;
+  clear: both;
+}

--- a/app/assets/stylesheets/shame.scss
+++ b/app/assets/stylesheets/shame.scss
@@ -514,6 +514,7 @@ header .navbar-nav > li > a {
 .dropdown-account .dropdown-menu {
     right: 0;
     left: auto;
+    margin-top: 8px;
 }
 
 .checkbox.toggle_bookmark {
@@ -717,4 +718,7 @@ a.more_facets_link {
         padding: 0.5em;
         display: inline-block;
     }
+}
+.renew-items .form-control {
+    max-width: 350px;
 }

--- a/app/views/_account.html.erb
+++ b/app/views/_account.html.erb
@@ -7,6 +7,9 @@
       </button>
       <ul class="dropdown-menu" role="menu">
         <li>
+          <%= link_to 'My Account', page_path('account') %>
+        </li>
+        <li>
           <%= render partial: 'blacklight/nav/saved_searches' %>
         </li>
         <li>

--- a/app/views/pages/account.html.erb
+++ b/app/views/pages/account.html.erb
@@ -1,0 +1,82 @@
+<div class="col-md-12">
+  <h1 class="page-heading">My Account</h1>
+  <p>Review your library account.</p>
+
+  <h2 class="section-heading">Personal Information</h2>
+  <p>
+    <span class="netid">NetID</span>
+    <address>
+    <span class="name">Jane Smith</span>
+    <span class="street">123 Street Rd.</span>
+    <span class="city">Princeton</span>, <span class="state">NJ</span> <span class="zipcode">08504</span>
+    </address>
+  </p>
+
+  <h2 class="section-heading">Patron Blocks</h2>
+  <p>No patron blocks.</p>
+
+  <h2 class="section-heading">Charged Items</h2>
+  <div class="placeholder-container is-disabled">
+  <div class="ribbon"><span>Placeholder</span></div>
+  <div class="table-responsive">
+    <table class="table table-striped table-bordered">
+      <thead>
+        <tr>
+          <th>Item</th>
+          <th>Item Type</th>
+          <th>Status</th>
+          <th>Renew?</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Caravan : the assembled tales of John Galsworthy. Galsworthy, John, 1867-1933.</td>
+          <td>Book</td>
+          <td>Charged: Due 06-15-2016</td>
+          <td><label><input type="checkbox"> Renew</label></td>
+        </tr>
+        <tr>
+          <td>Care and feeding of animals, illustrated by Hoot von Zitzewitz. Small, Mary Cox.</td>
+          <td>Book</td>
+          <td>Charged: Due 06-15-2016</td>
+          <td><label><input type="checkbox"> Renew</label></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <form class="renew-items">
+    <div class="form-group">
+      <select class="form-control">
+        <option>Renew selected items</option>
+        <option>Renew all items from Princeton University Library</option>
+      </select>
+    </div>
+    <button type="submit" class="btn btn-primary">Renew items</button>
+  </form>
+  </div>
+
+  <h2 class="section-heading">Request Information</h2>
+  <div class="placeholder-container is-disabled">
+  <div class="ribbon"><span>Placeholder</span></div>
+    <table class="table table-striped table-bordered">
+      <thead>
+        <tr>
+          <th>Item</th>
+          <th>Status</th>
+          <th>Pickup Location</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Dinosaurs / Kate Petty ; illustrated by Richard Orr, Stephen Bennett.</td>
+          <td>Pending</td>
+          <td>Firestone Circulation Desk</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <h2 class="section-heading">Fines and Fees</h2>
+  <p>You have no fines or fees.</p>
+</div>

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -1,3 +1,4 @@
+<div class="col-md-12">
   <h1 class="page-heading">Search Tips</h1>
   <div class="search-tips">
     <ul class="list--search-tips">
@@ -88,4 +89,5 @@
         </dl>
       </li>
     </ul>
+  </div>
   </div>

--- a/app/views/pages/notes.html.erb
+++ b/app/views/pages/notes.html.erb
@@ -1,4 +1,4 @@
-<div class="container release-notes">
+<div class="container release-notes col-md-12">
     <h1 class="page-heading">Release Notes</h1>
     <p>Information about each release and plans for future development of Princeton University Library's new catalog.</p>
     <dl>


### PR DESCRIPTION
Mimic current catalog.princeton.edu display of users' library account information page. 

Displays:
1. Personal Information
2. Patron Blocks
3. Charged Items 
4. Request Information
5. Fines and Fees