### PR TITLE
Adds Support for Paging Request via application_helper

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,13 +7,14 @@ GIT
 
 GIT
   remote: https://github.com/pulibrary/requests.git
-  revision: 1a5877b3061e28ad6ff70971f0420fe6a3648ea1
+  revision: 93ef94db653592c60f6974565d9e83f8a7c2f115
   branch: request_test_specs
   specs:
     requests (0.0.1)
       bootstrap-sass (~> 3.3)
       borrow_direct (~> 1.2.0)
       coveralls
+      email_validator
       faraday
       friendly_id (~> 5.1.0)
       lcsort
@@ -154,6 +155,8 @@ GEM
     docile (1.1.5)
     domain_name (0.5.20160310)
       unf (>= 0.0.5, < 1.0.0)
+    email_validator (1.6.0)
+      activemodel
     erubis (2.7.0)
     execjs (2.7.0)
     factory_girl (4.7.0)
@@ -207,7 +210,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_portile2 (2.0.0)
+    mini_portile2 (2.1.0)
     minitest (5.9.0)
     modernizr-rails (2.7.1)
     multi_json (1.12.0)
@@ -216,8 +219,9 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (3.1.1)
     newrelic_rpm (3.15.2.317)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
     omniauth (1.2.2)
       hashie (>= 1.2, < 4)
       rack (~> 1.0)
@@ -231,6 +235,7 @@ GEM
     parslet (1.7.1)
       blankslate (>= 2.0, <= 4.0)
     pg (0.18.4)
+    pkg-config (1.1.7)
     poltergeist (1.9.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -274,7 +279,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.1.0)
-    rake (11.1.2)
+    rake (11.2.2)
     rdoc (4.2.2)
       json (~> 1.4)
     ref (2.0.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   # Please be sure to impelement current_user and user_session. Blacklight depends on
   # these methods in order to perform user specific actions.
 
-  layout 'blacklight'
+  layout 'application'
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,7 @@
     <![endif]-->
 
     <title><%= render_page_title %></title>
-    <%= opensearch_description_tag application_name, opensearch_catalog_url(:format => 'xml') %>
+    <%= opensearch_description_tag application_name, main_app.opensearch_catalog_url(:format => 'xml') %>
     <%= favicon_link_tag 'favicon.ico' %>
     <%= stylesheet_link_tag "application", media: "all" %>
     <%= stylesheet_link_tag "print", media: "print" %>

--- a/config/locales/requests.en.yml
+++ b/config/locales/requests.en.yml
@@ -2,6 +2,5 @@
 en:
   requests:
     account:
-      pul_auth: "Requesting materials as %{current_user_name}"
-      guest: "Logged in as %{current_user_name}. Options for guest borrowers are displayed below"
+      pul_auth: "You are logged as %{current_user_name}"
       unauthenticated: "Please sign in to see all requests"

--- a/config/requests.yml
+++ b/config/requests.yml
@@ -10,7 +10,7 @@ defaults: &defaults
 development:
   <<: *defaults
   voyager_ub_id: 1@DB
-
+  bibdata_base: http://localhost:7000
 test:
   <<: *defaults
   voyager_ub_id: 1@DB

--- a/spec/helpers/holding_block_spec.rb
+++ b/spec/helpers/holding_block_spec.rb
@@ -1,6 +1,55 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationHelper do
+  describe '#pageable?' do
+    let(:pageable_holding) { helper.pageable?(holding_in_range) }
+    let(:not_pageable_holding) { helper.pageable?(holding_out_of_range) }
+    let(:not_lc_call_num) { helper.pageable?(non_lc_call_num) }
+    let(:holding_in_range) do
+      {
+        'location' => 'Firestone Library - Near East Collections',
+        'library' => 'Firestone Library',
+        'location_code' => 'nec',
+        'call_number' => 'PZ6611.T3F545 1987',
+        'call_number_browse' => 'PZ6611.T3F545 1987'
+      }
+    end
+
+    let(:holding_out_of_range) do
+      {
+        'location' => 'Firestone Library - Near East Collections',
+        'library' => 'Firestone Library',
+        'location_code' => 'nec',
+        'call_number' => 'Z6611.T3F545 1987',
+        'call_number_browse' => 'Z6611.T3F545 1987'
+      }
+    end
+
+    let(:non_lc_call_num) do
+      {
+        'location' => 'Firestone Library - Near East Collections',
+        'library' => 'Firestone Library',
+        'location_code' => 'nec',
+        'call_number' => '33334.53535',
+        'call_number_browse' => '33334.53535'
+      }
+    end
+
+    context 'When Holding is in pageable range' do
+      it 'returns true when the call number is in range' do
+        expect(pageable_holding).to be_truthy
+      end
+
+      it 'returns nil when the call number is out of range' do
+        expect(not_pageable_holding).to be_nil
+      end
+
+      it 'returns nil when the call number is not an LC number' do
+        expect(not_lc_call_num).to be_nil
+      end
+    end
+  end
+
   describe '#holding_block helpers' do
     let(:holding_id) { '3580281' }
     let(:library) { 'Rare Books and Special Collections' }

--- a/spec/helpers/locations_spec.rb
+++ b/spec/helpers/locations_spec.rb
@@ -39,11 +39,17 @@ RSpec.describe ApplicationHelper do
 
   describe '#open_location?' do
     let(:loc) { { open: true } }
+    let(:holding) { { 'call_number' => 'KF 1232 .B2', 'location_code' => 'f' } }
+    let(:holding_pageable) { { 'call_number' => 'QL 1232 .B8', 'location_code' => 'f' } }
     it 'returns the location open attribute value' do
-      expect(open_location?(loc)).to eq true
+      expect(open_location?(loc, holding)).to eq true
     end
     it 'returns false when nil location is passed to function' do
-      expect(open_location?(nil)).to eq false
+      expect(open_location?(nil, holding)).to eq false
+    end
+
+    it 'returns false when a pageable holding is present' do
+      expect(open_location?(loc, holding_pageable)).to eq false
     end
   end
 


### PR DESCRIPTION
The added pageable? method added to helper depends on the Requests::Pageable concern from the requests gem to test whether or not a given holding will display a paging request link. Also advances to the lastest commit ref for the request_test_specs branch on the requests gem. 