### PR TITLE
Addresses #447.

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -2,7 +2,6 @@ require './lib/orangelight/voyager_patron_client.rb'
 require './lib/orangelight/voyager_account.rb'
 
 class AccountController < ApplicationController
-  include Blacklight::Configurable
   include ApplicationHelper
   include AccountHelper
 


### PR DESCRIPTION
Mixing in Blacklight::Configurable flipped the site to use the blacklight.html.erb layout file instead of application.html.erb. 