### PR TITLE
on shelf availability, disable facet enum cache, specify deploy branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@
 Versions:
 
 * Ruby: 2.2.3
-* Rails: 4.2.4
-* Blacklight: 5.14.0
+* Rails: 4.2.5.1
+* Blacklight: 5.18.0
 * blacklight_advanced_search: 5.1.2
 
 To install run `bundle install`
 
-postgresql configuration
+Application Configuration
 ------------------
-
+### Postgres Installation
 ```bash
 apt-get install postgresql
 su - postgres
@@ -25,7 +25,7 @@ psql -c "CREATE ROLE orangelight with createdb login password 'orange';"
 exit
 ```
 
-### database configruation
+### Database Configruation
 ```bash
 cp config/database.yml.tmpl config/database.yml
 rake db:create
@@ -34,14 +34,14 @@ rake db:migrate
 Production credentials: In production you'll need to add production 
 credentials to database.yml
 
-### Load test data
+### Load Test Data
 ```bash
 rake jetty:clean
 rake jetty:start
 rake pulsearch:index
 rake db:seed
 ```
-### Whitelist configuration
+### Whitelist Configuration
 ```bash
 cp config/ip_whitelist.yml.tmpl config/ip_whitelist.yml
 ```
@@ -54,3 +54,11 @@ cp config/requests.yml.tmpl config/requests.yml
 ```
 
 Configure various options for PUL Requests.
+
+Deploying with Capistrano
+------------------
+Default branch for deployment is `development`. You can specify a branch using the BRANCH environment variable.
+```
+BRANCH=my_branch cap staging deploy # deploys my_branch to staging
+cap staging deploy # deploys development branch to staging
+```

--- a/app/assets/javascripts/availability.js.coffee
+++ b/app/assets/javascripts/availability.js.coffee
@@ -5,7 +5,7 @@ class AvailabilityUpdater
     this.request_availability()
   availability_url: "https://bibdata.princeton.edu/availability"
   id = ''
-  available_statuses = ['Not Charged']
+  available_statuses = ['Not Charged', 'On Shelf']
   returned_statuses = ['In Transit Discharged', 'Discharged']
   in_process_statuses = ['In Process']
   checked_out_statuses = ['Charged', 'Renewed', 'Overdue', 'On Hold',
@@ -13,7 +13,7 @@ class AvailabilityUpdater
     'Remote Storage Request', 'Hold Request', 'Recall Request']
   missing_statuses = ['Missing', 'Lost--Library Applied',
     'Lost--System Applied', 'Claims Returned', 'Withdrawn']
-  available_labels = ['Available', 'Returned', 'In Process', 'Requestable']
+  available_labels = ['Available', 'Returned', 'In Process', 'Requestable', 'On Shelf']
   unavailable_labels = ['Checked Out', 'Missing']
   request_availability: ->
     if $(".documents-list").length > 0

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -13,7 +13,7 @@ set :rvm_ruby_string, :local
 set :stage, :production
 set :rails_env, 'production'
 
-set :branch, 'development'
+set :branch, ENV['BRANCH'] || 'development'
 
 # Extended Server Syntax
 # ======================

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -17,7 +17,7 @@ set :rvm_ruby_string, :local        # use the same ruby as used locally for depl
 set :stage, :production
 set :rails_env, 'production'
 
-set :branch, 'development'
+set :branch, ENV['BRANCH'] || 'development'
 
 # Extended Server Syntax
 # ======================

--- a/solr_conf/conf/solrconfig.xml
+++ b/solr_conf/conf/solrconfig.xml
@@ -398,8 +398,10 @@
       <str name="facet.field">format</str>
       <str name="facet.field">language_facet</str>
       <str name="facet.field">pub_date_start_sort</str>
+      <!--
       <str name="facet.method">enum</str>
       <str name="facet.enum.cache.minDf">25000</str>
+        -->
 
       <str name="spellcheck">true</str>
       <str name="spellcheck.dictionary">default</str>
@@ -602,7 +604,8 @@
         oclc_s,
         lccn_s,
         holdings_1display,
-        electronic_access_1display
+        electronic_access_1display,
+        cataloged_tdt
       </str>
       
       <str name="facet">true</str>
@@ -611,9 +614,10 @@
       <str name="facet.field">format</str>
       <str name="facet.field">language_facet</str>
       <str name="facet.field">pub_date_start_sort</str>
+      <!--
       <str name="facet.method">enum</str>
       <str name="facet.enum.cache.minDf">25000</str>
-
+        -->
       <str name="spellcheck">true</str>
       <str name="spellcheck.dictionary">subject</str>
       <str name="spellcheck.onlyMorePopular">true</str>


### PR DESCRIPTION
 - "Uknown" records default to "On Shelf" status and display as available in the interface.
 - Made advanced and default search handler consistent, disable facet enum cache (which was causing performance issues - never checked in to version control)
 - Allow user to specify branch for cap deployment. Instructions in updated readme.