### PR TITLE
Add success/danger attributes to renewed item row 

### DIFF
--- a/app/helpers/account_helper.rb
+++ b/app/helpers/account_helper.rb
@@ -42,5 +42,14 @@ module AccountHelper
       content_tag(:b, "#{item[:renew_status]["status"]}")
     end
   end
-  
+
+  def renew_state item
+    unless item[:renew_status].nil?
+      if item[:renew_status]["status"] == 'Renewed'
+        "success"
+      else
+        "danger"
+      end
+    end
+  end
 end

--- a/app/views/account/_charged_items.html.erb
+++ b/app/views/account/_charged_items.html.erb
@@ -15,14 +15,14 @@
         </thead>
         <tbody>
           <% @account.charged_items.each do |item| %>
-            <tr data-item-id="<%= item['itemId'] %>">
+            <tr data-item-id="<%= item['itemId'] %>" class="<%= renew_state(item) %>">
               <td>
                 <% unless @account.has_blocks? %>
                   <% if item["renewable"] == 'true' %>
                     <label><input id="charged-<%= item["itemId"] %>" 
                       type="checkbox" name="renew_items[]" 
                       value="<%= format_renew_string(item) %>"> 
-                      <%= I18n.t('blacklight.account.renew_label') %></label>
+                    </label>
                   <% else %>
                     <span><%= I18n.t('blacklight.account.not_renewable_due_to_item_status') %></span>
                   <% end %>

--- a/spec/views/account/account_spec.rb
+++ b/spec/views/account/account_spec.rb
@@ -306,6 +306,7 @@ describe "Your Account", :type => :feature do
         expect(page).to have_xpath("//tr[@data-item-id='3688389']")
         click_button('Renew items')
         wait_for_ajax
+        expect(page).to have_selector(".success[data-item-id='3688389']")
         expect(find(:xpath, "//tr[@data-item-id='3688389']/td/span[@class='item--messages']/b").text).to eq("Renewed")
       end
 
@@ -314,6 +315,7 @@ describe "Your Account", :type => :feature do
         expect(page).to have_xpath("//tr[@data-item-id='7193128']")
         click_button('Renew items')
         wait_for_ajax
+        expect(page).to have_selector(".danger[data-item-id='7193128']")
         expect(find(:xpath, "//tr[@data-item-id='7193128']/td/span[@class='item--messages']/span[@class='message']").text).to eq("Item not authorized for renewal.")
         expect(find(:xpath, "//tr[@data-item-id='7193128']/td/span[@class='item--messages']/b").text).to eq("Not Renewed")
       end


### PR DESCRIPTION
Should close #449. I believe "danger" is the universal bootstrap class attribute for "red background".