### PR TITLE
Add Course Reserves Functionality

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -82,7 +82,10 @@ Metrics/MethodLength:
     - 'config/initializers/blacklight_initializer.rb'
     - 'lib/orangelight/browse_lists.rb'
     - 'lib/orangelight/voyager_account.rb'
-    - 'lib/orangelight/voyager_patron_client.rb'    
+    - 'lib/orangelight/voyager_patron_client.rb'
+    - 'spec/features/course_reserves_spec.rb'
+    - 'spec/requests/course_reserve_spec.rb'
+    - 'spec/repositories/course_reserve_repository_spec.rb'
 
 Metrics/ModuleLength:
   Exclude:

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -22,7 +22,7 @@ class CatalogController < ApplicationController
     redirect_to lccn_resolve(params[:id])
   end
 
-  self.search_params_logic += [:cjk_mm, :only_home_facets, :only_advanced_facets, :left_anchor_strip, :redirect_browse]
+  self.search_params_logic += [:cjk_mm, :only_home_facets, :only_advanced_facets, :left_anchor_strip, :redirect_browse, :course_reserve_filters]
 
   configure_blacklight do |config|
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params

--- a/app/controllers/course_reserves_controller.rb
+++ b/app/controllers/course_reserves_controller.rb
@@ -1,0 +1,5 @@
+class CourseReservesController < ApplicationController
+  def index
+    @courses = CourseReserveRepository.all
+  end
+end

--- a/app/indexers/reserve_indexer.rb
+++ b/app/indexers/reserve_indexer.rb
@@ -1,0 +1,50 @@
+class ReserveIndexer
+  class << self
+    def index!(courses)
+      new(courses).index!
+    end
+
+    def connection
+      @connection ||= RSolr.connect url: connection_url
+    end
+
+    def connection_url
+      (Blacklight.default_index.connection.uri.to_s.split('/')[0..-2] + [core]).join('/')
+    end
+
+    def core
+      ENV['RESERVES_CORE'] || 'blacklight-core'
+    end
+  end
+  attr_reader :courses
+  def initialize(courses)
+    @courses = courses
+  end
+
+  def index!
+    documents = courses.map { |x| to_solr(x) }.select { |x| !Array(x[:bib_ids_s]).empty? }
+    connection.add(documents, params: { softCommit: true })
+  end
+
+  private
+
+    def to_solr(course)
+      course.bib_ids = bib_ids.for_reserve(course.reserve_list_id)
+      {
+        id: "reserve-#{course.reserve_list_id}",
+        type_s: 'ReserveListing',
+        instructor_s: course.instructor,
+        bib_ids_s: course.bib_ids,
+        course_s: course.course_with_id,
+        department_s: course.department_with_identifier
+      }
+    end
+
+    def bib_ids
+      @bib_ids ||= BibIdsRepository.for(courses.reserve_list_ids)
+    end
+
+    def connection
+      self.class.connection
+    end
+end

--- a/app/repositories/bib_ids_repository.rb
+++ b/app/repositories/bib_ids_repository.rb
@@ -1,0 +1,38 @@
+class BibIdsRepository
+  class << self
+    def for(reserve_ids)
+      Relation.new(
+        JSON.parse(
+          Faraday.get("#{ENV['bibdata_base']}/bib_ids") do |req|
+            req.params = { reserve_id: reserve_ids }
+          end.body
+        )
+      )
+    end
+  end
+
+  class Relation
+    attr_reader :relations
+    def initialize(relations)
+      self.relations = relations
+    end
+
+    def to_a
+      @to_a ||= relations
+    end
+
+    def for_reserve(reserve_id)
+      to_a.select do |reserve|
+        reserve.reserve_list_id == reserve_id
+      end.flat_map(&:bib_id).uniq
+    end
+
+    private
+
+      def relations=(relations)
+        @relations = relations.map { |x| BibIDRelation.new(*x.values) }
+      end
+  end
+
+  BibIDRelation = Struct.new(:reserve_list_id, :bib_id)
+end

--- a/app/repositories/course_reserve_repository.rb
+++ b/app/repositories/course_reserve_repository.rb
@@ -1,0 +1,131 @@
+class CourseReserveRepository
+  class << self
+    def all
+      Relation.new(
+        MultiJson.load(
+          courses_json
+        )
+      )
+    end
+
+    private
+
+      def courses_json
+        courses_data.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '?')
+      end
+
+      def courses_data
+        Faraday.get("#{ENV['bibdata_base']}/courses").body
+      end
+  end
+
+  class Relation
+    attr_reader :courses
+    attr_accessor :query_params
+    delegate :map, to: :to_a
+    def initialize(courses, query_params = {})
+      self.courses = courses
+      self.query_params = query_params
+    end
+
+    def solr_query
+      QueryBuilder.new(query_params).to_s
+    end
+
+    class QueryBuilder
+      attr_reader :instructor, :course, :department
+      def initialize(query_params)
+        self.instructor = query_params.fetch(:instructor, nil)
+        self.course = query_params.fetch(:course_with_id, nil)
+        self.department = query_params.fetch(:department_with_identifier, nil)
+      end
+
+      def instructor=(instructor)
+        return if instructor.blank?
+        @instructor = instructor
+      end
+
+      def course=(course)
+        return if course.blank?
+        @course = course
+      end
+
+      def department=(department)
+        return if department.blank?
+        @department = department
+      end
+
+      def to_s
+        (['type_s:ReserveListing'] + [:instructor, :course, :department].map do |x|
+          to_query(x)
+        end).compact.join(' AND ')
+      end
+
+      private
+
+        def to_query(field)
+          value = send(field)
+          return unless value
+          "#{field}_s:\"#{value}\""
+        end
+    end
+
+    def query(query_params)
+      self.class.new(
+        select do |course|
+          query_params.map do |key, value|
+            value.blank? || course.send(key) == value
+          end.uniq == [true]
+        end.to_a,
+        query_params.merge(self.query_params)
+      )
+    end
+
+    def to_a
+      @to_a ||= courses
+    end
+
+    def select(&block)
+      self.class.new(to_a.select(&block))
+    end
+
+    def instructors
+      @instructors ||= courses.map(&:instructor).uniq
+    end
+
+    def departments
+      @departments ||= courses.map(&:department_with_identifier).uniq
+    end
+
+    def course_names
+      @course_names ||= courses.map(&:course_with_id).uniq
+    end
+
+    def reserve_list_ids
+      @reserve_list_ids ||= courses.map(&:reserve_list_id).uniq
+    end
+
+    private
+
+      def courses=(courses)
+        @courses = courses.map { |x| Course.new(*x.values) }
+      end
+  end
+
+  Course = Struct.new(:reserve_list_id, :department_name, :department_code, :course_name,
+                      :course_number, :section_id, :instructor_first_name,
+                      :instructor_last_name) do
+    attr_accessor :bib_ids
+    def instructor
+      "#{instructor_last_name}, #{instructor_first_name}"
+    end
+
+    def department_with_identifier
+      "#{department_code}: #{department_name}"
+    end
+
+    def course_with_id
+      "#{course_number}: #{course_name}"
+    end
+  end
+end

--- a/app/views/course_reserves/index.html.erb
+++ b/app/views/course_reserves/index.html.erb
@@ -1,0 +1,17 @@
+<%= form_tag catalog_index_path(search_field: "all_fields"), method: :get do %>
+  <div class="form-group">
+    <label for="f_instructor_name_">Instructor:</label>
+    <%= select_tag "f[instructor_name][]", options_from_collection_for_select(@courses.instructors.sort, :to_s, :to_s), class: 'form-control', include_blank: true %>
+  </div>
+  <div class="form-group">
+    <label for="f_course_">Course:</label>
+    <%= select_tag "f[course][]", options_from_collection_for_select(@courses.course_names.sort, :to_s, :to_s), class: 'form-control', include_blank: true %>
+  </div>
+  <div class="form-group">
+    <label for="f_department_">Department:</label>
+    <%= select_tag "f[department][]", options_from_collection_for_select(@courses.departments.sort, :to_s, :to_s), class: 'form-control', include_blank: true %>
+  </div>
+  <%= hidden_field_tag "search_field", "all_fields" %>
+  <%= hidden_field_tag "f[filter][]", "Course Reserves" %>
+  <%= submit_tag 'Search Course Reserves', class: 'btn btn-default' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -107,4 +107,6 @@ Rails.application.routes.draw do
   match '/422' => 'errors#missing', via: [:get, :post, :patch, :delete]
   match '/500' => 'errors#error', via: [:get, :post, :patch, :delete]
   # match '*catch_unknown_routes', to: 'application#catch_404s', via: [:get, :post]
+  #
+  get '/course_reserves', to: 'course_reserves#index'
 end

--- a/spec/features/course_reserves_spec.rb
+++ b/spec/features/course_reserves_spec.rb
@@ -1,0 +1,114 @@
+require 'rails_helper'
+
+describe 'course reserves functionality' do
+  before do
+    stub_all_query
+    stub_bib_ids
+  end
+  it 'displays appropriate course reserves' do
+    visit '/course_reserves'
+    select 'MOL: Molecular Biology', from: 'Department:'
+    select 'Test, Jane', from: 'Instructor:'
+    click_button 'Search Course Reserves'
+    expect(page).to have_selector '.document', count: 2
+  end
+
+  def stub_all_query
+    stub_request(:get, 'https://bibdata.princeton.edu/courses')
+      .to_return(status: 200,
+                 body: all_results.to_json)
+  end
+
+  def stub_bib_ids
+    stub_1
+    stub_2
+    stub_3
+    stub_4
+  end
+
+  def stub_1
+    stub_request(:get, 'https://bibdata.princeton.edu/bib_ids?reserve_id[]=1958&reserve_id[]=2088')
+      .to_return(status: 200,
+                 body: (reserve_1 + reserve_3).to_json)
+  end
+
+  def stub_2
+    stub_request(:get, 'https://bibdata.princeton.edu/bib_ids?reserve_id[]=1958&reserve_id[]=2087&reserve_id[]=2088')
+      .to_return(status: 200,
+                 body: (reserve_1 + reserve_2 + reserve_3).to_json)
+  end
+
+  def stub_3
+    stub_request(:get, 'https://bibdata.princeton.edu/bib_ids?reserve_id[]=2087')
+      .to_return(status: 200,
+                 body: reserve_2.to_json)
+  end
+
+  def stub_4
+    stub_request(:get, 'https://bibdata.princeton.edu/bib_ids?reserve_id[]=2088')
+      .to_return(status: 200,
+                 body: reserve_3.to_json)
+  end
+
+  def reserve_1
+    [
+      {
+        reserve_list_id: 1958,
+        bib_id: 4_705_304
+      }
+    ]
+  end
+
+  def reserve_2
+    [
+      {
+        reserve_list_id: 2087,
+        bib_id: 430_472
+      }
+    ]
+  end
+
+  def reserve_3
+    [
+      {
+        reserve_list_id: 2088,
+        bib_id: 345_682
+      }
+    ]
+  end
+
+  def all_results
+    [
+      {
+        reserve_list_id: 1958,
+        department_name: 'Molecular Biology',
+        department_code: 'MOL',
+        course_name: 'Genetics',
+        course_number: 'MOL 342',
+        section_id: 171,
+        instructor_first_name: 'Jane',
+        instructor_last_name: 'Test'
+      },
+      {
+        reserve_list_id: 2088,
+        department_name: 'Molecular Biology',
+        department_code: 'MOL',
+        course_name: 'Genetics',
+        course_number: 'MOL 343',
+        section_id: 171,
+        instructor_first_name: 'Jane',
+        instructor_last_name: 'Test'
+      },
+      {
+        reserve_list_id: 2087,
+        department_name: 'Molecular Biology',
+        department_code: 'MOL',
+        course_name: 'From DNA to Human Complexity',
+        course_number: 'MOL 101',
+        section_id: 0,
+        instructor_first_name: 'Joe',
+        instructor_last_name: 'Test'
+      }
+    ]
+  end
+end

--- a/spec/repositories/course_reserve_repository_spec.rb
+++ b/spec/repositories/course_reserve_repository_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe CourseReserveRepository do
+  describe '.all' do
+    before do
+      stub_all_query
+    end
+    subject { described_class.all }
+    it 'returns a relation of all available course reserves' do
+      expect(subject.to_a.length).to eq 2
+    end
+    it 'has bulk accessors for instructors' do
+      expect(subject.instructors).to eq [
+        'Schupbach, Gertrud M.',
+        'Bassler, Bonnie L.'
+      ]
+    end
+    it 'has bulk accessors for departments' do
+      expect(subject.departments).to eq [
+        'MOL: Molecular Biology'
+      ]
+    end
+    it 'has bulk accessors for courses' do
+      expect(subject.course_names).to eq [
+        'MOL 342: Genetics',
+        'MOL 101: From DNA to Human Complexity'
+      ]
+    end
+    it 'has bulk accessors for reserve IDs' do
+      expect(subject.reserve_list_ids).to eq [
+        1958,
+        2087
+      ]
+    end
+  end
+
+  def stub_all_query
+    stub_request(:get, 'https://bibdata.princeton.edu/courses')
+      .to_return(status: 200,
+                 body: all_results.to_json)
+  end
+
+  def all_results
+    [
+      {
+        reserve_list_id: 1958,
+        department_name: 'Molecular Biology',
+        department_code: 'MOL',
+        course_name: 'Genetics',
+        course_number: 'MOL 342',
+        section_id: 171,
+        instructor_first_name: 'Gertrud M.',
+        instructor_last_name: 'Schupbach'
+      },
+      {
+        reserve_list_id: 2087,
+        department_name: 'Molecular Biology',
+        department_code: 'MOL',
+        course_name: 'From DNA to Human Complexity',
+        course_number: 'MOL 101',
+        section_id: 0,
+        instructor_first_name: 'Bonnie L.',
+        instructor_last_name: 'Bassler'
+      }
+    ]
+  end
+end

--- a/spec/requests/course_reserve_spec.rb
+++ b/spec/requests/course_reserve_spec.rb
@@ -1,0 +1,144 @@
+require 'spec_helper'
+require 'rails_helper'
+
+describe 'course reserves' do
+  before do
+    conn = Blacklight.default_index.connection
+    conn.delete_by_query('type_s:ReserveListing')
+    conn.commit
+  end
+  describe 'searching with an instructor name given' do
+    it 'returns matching reserve ids' do
+      stub_all_query
+      stub_bib_ids
+      get '/catalog.json?search_field=all_fields&f[instructor_name][]=Test, Jane&f[filter][]=Course Reserves'
+      r = JSON.parse(response.body)
+      expect(r['response']['docs'].length).to eq 2
+      get '/catalog.json?search_field=all_fields&f[instructor_name][]=Test, Joe&f[filter][]=Course Reserves'
+      r = JSON.parse(response.body)
+      expect(r['response']['docs'].length).to eq 1
+    end
+  end
+
+  describe 'searching with a department given' do
+    it 'returns matching reserve ids' do
+      stub_all_query
+      stub_bib_ids
+      get '/catalog.json?search_field=all_fields&f[department][]=MOL: Molecular Biology&f[filter][]=Course Reserves'
+      r = JSON.parse(response.body)
+      expect(r['response']['docs'].length).to eq 3
+    end
+  end
+
+  describe 'searching with both an instructor and course' do
+    it 'returns only those matching both result sets' do
+      stub_all_query
+      stub_bib_ids
+      get '/catalog.json?search_field=all_fields&f[instructor_name][]=Test, Jane&f[filter][]=Course Reserves'
+      get '/catalog.json?search_field=all_fields&f[instructor_name][]=Test, Jane&f[course][]=MOL 343: Genetics&f[filter][]=Course Reserves'
+      # Ensure non-matching documents aren't deleted.
+      expect(Blacklight.default_index.connection.get('select', params: { q: 'type_s:ReserveListing AND instructor_s:"Test, Jane"' })['response']['docs'].length).to eq 2
+      r = JSON.parse(response.body)
+      expect(r['response']['docs'].length).to eq 1
+    end
+  end
+
+  def stub_all_query
+    stub_request(:get, 'https://bibdata.princeton.edu/courses')
+      .to_return(status: 200,
+                 body: all_results.to_json)
+  end
+
+  def stub_bib_ids
+    stub_1
+    stub_2
+    stub_3
+    stub_4
+  end
+
+  def stub_1
+    stub_request(:get, 'https://bibdata.princeton.edu/bib_ids?reserve_id[]=1958&reserve_id[]=2088')
+      .to_return(status: 200,
+                 body: (reserve_1 + reserve_3).to_json)
+  end
+
+  def stub_2
+    stub_request(:get, 'https://bibdata.princeton.edu/bib_ids?reserve_id[]=1958&reserve_id[]=2087&reserve_id[]=2088')
+      .to_return(status: 200,
+                 body: (reserve_1 + reserve_2 + reserve_3).to_json)
+  end
+
+  def stub_3
+    stub_request(:get, 'https://bibdata.princeton.edu/bib_ids?reserve_id[]=2087')
+      .to_return(status: 200,
+                 body: reserve_2.to_json)
+  end
+
+  def stub_4
+    stub_request(:get, 'https://bibdata.princeton.edu/bib_ids?reserve_id[]=2088')
+      .to_return(status: 200,
+                 body: reserve_3.to_json)
+  end
+
+  def reserve_1
+    [
+      {
+        reserve_list_id: 1958,
+        bib_id: 4_705_304
+      }
+    ]
+  end
+
+  def reserve_2
+    [
+      {
+        reserve_list_id: 2087,
+        bib_id: 430_472
+      }
+    ]
+  end
+
+  def reserve_3
+    [
+      {
+        reserve_list_id: 2088,
+        bib_id: 345_682
+      }
+    ]
+  end
+
+  def all_results
+    [
+      {
+        reserve_list_id: 1958,
+        department_name: 'Molecular Biology',
+        department_code: 'MOL',
+        course_name: 'Genetics',
+        course_number: 'MOL 342',
+        section_id: 171,
+        instructor_first_name: 'Jane',
+        instructor_last_name: 'Test'
+      },
+      {
+        reserve_list_id: 2088,
+        department_name: 'Molecular Biology',
+        department_code: 'MOL',
+        course_name: 'Genetics',
+        course_number: 'MOL 343',
+        section_id: 171,
+        instructor_first_name: 'Jane',
+        instructor_last_name: 'Test'
+      },
+      {
+        reserve_list_id: 2087,
+        department_name: 'Molecular Biology',
+        department_code: 'MOL',
+        course_name: 'From DNA to Human Complexity',
+        course_number: 'MOL 101',
+        section_id: 0,
+        instructor_first_name: 'Joe',
+        instructor_last_name: 'Test'
+      }
+    ]
+  end
+end


### PR DESCRIPTION
The workflow looks like this:

* On course reserves page, query bibdata for reserves and display a list
  of dropdowns which set pseudo-facets.
* When the pseudo-facets come through, strip them from the query and
  hot-index reserve records which match the query parameters into a
  secondary core.
* Use the hot-indexed records to do a join query and display only the
  bibs that match those reserve parameters.