### PR TITLE
add library facet to homepage, remove access facet

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,6 +353,3 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   yajl-ruby
-
-BUNDLED WITH
-   1.10.4

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -82,7 +82,7 @@ class CatalogController < ApplicationController
     #
     # :show may be set to false if you don't want the facet to be drawn in the
     # facet bar
-    config.add_facet_field 'access_facet', label: 'Access', sort: 'index', collapse: false, home: true
+    config.add_facet_field 'location', :label => 'Library', :limit => 20, sort: 'index', home: true, solr_params: { 'facet.mincount' => Blacklight.blacklight_yml['mincount'] || 1 }
     config.add_facet_field 'format', :label => 'Format', partial: "facet_format", sort: 'index', :limit => 15, collapse: false, home: true
 
     # num_segments and segments set to defaults here, included to show customizable features
@@ -95,7 +95,6 @@ class CatalogController < ApplicationController
     config.add_facet_field 'genre_facet', :label => 'Subject: Genre', :limit => true
     config.add_facet_field 'subject_era_facet', :label => 'Subject: Era', :limit => true
     config.add_facet_field 'language_facet', :label => 'Language', :limit => true
-    config.add_facet_field 'location', :label => 'Library', :limit => 20, sort: 'index'
     config.add_facet_field 'lc_1letter_facet', :label => 'Classification', :limit => 25, show: false, sort: 'index'
     config.add_facet_field 'author_s', :label => 'Author', :limit => true, show: false
     config.add_facet_field 'lc_rest_facet', :label => 'Full call number code', :limit => 25, show: false, sort: 'index'

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -19,3 +19,4 @@ test: &test
 production:
   adapter: solr
   url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core" %>
+mincount: 1

--- a/spec/requests/request_spec.rb
+++ b/spec/requests/request_spec.rb
@@ -173,14 +173,14 @@ describe "blacklight tests" do
     it "Only facets configured for homepage display are requested in Solr" do
       get "/catalog.json"
       r = JSON.parse(response.body)
-      expect(r["response"]["facets"].any? {|f| f['name'] == 'access_facet'}).to eq true
+      expect(r["response"]["facets"].any? {|f| f['name'] == 'location'}).to eq true
       expect(r["response"]["facets"].any? {|f| f['name'] == 'instrumentation_facet'}).to eq false
     end
 
     it "All configured facets are requested in Solr within a search" do
       get "/catalog.json?search_field=all_fields"
       r = JSON.parse(response.body)
-      expect(r["response"]["facets"].any? {|f| f['name'] == 'access_facet'}).to eq true
+      expect(r["response"]["facets"].any? {|f| f['name'] == 'location'}).to eq true
       expect(r["response"]["facets"].any? {|f| f['name'] == 'instrumentation_facet'}).to eq true
     end
   end


### PR DESCRIPTION
Replace access facet with library facet on homepage. Library facet is collapsed by default and now the first facet to appear on the left.

Added the ability to filter out 'dirty' locations by setting a facet minimum count requirement. Related to #235.