### PR TITLE
allow advanced form to remember user input on back button click

### DIFF
--- a/app/assets/stylesheets/components/search--advanced.scss
+++ b/app/assets/stylesheets/components/search--advanced.scss
@@ -67,3 +67,16 @@
 .page-header {
   margin: 5px 0 10px;
 }
+
+.well > h4 {
+  margin: 0.25em 0 0.5em;
+}
+
+.well.search_history {
+  padding: 10px;
+}
+
+.inclusive_or.well {
+  padding: 10px;
+  margin-bottom: 5px;
+}

--- a/app/views/advanced/_advanced_search_form.html.erb
+++ b/app/views/advanced/_advanced_search_form.html.erb
@@ -1,38 +1,37 @@
-<div class="col-md-7">
-  <% unless (search_context_str = render_search_to_s( advanced_search_context)).blank? %>
-    <div class="constraints well search_history">
-      <h4><%= t 'blacklight_advanced_search.form.search_context' %></h4>
-      <%= search_context_str %>
-    </div>
-  <% end %>
-
 <%= form_tag catalog_index_path, :class => 'advanced form-horizontal', :method => :get do  %>
+  <div class="col-md-7">
+    <% unless (search_context_str = render_search_to_s( advanced_search_context)).blank? %>
+      <div class="constraints well search_history">
+        <h4 class="advanced-search-context"><%= t 'blacklight_advanced_search.form.search_context' %></h4>
+        <%= search_context_str %>
+      </div>
+    <% end %>
 
-  <%= render_hash_as_hidden_fields(params_for_search(advanced_search_context.except(:model, :rpp, :start), {})) %>
+    <%= render_hash_as_hidden_fields(params_for_search(advanced_search_context.except(:model, :rpp, :start), {})) %>
 
-  <div class="input-criteria">
-    <div id="guided_search">
-      <%= render 'advanced/guided_search_fields' %>
+    <div class="input-criteria">
+      <div id="guided_search">
+        <%= render 'advanced/guided_search_fields' %>
+      </div>
+    </div>
+
+  </div>
+  <div class="col-md-5">
+    <div class="limit-criteria">
+      <h3 class="limit-criteria-heading"><%= t('blacklight_advanced_search.form.limit_criteria_heading_html')%></h3>
+
+      <div id="advanced_search_facets" class="limit_input">
+        <% if blacklight_config.try(:advanced_search).try {|h| h[:form_facet_partial] } %>
+          <%= render blacklight_config.advanced_search[:form_facet_partial] %>
+        <% else %>
+          <%= render 'advanced_search_facets_as_select' %>
+        <% end %>
+      </div>
     </div>
   </div>
 
-</div>
-<div class="col-md-5">
-  <div class="limit-criteria">
-    <h3 class="limit-criteria-heading"><%= t('blacklight_advanced_search.form.limit_criteria_heading_html')%></h3>
-
-    <div id="advanced_search_facets" class="limit_input">
-      <% if blacklight_config.try(:advanced_search).try {|h| h[:form_facet_partial] } %>
-        <%= render blacklight_config.advanced_search[:form_facet_partial] %>
-      <% else %>
-        <%= render 'advanced_search_facets_as_select' %>
-      <% end %>
-    </div>
+  <div class="search-submit-buttons clearfix col-sm-7">
+    <%= render 'advanced_search_submit_btns' %>
   </div>
-</div>
-
-<div class="search-submit-buttons clearfix col-sm-7">
-  <%= render 'advanced_search_submit_btns' %>
-</div>
 
 <% end %>

--- a/app/views/advanced/_guided_search_fields.html.erb
+++ b/app/views/advanced/_guided_search_fields.html.erb
@@ -3,7 +3,7 @@
   <div class="search-field">
     <%= select_tag('f1', options_for_select(advanced_key_value, guided_field(:f1, 'all_fields')), :class=>"search_field") %>
     <div name="row1">
-      <%= text_field_tag "q1", label_tag_default_for(:q1), :class => 'form-control', :autocomplete => "off", autocorrect: "off", autocapitalize: "off", spellcheck: "false" %>
+      <%= text_field_tag "q1", label_tag_default_for(:q1), :class => 'form-control', autocorrect: "off", autocapitalize: "off", spellcheck: "false" %>
     </div>
   </div>
   <div class="search-operators">
@@ -14,7 +14,7 @@
   <div class="search-field">
     <%= select_tag('f2', options_for_select(advanced_key_value, guided_field(:f2, 'title')), :class=>"search_field") %>
     <div name="row2">
-      <%= text_field_tag "q2", label_tag_default_for(:q2), :class => 'form-control', :autocomplete => "off", autocorrect: "off", autocapitalize: "off", spellcheck: "false" %>
+      <%= text_field_tag "q2", label_tag_default_for(:q2), :class => 'form-control', autocorrect: "off", autocapitalize: "off", spellcheck: "false" %>
     </div>
   </div>
   <div class="search-operators">
@@ -25,7 +25,7 @@
   <div class="search-field">
     <%= select_tag('f3', options_for_select(advanced_key_value, guided_field(:f3, 'author')), :class=>"search_field") %>
     <div name="row3">
-      <%= text_field_tag "q3", label_tag_default_for(:q3), :class => 'form-control', :autocomplete => "off", autocorrect: "off", autocapitalize: "off", spellcheck: "false" %>
+      <%= text_field_tag "q3", label_tag_default_for(:q3), :class => 'form-control', autocorrect: "off", autocapitalize: "off", spellcheck: "false" %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Allows the browser to remember the form values inputed by user when clicking the back button after submitting an advanced search.