### PR TITLE
author label, spelling suggestion limit, move up language facet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ gem 'capistrano', '~> 3.4.0'
 gem 'faraday'
 gem 'faraday-cookie_jar'
 gem 'yajl-ruby', require: 'yajl'
-gem "devise"
+gem "devise", '~> 3.5'
 gem "devise-guests", '~> 0.5'
 gem "omniauth-cas"
 gem "blacklight-marc", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: https://github.com/pulibrary/requests.git
-  revision: 125eafe93cfa246f071514e4d579e81a4c94af04
+  revision: a295a29f54239978fb67bf273738b361c43c76ae
   branch: request_test_specs
   specs:
     requests (0.0.1)
@@ -58,7 +58,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    acts_as_list (0.7.2)
+    acts_as_list (0.7.4)
       activerecord (>= 3.0)
     addressable (2.4.0)
     arel (6.0.3)
@@ -97,9 +97,9 @@ GEM
     borrow_direct (1.2.0)
       httpclient (~> 2.4)
     builder (3.2.2)
-    byebug (8.2.4)
+    byebug (8.2.5)
     cancancan (1.13.1)
-    capistrano (3.4.0)
+    capistrano (3.4.1)
       i18n
       rake (>= 10.0.0)
       sshkit (~> 1.3)
@@ -109,7 +109,7 @@ GEM
     capistrano-rails (1.1.6)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
-    capybara (2.7.0)
+    capybara (2.7.1)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -125,7 +125,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.10.0)
-    concurrent-ruby (1.0.1)
+    concurrent-ruby (1.0.2)
     coveralls (0.8.13)
       json (~> 1.8)
       simplecov (~> 0.11.0)
@@ -136,7 +136,7 @@ GEM
       safe_yaml (~> 1.0.0)
     deprecation (1.0.0)
       activesupport
-    devise (3.5.6)
+    devise (3.5.9)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
@@ -166,11 +166,11 @@ GEM
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     hashdiff (0.3.0)
-    hashie (3.4.3)
+    hashie (3.4.4)
     high_voltage (2.4.0)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
-    httpclient (2.7.1)
+    httpclient (2.8.0)
     i18n (0.7.0)
     jbuilder (2.4.1)
       activesupport (>= 3.0.0, < 5.1)
@@ -187,7 +187,7 @@ GEM
       addressable (~> 2.3)
     lcsort (0.9.0)
     library_stdnums (1.4.1)
-    libv8 (3.16.14.13)
+    libv8 (3.16.14.15)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -205,12 +205,12 @@ GEM
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     modernizr-rails (2.7.1)
-    multi_json (1.11.2)
+    multi_json (1.12.0)
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (3.1.1)
-    newrelic_rpm (3.15.1.316)
+    newrelic_rpm (3.15.2.317)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     omniauth (1.2.2)
@@ -273,7 +273,7 @@ GEM
     rdoc (4.2.2)
       json (~> 1.4)
     ref (2.0.0)
-    responders (2.1.2)
+    responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
     rsolr (1.0.13)
       builder (>= 2.1.2)
@@ -338,7 +338,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sshkit (1.9.0)
+    sshkit (1.10.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
     term-ansicolor (1.3.2)
@@ -348,7 +348,7 @@ GEM
       ref
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (2.0.2)
+    tilt (2.0.3)
     tins (1.6.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -360,7 +360,7 @@ GEM
     unicode-display_width (1.0.5)
     warden (1.2.6)
       rack (>= 1.0)
-    webmock (1.24.3)
+    webmock (2.0.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -388,7 +388,7 @@ DEPENDENCIES
   capybara
   coffee-rails (~> 4.0.0)
   coveralls
-  devise
+  devise (~> 3.5)
   devise-guests (~> 0.5)
   factory_girl_rails
   faraday

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -90,10 +90,10 @@ class CatalogController < ApplicationController
       assumed_boundaries: [1100, Time.now.year + 1],
       segments: true
     }
+    config.add_facet_field 'language_facet', label: 'Language', limit: true
     config.add_facet_field 'subject_topic_facet', label: 'Subject: Topic', limit: true
     config.add_facet_field 'genre_facet', label: 'Subject: Genre', limit: true
     config.add_facet_field 'subject_era_facet', label: 'Subject: Era', limit: true
-    config.add_facet_field 'language_facet', label: 'Language', limit: true
     config.add_facet_field 'lc_1letter_facet', label: 'Classification', limit: 25, show: false, sort: 'index'
     config.add_facet_field 'author_s', label: 'Author', limit: true, show: false
     config.add_facet_field 'class_year_s', label: 'PU Class Year', limit: true, show: false
@@ -126,7 +126,7 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field 'author_display', label: 'Author', helper_method: :browse_name
+    config.add_index_field 'author_display', label: 'Author/Artist', helper_method: :browse_name
     config.add_index_field 'pub_created_display', label: 'Published/Created'
     config.add_index_field 'format', label: 'Format', helper_method: :format_icon
 
@@ -137,7 +137,7 @@ class CatalogController < ApplicationController
     # config.add_show_field 'subtitle_display', :label => 'Subtitle'
     # config.add_show_field 'subtitle_vern_display', :label => 'Subtitle'
 
-    config.add_show_field 'author_display', label: 'Author', helper_method: :browse_name
+    config.add_show_field 'author_display', label: 'Author/Artist', helper_method: :browse_name
     config.add_show_field 'format', label: 'Format', helper_method: :format_render
     config.add_show_field 'url_fulltext_display', label: 'URL'
     config.add_show_field 'url_suppl_display', label: 'More Information'
@@ -387,7 +387,7 @@ class CatalogController < ApplicationController
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.
-    config.spell_max = 5
+    config.spell_max = 0
 
     # Add bookmark all widget
     config.add_results_collection_tool(:bookmark_all)


### PR DESCRIPTION
Updates author_display default label to "Author/Display." Closes #521.
Only displays spelling suggestions when no results are returned. Closes #489.
Moves up language facet to be above subject facets. Closes #523.
Also ran a bundle update.