### PR TITLE
Logout of CAS when logging out of Orangelight

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,4 +15,8 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(_resource)
     account_path
   end
+
+  def after_sign_out_path_for(_resource)
+    Rails.configuration.x.after_sign_out_url
+  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,8 @@ module Orangelight
     config.action_dispatch.default_headers['X-UA-Compatible'] = 'IE=edge,chrome=1'
     require Rails.root.join('lib/custom_public_exceptions')
     config.exceptions_app = CustomPublicExceptions.new(Rails.public_path)
+
+    # Redirect to CAS logout after signing out of Orangelight
+    config.x.after_sign_out_url = 'https://fed.princeton.edu/cas/logout'
   end
 end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -24,8 +24,8 @@ en:
       unlock_instructions:
         subject: "Unlock Instructions"
     omniauth_callbacks:
-      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
-      success: "Successfully authenticated from %{kind} account. Please log out to protect your privacy when using a shared computer."
+      failure: "Could not authenticate you from Princeton Central Authentication Service because \"%{reason}\"."
+      success: "Successfully authenticated from Princeton Central Authentication Service. Please log out to protect your privacy when using a shared computer."
     passwords:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."


### PR DESCRIPTION
* Redirecting to CAS logout after Orangelight logout - Closes #567 
* Updating CAS name in Devise locale file - Closes #177 