### PR TITLE
improve email and sms templates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,6 +381,3 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   webmock
   yajl-ruby
-
-BUNDLED WITH
-   1.10.4

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -24,7 +24,7 @@ class SolrDocument
   SolrDocument.use_extension( Blacklight::Solr::Document::Email )
 
   # SMS uses the semantic field mappings below to generate the body of an SMS email.
-  SolrDocument.use_extension( Blacklight::Solr::Document::Sms )
+  SolrDocument.use_extension( Blacklight::Document::Sms )
 
   # DublinCore uses the semantic field mappings below to assemble an OAI-compliant Dublin Core document
   # Semantic mappings of solr stored fields. Fields may be multi or

--- a/app/views/record_mailer/sms_record.text.erb
+++ b/app/views/record_mailer/sms_record.text.erb
@@ -1,0 +1,4 @@
+<% @documents.each do |document| %>
+<%= polymorphic_url(document, @url_gen_params) %>
+<%= document.to_sms_text %>
+<% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,7 @@ module Orangelight
     config.action_dispatch.default_headers.merge!({
        'X-UA-Compatible' => 'IE=edge,chrome=1'
      })
-
+    require Rails.root.join("lib/blacklight/document/sms")
     require Rails.root.join("lib/custom_public_exceptions")
     config.exceptions_app = CustomPublicExceptions.new(Rails.public_path)
   end

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -12,3 +12,8 @@ en:
     header_links:
       login: 'My Account'
       search_history: 'Search History'
+    email:
+      text:
+        subject:
+          one: 'PU Library Catalog Shared Record'
+          other: 'PU Library Catalog Shared Records'

--- a/lib/blacklight/document/sms.rb
+++ b/lib/blacklight/document/sms.rb
@@ -1,0 +1,12 @@
+# -*- encoding : utf-8 -*-
+# This module provides the body of an email export based on the document's semantic values
+module Blacklight::Document::Sms
+
+  # Return a text string that will be the body of the email
+  def to_sms_text
+    body = ''
+    body << "Call Number: #{self['call_number_display'].uniq.join(', ')}" if self['call_number_display']
+    body
+  end
+
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -51,4 +51,30 @@ RSpec.describe SolrDocument do
       end
     end
   end
+
+  describe "Blacklight::Document::Sms" do
+
+    it "should not include any text if call number not present" do
+      doc = described_class.new()
+      sms_text = doc.to_sms_text
+      expect(sms_text).to eq ''
+    end
+    it "should include call number in text" do
+      doc = described_class.new({call_number_display: ['AB 4209.3']})
+      sms_text = doc.to_sms_text
+      expect(sms_text).to match(/AB 4209.3/)
+    end
+    it "should include all call numbers if there are multiple holdings" do
+      doc = described_class.new({call_number_display: ['AB 4209.3', 'Electronic Resource']})
+      sms_text = doc.to_sms_text
+      expect(sms_text).to match(/AB 4209.3/)
+      expect(sms_text).to match(/Electronic Resource/)
+    end
+    it "should include all call numbers if there are multiple holdings" do
+      doc = SolrDocument.new({call_number_display: ['Electronic Resource', 'Electronic Resource', 'Electronic Resource']})
+      sms_text = doc.to_sms_text
+      expect(sms_text.scan(/Electronic Resource/).length).to eq 1
+    end
+  end
+
 end


### PR DESCRIPTION
Closes #289 and closes #297.
Sms - send link and unique call numbers
Emails aren't pretty looking, but at least they send the essential information. Changed the subject line.