### PR TITLE
display multiple formats, only include class for first format

### DIFF
--- a/app/assets/stylesheets/icons/icons.scss
+++ b/app/assets/stylesheets/icons/icons.scss
@@ -43,8 +43,7 @@
 }
 
 .icon-manuscript:before,
-.blacklight-manuscript .document-thumbnail .default:before,
-.blacklight-manuscript.blacklight-book .document-thumbnail .default:before {
+.blacklight-manuscript .document-thumbnail .default:before {
   content: "\e603";
 }
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -143,7 +143,7 @@ class CatalogController < ApplicationController
 
 
     config.add_show_field 'author_display', :label => 'Author', :helper_method => :browse_name
-    config.add_show_field 'format', :label => 'Formats'
+    config.add_show_field 'format', :label => 'Format', helper_method: :format_render
     config.add_show_field 'url_fulltext_display', :label => 'URL'
     config.add_show_field 'url_suppl_display', :label => 'More Information'
     config.add_show_field 'language_facet', :label => 'Language'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -210,8 +210,13 @@ module ApplicationHelper
   end
 
   def format_icon args
-    var = args[:document][args[:field]][0]
-    "#{render_icon(var)} #{var}".html_safe
+    icon = "#{render_icon(args[:document][args[:field]][0])}"
+    formats = format_render(args)
+    "#{icon} #{formats}".html_safe
+  end
+
+  def format_render args
+    args[:document][args[:field]].join(', ')
   end
 
   def voyager_url bibid

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+module CatalogHelper
+  include Blacklight::CatalogHelperBehavior
+
+  ##
+  # Get the classes to add to a document's div
+  #
+  # @return [String]
+  def render_document_class(document = @document)
+    types = document_types(document)
+    return if types.blank?
+    type = types.first
+    "#{document_class_prefix}#{type.try(:parameterize) || type}"
+  end
+
+  private
+  def document_types(document)
+    document[blacklight_config.view_config(document_index_view_type).display_type_field]
+  end
+end

--- a/spec/helpers/formats_spec.rb
+++ b/spec/helpers/formats_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper do
+
+  let(:format) { ['Dissertation', 'Manuscript', 'Book'] }
+  let(:format_display) { helper.format_icon(field_config) }
+  let(:render_format) { helper.format_render(field_config) }
+  let(:document) do
+    {
+        id: '1',
+        format: format
+    }.with_indifferent_access
+  end
+
+  let(:field_config) do
+    {
+      field: :format,
+      document: document
+    }.with_indifferent_access
+  end
+
+  describe '#render_format' do
+    it 'returns list of formats separated by comma' do
+      expect(render_format).to include(format.join(', '))
+    end
+  end
+
+  describe '#format_icon' do
+    it 'returns icon span for first format' do
+      expect(format_display).to include('icon-dissertation')
+    end
+    it 'does not returns icon span for remaining formats' do
+      expect(format_display).not_to include('icon-book')
+      expect(format_display).not_to include('icon-manuscript')
+    end
+  end
+
+# blacklight_config.view_config(document_index_view_type).display_type_field]
+  describe CatalogHelper do
+    # let(:blacklight_config) do
+    # end
+    it '#render_document_class includes only first format' do
+      allow(helper).to receive(:document_types).and_return(format)
+      document_class = helper.render_document_class(document)
+      expect(document_class).to eq('blacklight-dissertation')
+    end
+  end
+end


### PR DESCRIPTION
Allow all formats assigned to record to display in search results and show view. Only show format icon for the first format assigned, the "primary" format.