### PR TITLE
Full availability api

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -363,6 +363,3 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   yajl-ruby
-
-BUNDLED WITH
-   1.10.4

--- a/app/assets/javascripts/availability.js.coffee
+++ b/app/assets/javascripts/availability.js.coffee
@@ -42,7 +42,7 @@ class AvailabilityUpdater
     element.text("View Record for Full Availability")
     element.prop('title', "Click on the record for full availability info")
   apply_record_icon: (record_id, holding_id, status) ->
-    availability_element = $("*[data-record-id='#{record_id}'][data-holding-id='#{holding_id}'] .availability-icon")
+    availability_element = $("*[data-availability-record='true'][data-record-id='#{record_id}'][data-holding-id='#{holding_id}'] .availability-icon")
     availability_element.addClass("label")
     label = switch
       when status in available_statuses then 'Available'

--- a/app/assets/javascripts/availability.js.coffee
+++ b/app/assets/javascripts/availability.js.coffee
@@ -4,42 +4,67 @@ class AvailabilityUpdater
   constructor: ->
     this.request_availability()
   availability_url: "https://bibdata.princeton.edu/availability"
+  id = ''
+  available_statuses = ['Not Charged']
+  returned_statuses = ['In Transit Discharged', 'Discharged']
+  in_process_statuses = ['In Process']
+  checked_out_statuses = ['Charged', 'Renewed', 'Overdue', 'On Hold',
+    'In Transit', 'In Transit On Hold', 'At Bindery',
+    'Remote Storage Request', 'Hold Request', 'Recall Request']
+  missing_statuses = ['Missing', 'Lost--Library Applied',
+    'Lost--System Applied', 'Claims Returned', 'Withdrawn']
+  available_labels = ['Available', 'Returned', 'In Process', 'Requestable']
+  unavailable_labels = ['Checked Out', 'Missing']
   request_availability: ->
-    if ($(".documents-list").length > 0 || $(".holding-block").length > 0)
+    if $(".documents-list").length > 0
       ids = this.record_ids().toArray()
       params = $.param({ids: ids})
       url = "#{@availability_url}?#{params}"
       $.getJSON(url, this.process_records)
+    else if $(".holding-block").length > 0
+      id = window.location.pathname.split('/')[2]
+      url = "#{@availability_url}?id=#{id}"
+      $.getJSON(url, this.process_single)
   process_records: (records) =>
     for record_id, holding_records of records
       this.apply_record(record_id, holding_records)
+  process_single: (holding_records) =>
+    for holding_id, availability_info of holding_records
+      this.apply_record_icon(id, holding_id, availability_info['status'])
   apply_record: (record_id, holding_records) ->
     for holding_id, availability_info of holding_records
+      this.record_needs_more_info(record_id) if availability_info['more_items']
       this.apply_record_icon(record_id, holding_id, availability_info['status'])
     true
   record_needs_more_info: (record_id) ->
-    element = $("*[data-record-id='#{record_id}'] .availability-icon")
+    element = $("*[data-record-id='#{record_id}'] .more-info")
     element.addClass("label label-default")
-    element.text("View Record for Availability")
+    element.text("View Record for Full Availability")
     element.prop('title', "Click on the record for full availability info")
   apply_record_icon: (record_id, holding_id, status) ->
     availability_element = $("*[data-record-id='#{record_id}'][data-holding-id='#{holding_id}'] .availability-icon")
     availability_element.addClass("label")
-    unavailable_statuses = ["At Bindery", "Claims Returned", "Charged",
-      "Hold Request", "In Transit", "Lost", "Missing", "On Hold", "Overdue",
-      "Recall Request", "Remote Storage Request", "Renewed", "Withdrawn"]
-    status = if status == "Not Charged" then "Available" else status
-    availability_element.text(status)
-    if status in unavailable_statuses
+    label = switch
+      when status in available_statuses then 'Available'
+      when status in returned_statuses then 'Returned'
+      when status in in_process_statuses then 'In Process'
+      when status in checked_out_statuses then 'Checked Out'
+      when status in missing_statuses then 'Missing'
+      when status == 'Limited' then 'On-Site Access'
+      else status
+    availability_element.text(label)
+    if label in unavailable_labels
       availability_element.addClass("label-danger")
-    else if status == 'Unknown'
-      availability_element.addClass("label-default")
-    else if status == 'Limited'
+    else if label in available_labels
+      availability_element.addClass("label-success")
+    else if label == 'On-Site Access'
       availability_element.addClass("label-warning")
-    else if status == 'Online'
+    else if label == 'Online'
       availability_element.addClass("label-primary")
     else
-      availability_element.addClass("label-success")
-    availability_element.prop('title', status)
+      availability_element.addClass("label-default")
+    availability_element.prop('title', "Availability: #{status}")
+    availability_element.attr('data-original-title', "Availability: #{status}")
+    availability_element.attr('data-toggle', 'tooltip')
   record_ids: ->
     $("*[data-availability-record][data-record-id]").map((_, x) -> $(x).attr("data-record-id"))

--- a/app/assets/javascripts/orangelight.js
+++ b/app/assets/javascripts/orangelight.js
@@ -18,8 +18,29 @@ $( document ).ready(function() {
         trigger: "hover"
     });
 
+    //tooltip for call number browse
+    $(".holding-call-number").tooltip({
+        selector: "[data-toggle='tooltip']",
+        placement: "bottom",
+        container: "body"
+    });
+
+    //tooltip for availability-icon
+    $("[data-record-id]").tooltip({
+        selector: "[data-toggle='tooltip']",
+        placement: "left",
+        container: "body"
+    });
+
     //tooltip for subject heirarchy
     $(".facet-values").tooltip({
+        selector: "[data-toggle='tooltip']",
+        placement: "right",
+        container: "body"
+    });
+
+    //tooltip for stack map
+    $(".library-location").tooltip({
         selector: "[data-toggle='tooltip']",
         placement: "right",
         container: "body"

--- a/app/assets/stylesheets/components/availability.scss
+++ b/app/assets/stylesheets/components/availability.scss
@@ -1,7 +1,3 @@
-.location--panel {
-  padding-left: 2em;
-}
-
 .location--panel .panel {
   box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.15);
   background: white;
@@ -31,22 +27,21 @@
       color: #777;
     }
     &.label-warning {
-        color: darken(#f0ad4e, 20%);
+      color: darken(#f0ad4e, 20%);
     }
     &.label-danger {
-        color: darken(#d9534f, 20%);
+      color: darken(#d9534f, 20%);
     }
     &.label-success {
-        color: darken(#5cb85c, 20%);
+      color: darken(#5cb85c, 20%);
     }
   }
   .btn {
     margin-top: .4em;
-    display: none;
   }
 
   .holding-block {
-    padding: 1.5em;
+    padding: 1.5em 1em;
     border-bottom: 1px solid #eee;
     display: block;
 
@@ -64,20 +59,29 @@
 
 .location--online .panel .panel-body {
     display: block;
-    padding: 1.5em 1.5em 0;
+    padding: 1em;
     a {
-        padding-bottom: 1.5em;
-        display: inline-block;
+      display: inline-block;
+    }
+    ul {
+      margin-bottom: 0px;
+    }
+    .electronic-access {
+      margin: .25em 0;
     }
     .umlaut-section a {
-        padding: 0;
+      padding: 0;
     }
     .umlaut-section li {
-        margin-bottom: 1.5em;
+      margin-bottom: 1.5em;
     }
 }
 
 .availability-icon.label:hover {
   color: white;
   text-decoration: none;
+}
+
+.record-availability {
+  padding-left: 5px;
 }

--- a/app/assets/stylesheets/components/availability.scss
+++ b/app/assets/stylesheets/components/availability.scss
@@ -9,7 +9,7 @@
   border-radius: 0;
 
   .panel-heading {
-    font-size: 1.2em;
+    font-size: 1.1em;
     margin: 0;
     border-bottom: 2px solid #eee;
     background: none;
@@ -31,17 +31,18 @@
       color: #777;
     }
     &.label-warning {
-        color: #f0ad4e;
+        color: darken(#f0ad4e, 20%);
     }
     &.label-danger {
-        color: #d9534f;
+        color: darken(#d9534f, 20%);
     }
     &.label-success {
-        color: #5cb85c;
+        color: darken(#5cb85c, 20%);
     }
   }
   .btn {
-    margin-top: .75em;
+    margin-top: .4em;
+    display: none;
   }
 
   .holding-block {
@@ -50,9 +51,9 @@
     display: block;
 
     h3 {
-      margin: 0 0 0.5em;
+      margin: -.3em 0 0.1em;
       line-height: 1.2em;
-      font-size: 0.9rem;
+      font-size: 0.8rem;
     }
   }
 

--- a/app/assets/stylesheets/components/record--descriptions.scss
+++ b/app/assets/stylesheets/components/record--descriptions.scss
@@ -22,7 +22,7 @@
 }
 
 .availability-icon {
-  margin-right: 5px;
+  margin-right: 6px;
   text-transform: uppercase;
 }
 
@@ -48,6 +48,7 @@
 
   .dl-horizontal dd {
     margin-left: 170px;
+    margin-right: -30px;
     clear: none;
     margin-bottom: 1em;
   }
@@ -61,4 +62,8 @@
   .content {
     margin-left: -30px;
   }
+}
+
+.header-row {
+  padding-left: 0px;
 }

--- a/app/assets/stylesheets/shame.scss
+++ b/app/assets/stylesheets/shame.scss
@@ -123,7 +123,7 @@ header .input-group-addon {
 
 .button--start-over {
     // width: 100%;
-    margin: 0;
+    margin: 0px 0px 0px -3px;
     padding: 0;
     a {
         // width: 100%;
@@ -315,6 +315,7 @@ main {
     box-shadow: none;
     -webkit-box-shadow: none;
     margin-bottom: 0.35em;
+    padding: 2px 15px;
 }
 
 .button--start-over {
@@ -647,7 +648,7 @@ select::-ms-expand {
 // }
 
 .checkbox.toggle_bookmark {
-    padding: 0px 18px 0px 0px;
+    padding: 0px 12px 0px 0px;
 }
 
 li .toggle_bookmark input[type=checkbox] {
@@ -732,4 +733,8 @@ a.more_facets_link {
 }
 .renew-items .form-control {
     max-width: 350px;
+}
+
+.glyphicon-map-marker {
+    font-size: 1.2em;
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -256,7 +256,6 @@ class CatalogController < ApplicationController
     config.add_show_field 'coden_display', :label => 'Coden designation'
     config.add_show_field 'standard_no_1display', hash: true
     config.add_show_field 'original_language_display', :label => 'Original language'
-    config.add_show_field 'holdings_1display', :label => 'Holding info', helper_method: :holding_block
     config.add_show_field 'shelving_title_display', :label => 'Shelving title'
     config.add_show_field 'location_has_display', :label => 'Location has'
     config.add_show_field 'location_has_current_display', :label => 'Location has (current)'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,7 +15,7 @@ module ApplicationHelper
       if /getit\.princeton\.edu/.match(url)
         urls << content_tag(:div, "", :id => "full_text", :class => ["availability--panel", "availability_full-text"], 'data-umlaut-fulltext' => true )
       end
-      urls << link
+      urls << content_tag(:div, link.html_safe, class: 'electronic-access')
     end
     if links.count > 1
       content_tag(:ul, urls.html_safe)
@@ -43,7 +43,7 @@ module ApplicationHelper
     if DONT_FIND_IT.include?(library)
       ''
     else
-      ' ' + link_to("[#{t('blacklight.holdings.stackmap')}]".html_safe, "http://library.princeton.edu/searchit/map?loc=#{location}&id=#{bib}", :target => "_blank", class: "find-it", 'data-map-location' => "#{location}")
+      ' ' + link_to("[#{t('blacklight.holdings.stackmap')}]".html_safe, "http://library.princeton.edu/searchit/map?loc=#{location}&id=#{bib}", :target => '_blank', class: 'find-it', 'data-map-location' => "#{location}")
     end
   end
 
@@ -51,7 +51,7 @@ module ApplicationHelper
     if DONT_FIND_IT.include?(library)
       ''
     else
-      ' ' + link_to("<span class=\"glyphicon glyphicon-map-marker\"></span>".html_safe, "http://library.princeton.edu/searchit/map?loc=#{location}&id=#{bib}", :target => "_blank", title: t('blacklight.holdings.stackmap'), class: "find-it", 'data-map-location' => "#{location}")
+      ' ' + link_to('<span class="glyphicon glyphicon-map-marker"></span>'.html_safe, "http://library.princeton.edu/searchit/map?loc=#{location}&id=#{bib}", :target => '_blank', 'data-toggle' => 'tooltip', title: t('blacklight.holdings.stackmap'), class: 'find-it', 'data-map-location' => "#{location}")
     end
   end
 
@@ -91,14 +91,16 @@ module ApplicationHelper
     links = search_links(args[:document]['electronic_access_1display'])
     holdings_hash = JSON.parse(args[:document][args[:field]])
     holdings_hash.first(2).each do |id, holding|
+      check_availability = true
       render_arrow = (!holding['library'].blank? and !holding['call_number'].blank?)
       arrow = render_arrow ? ' &raquo; ' : ''
       info = ''
       if holding['library'] == 'Online'
+        check_availability = false
         if links.empty?
-          info << content_tag(:span, 'LINK MISSING', class: 'label label-danger',
+          info << content_tag(:span, 'Link Missing', class: 'availability-icon label label-danger',
                               title: 'Availability: Online', 'data-toggle' => 'tooltip')
-          info << ' Please contact public services about this error.'
+          info << 'Online access is not currently available.'
         else
         info << link_to('Online', catalog_path(args[:document]['id']), class: 'availability-icon label label-primary',
                             title: 'Electronic Access')
@@ -109,7 +111,7 @@ module ApplicationHelper
         info << "#{holding['library']}#{arrow}#{holding['call_number']}".html_safe
         info << locate_link(holding['location_code'], args[:document]['id'], holding['library']).html_safe
       end
-      block << content_tag(:li, info.html_safe, data: { availability_record: true, record_id: args[:document]['id'], holding_id: id })
+      block << content_tag(:li, info.html_safe, data: { availability_record: check_availability, record_id: args[:document]['id'], holding_id: id })
     end
     if holdings_hash.length > 2
       block << content_tag(:li, link_to('View Record for Full Availability', catalog_path(args[:document]['id']),

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,6 +1,6 @@
 <%# default partial to display solr document fields in catalog index view -%>
 
-<ul class="document-metadata dl-horizontal dl-invert col-md-10">
+<ul class="document-metadata dl-horizontal dl-invert">
 
   <% index_fields(document).each do |solr_fname, field| -%>
     <% if should_render_index_field? document, field %>

--- a/app/views/catalog/_show_availability_sidebar.html.erb
+++ b/app/views/catalog/_show_availability_sidebar.html.erb
@@ -1,5 +1,5 @@
 <% unless @document['electronic_access_1display'].nil? %>
-  <div class="row location--panel location--online">
+  <div class="location--panel location--online">
     <div class="panel panel-default">
       <div class="panel-heading"><%= t('blacklight.holdings.online') %></div>
       <div class="panel-body">
@@ -12,7 +12,7 @@
 <% unless @document['holdings_1display'].nil? %>
 <% h = holding_request_block(@document['holdings_1display'], @document['id']) %>
   <% unless h.nil? %>
-  <div class="row location--panel location--holding">
+  <div class="location--panel location--holding">
     <div class="panel panel-default">
       <div class="panel-heading"><%= t('blacklight.holdings.print') %></div>
       <div class="panel-body">

--- a/app/views/catalog/_show_header_default.html.erb
+++ b/app/views/catalog/_show_header_default.html.erb
@@ -1,5 +1,5 @@
 
-<div class="col-xs-12">
+<div class="col-xs-12 header-row">
     <%# bookmark/folder functions -%>
     <% titlevalue = render_document_show_field_value @document, :field => 'title_vern_display' %>
     <% unless titlevalue == '' %>

--- a/app/views/catalog/librarian_view.html.erb
+++ b/app/views/catalog/librarian_view.html.erb
@@ -1,6 +1,6 @@
 <div class="pagination-search-widgets">
     <div class="col-md-12">
-    <%= link_to "Back to Item", :back, :class => "btn btn-default" %>
+    <%= link_to "Back to Item", catalog_path(@document), :class => "btn btn-default" %>
     </div>
 </div>
 

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'previous_next_doc' %>
 
-<div id="main-content" class="col-sm-9 col-xs-12">
+<div id="main-content" class="col-sm-9 col-xs-12 main-content">
   <%= render_document_heading_partial %>
 
   <div id="sidebar" class="col-sm-2 col-xs-12 <%= render_document_class %>">
@@ -23,7 +23,7 @@
   </div>
 </div>
 
-<div id="availability" class="col-sm-3 col-xs-12">
+<div id="availability" class="col-sm-3 col-xs-12 record-availability">
   <%= render 'show_availability_sidebar' %>
 </div>
 

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,24 +1,26 @@
 <%= render 'previous_next_doc' %>
 
-<%= render_document_heading_partial %>
+<div id="main-content" class="col-sm-9 col-xs-12">
+  <%= render_document_heading_partial %>
 
-<div id="sidebar" class="col-sm-2 col-xs-12 <%= render_document_class %>">
-  <%= render_document_sidebar_partial %>
-</div>
+  <div id="sidebar" class="col-sm-2 col-xs-12 <%= render_document_class %>">
+    <%= render_document_sidebar_partial %>
+  </div>
 
-<div id="content" class="col-sm-7 col-xs-12 content">
-  <%= render_document_main_content_partial %>
+  <div id="content" class="col-sm-10 col-xs-12 content">
+    <%= render_document_main_content_partial %>
 
-    <dl class="dl-horizontal dl-invert">
-      <dt class="other-views">Other Views:</dt>
-      <dd class="classic-views">
-        <ul>
-          <li><%= link_to t('blacklight.tools.librarian_view'), librarian_view_catalog_path(@document), {:id => 'librarianLink'} %></li>
-          <li><%= link_to "#{t('blacklight.voyager')} <span class=\"glyphicon glyphicon-share-alt\"></span>".html_safe, voyager_url(@document.id), {:id => 'librarianLink', :target => "_blank"} %></li>
-          <!-- <li><%#= link_to "#{t('blacklight.umlaut')} <span class=\"glyphicon glyphicon-share-alt\"></span>".html_safe, "#{ENV['umlaut_base']}/resolve?#{@document.export_as_openurl_ctx_kev(document_partial_name(@document))}", {:id => 'getitLink' } %></li> -->
-        </ul>
-      </dd>
-    </dl>
+      <dl class="dl-horizontal dl-invert">
+        <dt class="other-views">Other Views:</dt>
+        <dd class="classic-views">
+          <ul>
+            <li><%= link_to t('blacklight.tools.librarian_view'), librarian_view_catalog_path(@document), {:id => 'librarianLink'} %></li>
+            <li><%= link_to "#{t('blacklight.voyager')} <span class=\"glyphicon glyphicon-share-alt\"></span>".html_safe, voyager_url(@document.id), {:id => 'librarianLink', :target => "_blank"} %></li>
+            <!-- <li><%#= link_to "#{t('blacklight.umlaut')} <span class=\"glyphicon glyphicon-share-alt\"></span>".html_safe, "#{ENV['umlaut_base']}/resolve?#{@document.export_as_openurl_ctx_kev(document_partial_name(@document))}", {:id => 'getitLink' } %></li> -->
+          </ul>
+        </dd>
+      </dl>
+  </div>
 </div>
 
 <div id="availability" class="col-sm-3 col-xs-12">

--- a/config/requests.yml.tmpl
+++ b/config/requests.yml.tmpl
@@ -1,13 +1,12 @@
 # requests.yml
 
 defaults: &defaults
-  umlaut_base: https://getit.princeton.edu
+  umlaut_base: https://getit-dev.princeton.edu
   bibdata_base: https://bibdata.princeton.edu/bibliographic
   proxy_base: https://library.princeton.edu/resolve/lookup?url=
 
 development:
   <<: *defaults
-  umlaut_base: https://getit-dev.princeton.edu
 
 test:
   <<: *defaults

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -36,7 +36,7 @@ describe "Availability"  do
       visit "/catalog/8606339"
       sleep 5.seconds
       expect(page.all('.location--online .umlaut .fulltext').length).to eq 1
-      expect(page.all('.location--online .umlaut .fulltext .response_item').length).to eq 5
+      expect(page.all('.location--online .umlaut .fulltext .response_item').length).to be >= 4
     end
   end
 

--- a/spec/helpers/holding_block_spec.rb
+++ b/spec/helpers/holding_block_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ApplicationHelper do
     let(:location) { 'Rare Books and Special Collections - Reference Collection in Dulles Reading Room' }
     let(:call_number) { 'PS3539.A74Z93 2000' }
     let(:search_result) { helper.holding_block_search(field_config) }
-    let(:show_result) { helper.holding_block(field_config) }
+    let(:show_result) { helper.holding_request_block(holding_block_json, 1) }
     let(:holding_block_json) do
       {
         holding_id => {

--- a/spec/helpers/holding_block_spec.rb
+++ b/spec/helpers/holding_block_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe ApplicationHelper do
         expect(search_result).to have_selector ".availability-icon"
       end
       it "link missing label appears when 856s is missing from elf location" do
-        expect(search_result).to include "LINK MISSING"
+        expect(search_result).to include "Link Missing"
       end
     end
     context "#holding_block record show" do
@@ -92,7 +92,7 @@ RSpec.describe ApplicationHelper do
         expect(show_result).to have_selector "*[data-original-title='Browse: #{call_number}']"
       end
       it "tags the holding record id" do
-        expect(show_result).to have_selector "*[holding_id='#{holding_id}']"
+        expect(show_result).to have_selector "*[data-holding-id='#{holding_id}']"
       end
     end
   end

--- a/spec/requests/request_spec.rb
+++ b/spec/requests/request_spec.rb
@@ -13,12 +13,12 @@ describe "blacklight tests" do
   end
 
   describe "Multiple locations check" do
-    it "items with 3 or more holdings are listed as multiple holdings in search results" do
+    it "records with 3 or more holdings indicate that the record view has full availability" do
       get "/catalog/857469.json"
       r = JSON.parse(response.body)
       expect(r["response"]["document"]["location"].length).to be > 2
         get "/catalog?&search_field=all_fields&q=857469"
-        expect(response.body).to include '<a class="availability-icon label label-default" title="Click on the record for full availability info" href="/catalog/857469">View Record for Full Availability</a>'
+        expect(response.body).to include '<a class="availability-icon label label-default" title="Click on the record for full availability info" data-toggle="tooltip" href="/catalog/857469">View Record for Full Availability</a>'
     end
     it "displays the location name for an item with a single location" do
       get "/catalog/321.json"
@@ -54,7 +54,8 @@ describe "blacklight tests" do
       docid = r["response"]["document"]["id"]
       get "/catalog/430472"
       r["response"]["document"]["location_code_s"].each do |location|
-        expect(response.body.include?("target=\"_blank\" class=\"find-it\" data-map-location=\"#{location}\" href=\"http://library.princeton.edu/searchit/map?loc=#{location}&amp;id=#{docid}\">[Where to Find It]</a>")).to eq true
+        expect(response.body.include?("class=\"find-it\" data-map-location=\"#{location}\" href=\"http://library.princeton.edu/searchit/map?loc=#{location}&amp;id=#{docid}\"")).to eq true
+
       end
     end
     it "does not provide a find it link for online holdings" do


### PR DESCRIPTION
 - Matches Voyager status to simplified labels. Closes #319 and closes #302 (Note that for all rare books locations to appear as "on-site access" I need to make a change to the bibdata availability API.
 - Have title row and bibliographic info span 9 columns and availability panel span 3 columns. This allows for a better alignment of RTL fields along the left edge of the availability panel. Finally closes #292.