### PR TITLE
Add 'live' request placeholder page.

### DIFF
--- a/app/controllers/request_controller.rb
+++ b/app/controllers/request_controller.rb
@@ -1,0 +1,12 @@
+class RequestController < ApplicationController
+  include ApplicationHelper
+
+  def show
+    @id = sanitize(params[:id])
+  end
+
+  private
+    def sanitize(str)
+      str.gsub(/[^A-Za-z0-9]/, '')
+    end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -146,7 +146,7 @@ module ApplicationHelper
 
   def request_placeholder(doc_id, holding_id, location_rules)
     content_tag(:div, class: 'location-services', data: { open: location_rules[:open], aeon: location_rules[:aeon_location], holding_id: holding_id }) do
-      link_to "Request", "https://library.princeton.edu/requests/#{doc_id}?mfhd=#{holding_id}", title: "View Options to Request copies from this Location", target: "_blank", class: "request btn btn-xs btn-primary", data: { toggle: "tooltip" }
+      link_to "Request", "/request/#{doc_id}?mfhd=#{holding_id}", title: "View Options to Request copies from this Location", target: "_blank", class: "request btn btn-xs btn-primary", data: { toggle: "tooltip" }
     end
   end
 

--- a/app/views/request/show.html.erb
+++ b/app/views/request/show.html.erb
@@ -1,6 +1,18 @@
-<div class="col-md-12">
-  <h1 class="page-heading">Request mockups</h1>
 
+
+<div class="col-md-12">
+  <h1 class="page-heading">Request Library Material</h1>
+  <div class="alert alert-info">
+    <p><strong>This Feature is Under Construction</strong><br>
+    We are working on a replacement of current material request form that will support University Single Sign-On services and simplify the process of requesting materials from the Library. Some mockups of common request types as they will appear in the new system are displayed below. If you want to request copies of this material now please follow the the button to the existing system below.
+    </p>
+  </div>
+  <div>
+    <div class="button--start-over">
+      <a class="catalog_startOverLink btn btn-primary" id="startOverLink" href="https://library.princeton.edu/requests/<%= @id %>">Use Existing Request Form</a>
+    </div>
+      <a class="btn btn-default icon-moveback" href="/catalog/<%= @id %>">Back to Record</a>
+  </div>
   <div class="placeholder-container is-disabled">
   <div class="ribbon"><span>Placeholder</span></div>
   <!-- Request item / checked-out item -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,8 @@ Rails.application.routes.draw do
   post '/account/renew', to: 'account#renew'
   post '/account/cancel', to: 'account#cancel'
 
+  get '/request/:id', to: 'request#show'
+
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/spec/routing/request_routing_spec.rb
+++ b/spec/routing/request_routing_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+describe RequestController, type: :routing do
+
+  describe "routing" do
+
+    it "/request/123456 routes to help page" do
+      expect(get: "/request/123456").to route_to("request#show", id: "123456")
+    end
+
+  end
+end

--- a/spec/views/request/request_spec.rb
+++ b/spec/views/request/request_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe "Request Page", :type => :feature do
+
+  it "Produces a page that contains a link to the request system" do
+    visit('/request/7916044')
+    expect(page).to have_xpath('.//a[@href="https://library.princeton.edu/requests/7916044"]')
+
+  end
+end


### PR DESCRIPTION
@jpstroop @tampakis Will this work as a placeholder? I moved the previous template @axamei constructed over to a temporary controller that can pass the context of a given ID to the existing request system. Added two "live" buttons. One to the current form, a second that can take them back to the show page of the record they followed to get there. 