### PR TITLE
quick cleanup

### DIFF
--- a/app/assets/javascripts/orangelight.js
+++ b/app/assets/javascripts/orangelight.js
@@ -22,28 +22,32 @@ $( document ).ready(function() {
     $(".holding-call-number").tooltip({
         selector: "[data-toggle='tooltip']",
         placement: "bottom",
-        container: "body"
+        container: "body",
+        trigger: "hover"
     });
 
     //tooltip for availability-icon
     $("[data-record-id]").tooltip({
         selector: "[data-toggle='tooltip']",
         placement: "left",
-        container: "body"
+        container: "body",
+        trigger: "hover"
     });
 
     //tooltip for subject heirarchy
     $(".facet-values").tooltip({
         selector: "[data-toggle='tooltip']",
         placement: "right",
-        container: "body"
+        container: "body",
+        trigger: "hover"
     });
 
     //tooltip for stack map
     $(".library-location").tooltip({
         selector: "[data-toggle='tooltip']",
         placement: "right",
-        container: "body"
+        container: "body",
+        trigger: "hover"
     });
 
     ///////////////////////////////////////////

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -82,8 +82,10 @@ class CatalogController < ApplicationController
     #
     # :show may be set to false if you don't want the facet to be drawn in the
     # facet bar
-    config.add_facet_field 'location', :label => 'Library', :limit => 20, sort: 'index', home: true, solr_params: { 'facet.mincount' => Blacklight.blacklight_yml['mincount'] || 1 }
-    config.add_facet_field 'format', :label => 'Format', partial: "facet_format", sort: 'index', :limit => 15, collapse: false, home: true
+    config.add_facet_field 'location', :label => 'Library', :limit => 20, sort: 'index',
+        home: true, solr_params: { 'facet.mincount' => Blacklight.blacklight_yml['mincount'] || 1 }
+    config.add_facet_field 'format', :label => 'Format', partial: "facet_format", sort: 'index',
+        :limit => 15, collapse: false, home: true, solr_params: { 'facet.mincount' => Blacklight.blacklight_yml['mincount'] || 1 }
 
     # num_segments and segments set to defaults here, included to show customizable features
     config.add_facet_field 'pub_date_start_sort', :label => 'Publication Year', :single => true, :range => {
@@ -98,7 +100,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'lc_1letter_facet', :label => 'Classification', :limit => 25, show: false, sort: 'index'
     config.add_facet_field 'author_s', :label => 'Author', :limit => true, show: false
     config.add_facet_field 'lc_rest_facet', :label => 'Full call number code', :limit => 25, show: false, sort: 'index'
-    config.add_facet_field 'recently_cataloged_facet', :label => 'Recently Cataloged', :query => {
+    config.add_facet_field 'recently_added_facet', :label => 'Recently Added', home: true, :query => {
        :weeks_1 => { :label => 'Within 1 Week', :fq => "cataloged_tdt:[NOW/DAY-7DAYS NOW/DAY+1DAY]" },
        :months_1 => { :label => 'Within 1 Month', :fq => "cataloged_tdt:[NOW/DAY-1MONTH NOW/DAY+1DAY]" },
        :months_6 => { :label => 'Within 6 Months', :fq => "cataloged_tdt:[NOW/DAY-6MONTHS NOW/DAY+1DAY]" }
@@ -113,6 +115,7 @@ class CatalogController < ApplicationController
 
     config.add_facet_field 'classification_pivot_field', :label => 'Classification', :pivot => ['lc_1letter_facet', 'lc_rest_facet']
     config.add_facet_field 'sudoc_facet', :label => 'SuDocs', :limit => true, sort: 'index'
+    config.add_facet_field 'location_code_s', :label => 'Location Code', show: false
 
     # Have BL send all facet field names to Solr, which has been the default
     # previously. Simply remove these lines if you'd rather use Solr request

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,11 +55,15 @@ module ApplicationHelper
     end
   end
 
+
+  # holding record fields: 'location', 'library', 'location_code', 'call_number', 'call_number_browse',
+  # 'shelving_title', 'location_note', 'electronic_access_1display', 'location_has', 'location_has_current',
+  # 'indexes', 'supplements'
   def holding_request_block (holdings, doc_id)
     block = ''
     holdings_hash = JSON.parse(holdings)
     holdings_hash.each do |id, holding|
-      unless holding['location_code'].start_with?('elf')
+      unless holding['location_code'].blank? or holding['location_code'].start_with?('elf')
         info = ''
         unless holding['location'].blank?
           location = "#{holding['location']}"
@@ -68,12 +72,16 @@ module ApplicationHelper
         end
         info << content_tag(:div, content_tag(:span, '', class: 'availability-icon').html_safe, data: { 'availability_record' => true, 'record_id' => doc_id, 'holding_id' => id })
         unless holding['call_number'].blank?
-          cn_browse_link = link_to('[Browse]', "/browse/call_numbers?q=#{holding['call_number']}", class: 'browse-cn',
-                              'data-toggle' => "tooltip", 'data-original-title' => "Browse: #{holding['call_number']}",
-                              title: "Browse: #{holding['call_number']}")
+          cn_browse_link = link_to('[Browse]', "/browse/call_numbers?q=#{holding['call_number_browse']}", class: 'browse-cn',
+                              'data-toggle' => "tooltip", 'data-original-title' => "Browse: #{holding['call_number_browse']}",
+                              title: "Browse: #{holding['call_number_browse']}")
           cn = "#{holding['call_number']} #{cn_browse_link}"
           info << content_tag(:span, cn.html_safe, class: 'holding-call-number')
         end
+        info << content_tag(:div, holding['shelving_title'], class: 'shelving-title') unless holding['shelving_title'].nil?
+        info << content_tag(:div, holding['location_note'], class: 'location-note') unless holding['location_note'].nil?
+        info << content_tag(:div, holding['location_has'], class: 'location-has') unless holding['location_has'].nil?
+        info << content_tag(:div, holding['location_has_current'], class: 'location-has-current') unless holding['location_has_current'].nil?
         info << request_placeholder(doc_id, id).html_safe
         block << content_tag(:div, info.html_safe, class: 'holding-block') unless info.empty?
       end

--- a/spec/helpers/holding_block_spec.rb
+++ b/spec/helpers/holding_block_spec.rb
@@ -14,7 +14,8 @@ RSpec.describe ApplicationHelper do
           location: location,
           library: library,
           location_code: 'exb', 
-          call_number: call_number
+          call_number: call_number,
+          call_number_browse: call_number
         },
         '3595800' => {
           location: 'Online - Online Resources',
@@ -89,7 +90,7 @@ RSpec.describe ApplicationHelper do
         expect(show_result).to have_link('[Browse]', href: "/browse/call_numbers?q=#{call_number}")
       end
       it "tooltip for the call number browse" do
-        expect(show_result).to have_selector "*[data-original-title='Browse: #{call_number}']"
+        expect(show_result).to have_selector "*[title='Browse: #{call_number}']"
       end
       it "tags the holding record id" do
         expect(show_result).to have_selector "*[data-holding-id='#{holding_id}']"


### PR DESCRIPTION
 - Fixes tooltip hovering issue from availability panel
 - Puts recently cataloged facet on homepage
 - Added hidden location code facet
 - No longer assumes every holding record has a location_code (see holdings_1display hash for https://pulsearch.princeton.edu/catalog/4686571.json)
 - Groups 866 with holding in availability panel