### PR TITLE
clean up atom feed template

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -156,8 +156,6 @@ class CatalogController < ApplicationController
     config.add_show_field 'compiled_created_display', :label => 'Compiled/Created'
     config.add_show_field 'edition_display', :label => 'Εdition'
     config.add_show_field 'medium_support_display', :label => 'Medium/Support'
-    # This is now routed to the sidebar
-    #config.add_show_field 'electronic_access_1display', :label => 'Electronic access', :helper_method => :urlify
 
     config.add_show_field 'description_display', :label => 'Description'
     config.add_show_field 'arrangement_display', :label => 'Arrangement'

--- a/app/views/catalog/_atom_index.html.erb
+++ b/app/views/catalog/_atom_index.html.erb
@@ -1,0 +1,19 @@
+<% index_fields(document).each do |solr_fname, field| -%>
+  <% if (should_render_index_field?(document, field)) %>
+    <% if (solr_fname == 'holdings_1display') %>
+      <% holdings_hash = JSON.parse(document[solr_fname]) %>
+      <% holdings_hash.first(2).each do |id, holding| %>
+        <% render_arrow = (!holding['library'].blank? and !holding['call_number'].blank?) %>
+        <% arrow = render_arrow ? ' &raquo; ' : '' %>
+        <% holding_info = "#{holding['library']}#{arrow}#{holding['call_number']}" %>
+        <% unless holding_info.blank? %>
+          <%= "#{holding_info}<br>".html_safe %>
+        <% end %>
+      <% end %>
+    <% elsif !document[solr_fname].is_a?(Array) %>
+      <%= document[solr_fname]%><br>
+    <% else %>
+      <%= document[solr_fname].join('<br>').html_safe %><br>
+    <% end %>
+  <% end -%>
+<% end -%>

--- a/app/views/catalog/_document_default.atom.builder
+++ b/app/views/catalog/_document_default.atom.builder
@@ -1,9 +1,9 @@
 xml.entry do
 
-  xml.title presenter(document).render_document_index_label(document_show_link_field(document))
+  xml.title document[document_show_link_field(document)]
 
   # updated is required, for now we'll just set it to now, sorry
-  xml.updated Time.current.iso8601
+  xml.updated document['cataloged_tdt']
 
   xml.link    "rel" => "alternate", "type" => "text/html", "href" => polymorphic_url(url_for_document(document))
   # add other doc-specific formats, atom only lets us have one per
@@ -19,9 +19,7 @@ xml.entry do
 
   with_format("html") do
     xml.summary "type" => "html" do
-      xml.text! render_document_partial(document,
-      :index,
-      :document_counter => document_counter)
+      xml.text! render partial: 'atom_index', locals: { document: document }
     end
   end
 

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,5 +1,5 @@
 <div id="sortAndPerPage" class="clearfix">
   <%= render :partial => "paginate_compact", :object => @response if show_pagination? %>
-  <%= link_to(" ", catalog_index_path(params.merge(:format => 'atom')), :class => "icon-rssfeed", :title => "Subscribe to results feed", 'data-toggle' => "tooltip" ) %>
+  <%= link_to(" ", catalog_index_path(params.merge(:format => 'atom', sort: 'cataloged_tdt desc, pub_date_start_sort desc, title_sort asc')), :class => "icon-rssfeed", :title => "Subscribe to results feed", 'data-toggle' => "tooltip" ) %>
   <%= render_results_collection_tools wrapping_class: "search-widgets pull-right" %>
 </div>

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -388,7 +388,8 @@
         oclc_s,
         lccn_s,
         holdings_1display,
-        electronic_access_1display
+        electronic_access_1display,
+        cataloged_tdt
       </str>
 
       <str name="facet">true</str>


### PR DESCRIPTION
Atom feed now sorts by most recently cataloged and includes the cataloged date in the response. Remove unrenderable javascript and markup from atom feed html view.