### PR TITLE
more in this series, genre in subject browse

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -182,7 +182,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'linking_notes_display', label: 'Linking notes'
     config.add_show_field 'subseries_of_display', label: 'Subseries of'
     config.add_show_field 'has_subseries_display', label: 'Has subseries'
-    config.add_show_field 'series_display', label: 'Series'
+    config.add_show_field 'series_display', label: 'Series', helper_method: :series_with_links
     config.add_show_field 'restrictions_note_display', label: 'Restrictions note', helper_method: :html_safe
     config.add_show_field 'biographical_historical_note_display', label: 'Biographical/&#8203;Historical note'
     config.add_show_field 'summary_note_display', label: 'Summary note'
@@ -247,7 +247,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'finding_aid_display', label: 'Finding aid'
     config.add_show_field 'cumulative_index_finding_aid_display', label: 'Cumulative index/&#8203;Finding aid'
     config.add_show_field 'subject_display', label: 'Subject(s)', helper_method: :subjectify
-    config.add_show_field 'form_genre_display', label: 'Form/&#8203;Genre'
+    config.add_show_field 'form_genre_display', label: 'Form/&#8203;Genre', helper_method: :subjectify
     config.add_show_field 'related_works_display', label: 'Related work(s)'
     config.add_show_field 'contains_display', label: 'Contains'
     config.add_show_field 'place_name_display', label: 'Place name(s)'
@@ -361,6 +361,25 @@ class CatalogController < ApplicationController
       field.solr_local_parameters = {
         qf: '$left_anchor_qf',
         pf: '$left_anchor_pf'
+      }
+    end
+
+    config.add_search_field('in_series') do |field|
+      field.include_in_advanced_search = false
+      field.include_in_simple_select = false
+      field.label = 'Series starts with'
+      field.solr_local_parameters = {
+        qf: '$in_series_qf',
+        pf: '$in_series_pf'
+      }
+    end
+
+    config.add_search_field('series_title') do |field|
+      field.include_in_simple_select = false
+      field.label = 'Series title'
+      field.solr_local_parameters = {
+        qf: '$series_title_qf',
+        pf: '$series_title_pf'
       }
     end
 

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -129,7 +129,7 @@ module BlacklightAdvancedSearch
 
         # spaces need to be stripped from the query because they don't get properly stripped in Solr
         ###### TO GET STARTS WITH TO WORK #######
-        q1 = @params[:f1] == 'left_anchor' ? @params[:q1].delete(' ') : @params[:q1]
+        q1 = %w(left_anchor in_series).include?(@params[:f1]) ? @params[:q1].delete(' ') : @params[:q1]
         q2 = @params[:f2] == 'left_anchor' ? @params[:q2].delete(' ') : @params[:q2]
         q3 = @params[:f3] == 'left_anchor' ? @params[:q3].delete(' ') : @params[:q3]
         #########################################

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -142,6 +142,25 @@ module ApplicationHelper
     arr.join
   end
 
+  def series_with_links(args)
+    series_titles = args[:document]['more_in_this_series_t'] || []
+    args[:document][args[:field]].each_with_index do |title, i|
+      newtitle = title
+      unless (series_name = series_titles.select { |t| title.start_with?(t) }.first).nil?
+        newtitle << %(  #{more_in_this_series_link(series_name)})
+        series_titles.delete(series_name)
+      end
+      args[:document][args[:field]][i] = newtitle.html_safe
+    end
+  end
+
+  def more_in_this_series_link(title)
+    link_to('[More in this series]', "/catalog?q1=#{CGI.escape title}&f1=in_series&search_field=advanced",
+            class: 'more-in-series', 'data-toggle' => 'tooltip',
+            'data-original-title' => "More in series: #{title}", title: "More in series: #{title}",
+            dir: title.dir.to_s)
+  end
+
   def holding_label(label)
     content_tag(:div, label, class: 'holding-label')
   end

--- a/spec/features/more_in_this_series_spec.rb
+++ b/spec/features/more_in_this_series_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+context 'viewing record with series title' do
+  it 'does not appear for 490 series titles' do
+    visit '/catalog/5525311'
+    expect(page.all('a.more-in-series').length).to eq 0
+  end
+  it 'link to search for 8xx series titles' do
+    visit '/catalog/4687191'
+    expect(page.all('a.more-in-series').length).to eq 2
+    all('a.more-in-series').first.click
+    expect(page.body).to include('/catalog/4687191')
+  end
+end


### PR DESCRIPTION
Series fields link to a series starts with search to replicate "More in this series" functionality in Voyager. Closes #605.

Also adds "Series title" search field to advanced search.