### PR TITLE
location label based on code lookup against location service data

### DIFF
--- a/app/assets/javascripts/availability.js.coffee
+++ b/app/assets/javascripts/availability.js.coffee
@@ -69,7 +69,7 @@ class AvailabilityUpdater
       ul = "<ul class=\"item-status\">"
       for key, item of data
         if item['status'] != "Not Charged"
-          li = "<li>#{item['enum']}: #{title_case(item['status'])}</li>"
+          li = "<li>#{item['enum'] || 'Item'}: #{title_case(item['status'])}</li>"
           ul = ul + li
           span = $("*[data-holding-id='#{holding_id}'] .availability-icon")
           txt = "Some items not available"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -97,8 +97,8 @@ module ApplicationHelper
 
   def process_physical_holding(holding, bib_id, holding_id, is_journal)
     info = ''
-    unless holding['location'].blank?
-      location = content_tag(:span, holding['location'], class: 'location-text', data:
+    unless (holding_loc = holding_location_label(holding)).blank?
+      location = content_tag(:span, holding_loc, class: 'location-text', data:
                             {
                               location: true,
                               holding_id: holding_id
@@ -225,9 +225,10 @@ module ApplicationHelper
   end
 
   def search_location_display(holding, document)
-    render_arrow = (!holding['library'].blank? && !holding['call_number'].blank?)
+    location = holding_location_label(holding)
+    render_arrow = (!location.blank? && !holding['call_number'].blank?)
     arrow = render_arrow ? ' &raquo; ' : ''
-    location_display = holding['location'] + arrow + content_tag(:span, %(#{holding['call_number']}#{locate_link_with_gylph(holding['location_code'], document['id'], holding['call_number'], holding['library'])}).html_safe, class: 'call-number')
+    location_display = location + arrow + content_tag(:span, %(#{holding['call_number']}#{locate_link_with_gylph(holding['location_code'], document['id'], holding['call_number'], holding['library'])}).html_safe, class: 'call-number')
     location_display.html_safe
   end
 
@@ -284,6 +285,12 @@ module ApplicationHelper
   def render_location_code(value)
     location = LOCATIONS[value.to_sym]
     location.nil? ? value : "#{value}: #{location_full_display(location)}"
+  end
+
+  def holding_location_label(holding)
+    loc_code = holding['location_code']
+    location = LOCATIONS[loc_code.to_sym] unless loc_code.nil?
+    location.nil? ? holding['location'] : location_full_display(location)
   end
 
   def location_full_display(loc)

--- a/spec/helpers/advanced_helper_spec.rb
+++ b/spec/helpers/advanced_helper_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe AdvancedHelper do
     describe 'architecture library' do
       let(:architecture_hash) { subject['Architecture Library'] }
       it 'includes holding location code facet items' do
-        expect(architecture_hash['codes']).to match_array([ues, uesla, uesrf])
+        expect(architecture_hash['codes']).to match_array([uesla])
       end
       it 'includes recap location code facet items' do
         expect(architecture_hash['recap_codes']).to match_array([rcppw])

--- a/spec/helpers/locations_spec.rb
+++ b/spec/helpers/locations_spec.rb
@@ -37,6 +37,26 @@ RSpec.describe ApplicationHelper do
     end
   end
 
+  describe '#holding_location_label' do
+    let(:fallback) { 'Fallback' }
+    let(:without_code) { { 'location' => fallback } }
+    let(:invalid_code) { { 'location' => fallback, 'location_code' => 'invalid' } }
+    let(:valid_code) { { 'location' => fallback, 'location_code' => 'clas' } }
+
+    it 'returns holding location label when location code lookup successful' do
+      expect(holding_location_label(valid_code)).to eq('Firestone Library - Classics Collection')
+    end
+    it 'returns holding location value when location code lookup fails' do
+      expect(holding_location_label(invalid_code)).to eq(fallback)
+    end
+    it 'returns holding location value when no location code' do
+      expect(holding_location_label(without_code)).to eq(fallback)
+    end
+    it 'returns nil when no location code or holding location value' do
+      expect(holding_location_label({})).to be_nil
+    end
+  end
+
   describe '#open_location?' do
     let(:loc) { { open: true } }
     let(:holding) { { 'call_number' => 'KF 1232 .B2', 'location_code' => 'f' } }


### PR DESCRIPTION
Pull the holding location labels directly from the location service data (rather than the solr doc). Allows records like https://pulsearch.princeton.edu/catalog/9287769 to render updated holding location labels without reindexing.

Second commit closes #617. Fallback label for item enum when nil.