### PR TITLE
make prev/next clickable, unsupported ie text-transform property

### DIFF
--- a/app/assets/stylesheets/components/availability.scss
+++ b/app/assets/stylesheets/components/availability.scss
@@ -7,7 +7,7 @@
   .availability-icon {
     display: inline-block;
     background: none;
-    text-transform: initial;
+    text-transform: none;
     font-size: 12px;
     padding: 0;
     margin-right: 0;

--- a/app/assets/stylesheets/components/buttons.scss
+++ b/app/assets/stylesheets/components/buttons.scss
@@ -98,14 +98,12 @@ a.clear-bookmarks {
 #previousNextDocument .next {
   opacity: .5;
   background: $light-gray;
-  pointer-events: none;
   cursor: not-allowed;
 }
 
 #previousNextDocument a.previous,
 #previousNextDocument a.next {
   opacity: 1;
-  pointer-events: initial;
   cursor: pointer;
 
   &:hover,


### PR DESCRIPTION
Availability info is now title cased in IE.
Prev/Next button is clickable in all browsers. Closes #612 
