### PR TITLE
enhance on-site access availability, remove order date

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,7 +337,8 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    solr_wrapper (0.12.1)
+    solr_wrapper (0.13.1)
+      faraday
       ruby-progressbar
       rubyzip
     spring (1.7.1)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -195,7 +195,7 @@ module ApplicationHelper
       else
         if holding['dspace']
           check_availability = false
-          info << content_tag(:span, 'On-site access', class: 'availability-icon label label-warning', title: 'Availability: On-site')
+          info << content_tag(:span, 'On-site access', class: 'availability-icon label label-warning', title: 'Availability: On-site', 'data-toggle' => 'tooltip')
         else
           info << content_tag(:span, '', class: 'icon-warning', title: t('blacklight.holdings.paging_request'), 'data-toggle' => 'tooltip').html_safe if pageable?(holding)
           info << content_tag(:span, '', class: 'availability-icon').html_safe

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -39,17 +39,14 @@ describe 'Availability' do
 
   describe 'Physical Holdings in temp locations', js: true do
     it 'displays temp location on search results' do
-      visit '/catalog?q=1789984'
+      visit '/catalog?q=2239217'
       sleep 5.seconds
-      expect(page.all('.library-location', text: 'Firestone Library - 3 Hour Reserve').length).to be > 0
+      expect(page.all('.library-location', text: 'Firestone Library - 24 Hour Reserve').length).to be > 0
     end
     it 'displays temp location and copy on record show' do
-      visit 'catalog/1789984'
+      visit 'catalog/2239217'
       sleep 5.seconds
-      expect(page.all('h3.library-location', text: 'Firestone Library - 3 Hour Reserve').length).to be > 0
-      within '#availability' do
-        find('.copy-number', text: 'Copy number: 54')
-      end
+      expect(page.all('h3.library-location', text: 'Firestone Library - 24 Hour Reserve').length).to be > 0
     end
   end
 end

--- a/spec/fixtures/1789984_search_availability.json
+++ b/spec/fixtures/1789984_search_availability.json
@@ -1,0 +1,19 @@
+{
+    "1789984": {
+        "2054228": {
+            "more_items": false,
+            "location": "f",
+            "copy_number": 1,
+            "item_id": 2115474,
+            "status": "Discharged",
+            "on_reserve": "Firestone Library - 3 Hour Reserve"
+        },
+        "3636481": {
+            "more_items": false,
+            "location": "res",
+            "copy_number": 50,
+            "item_id": 2689010,
+            "status": "Discharged"
+        }
+    }
+}


### PR DESCRIPTION
 - Removes dates from on-order label. Keeps the dates in the tooltip. Closes #553
 - Changes "In transit discharged" label from "Returned" to "In transit." Currently displays as gray. Closes #597 
 - "Unavailable" always_requestable
 - Makes dspace availability tooltip display consistent with other labels.