### PR TITLE
Consistent capitalization in copies in library box and move beta banner

### DIFF
--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -30,6 +30,7 @@
     min-height: 40px;
     height: 85px;
     position: relative;
+    clear: both;
     .menu--level-1,
     .logo__pul {
         height: 40px;

--- a/app/assets/stylesheets/shame.scss
+++ b/app/assets/stylesheets/shame.scss
@@ -5,6 +5,13 @@
 .beta {
   border-left: 4px solid #E0CB52;
   z-index: 1;
+  margin: 0;
+  border-radius: 0;
+  padding: 10px 15px;
+
+  p {
+    margin: 0;
+  }
 }
 
 .is-disabled {

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -41,8 +41,6 @@
   <main role="main" id="main-container">
     <div class="container">
 
-      <%= render partial: 'shared/this_is_beta' %>
-
       <%= content_tag :h1, application_name, class: 'sr-only application-heading' %>
 
       <%= render :partial=>'/flash_msg' %>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,4 +1,5 @@
 <header role="banner">
+<%= render partial: 'shared/this_is_beta' %>
   <div class="l-branding__pul">
     <div class="container">
       <a href="http://library.princeton.edu" title="Princeton University Library" class="logo__pul col-xs-12 col-sm-6">

--- a/app/views/shared/_this_is_beta.html.erb
+++ b/app/views/shared/_this_is_beta.html.erb
@@ -1,6 +1,8 @@
 <div class="col-xs-12 col-lg-12 alert alert-warning beta">
-  <p><strong>This is Beta Software</strong><br />
-    There may be features missing. <a title="Feedback on New Catalog" href="/feedback">Please send us a note</a>
-    if you have feedback or think you have found an error.
-  </p>
+  <div class="container">
+    <p><strong>This is Beta Software</strong><br />
+      There may be features missing. <a title="Feedback on New Catalog" href="/feedback">Please send us a note</a>
+      if you have feedback or think you have found an error.
+    </p>
+  </div>
 </div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -29,7 +29,7 @@ en:
     holdings:
       online: 'Online'
       print: 'Copies In Library'
-      stackmap: 'Where to Find It'
+      stackmap: 'Where to find it'
       browse: 'Browse nearby items'
       search_missing: 'No holdings available for this record'
       missing: 'There are no holdings available for this record. Please consult a library staff member at the nearest Circulation Desk.'


### PR DESCRIPTION
Adjust where to find it to have consistent capitalization in copies in library box. Closes #580

Move beta banner above header. Closes #576