### PR TITLE
display series title in results on series search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -22,7 +22,7 @@ class CatalogController < ApplicationController
     redirect_to lccn_resolve(params[:id])
   end
 
-  self.search_params_logic += [:cjk_mm, :only_home_facets, :only_advanced_facets, :left_anchor_strip, :redirect_browse, :course_reserve_filters]
+  self.search_params_logic += [:cjk_mm, :only_home_facets, :only_advanced_facets, :left_anchor_strip, :redirect_browse, :course_reserve_filters, :series_title_results]
 
   configure_blacklight do |config|
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
@@ -127,6 +127,7 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
+    config.add_index_field 'series_display', label: 'Series', helper_method: :series_results
     config.add_index_field 'author_display', label: 'Author/Artist', helper_method: :browse_name
     config.add_index_field 'pub_created_display', label: 'Published/Created'
     config.add_index_field 'format', label: 'Format', helper_method: :format_icon

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -155,6 +155,20 @@ module ApplicationHelper
     end
   end
 
+  def series_results(args)
+    series_display =
+      if params[:f1] == 'in_series'
+        same_series_result(params[:q1], args[:document][args[:field]])
+      else
+        args[:document][args[:field]]
+      end
+    args[:document][args[:field]] = series_display.join(', ')
+  end
+
+  def same_series_result(series, series_display)
+    series_display.select { |t| t.start_with?(series) }
+  end
+
   def more_in_this_series_link(title)
     no_parens = title.gsub(/[()]/, '')
     link_to('[More in this series]', "/catalog?q1=#{CGI.escape no_parens}&f1=in_series&search_field=advanced",

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -19,6 +19,15 @@ module BlacklightHelper
     solr_parameters[:q] = '{!qf=$left_anchor_qf pf=$left_anchor_pf}' + newq.delete(' ')
   end
 
+  def series_title_results(solr_parameters, user_parameters)
+    return unless %w(series_title in_series).include?(user_parameters[:f1]) ||
+                  user_parameters[:f2] == 'series_title' ||
+                  user_parameters[:f3] == 'series_title'
+    solr_parameters[:fl] = 'id,score,author_display,marc_relator_display,format,pub_created_display,'\
+                           'title_display,title_vern_display,isbn_s,oclc_s,lccn_s,holdings_1display,'\
+                           'electronic_access_1display,cataloged_tdt,series_display'
+  end
+
   def only_home_facets(solr_parameters, _user_parameters)
     return if has_search_parameters?
     solr_parameters['facet.field'] = home_facets

--- a/spec/helpers/series_results_spec.rb
+++ b/spec/helpers/series_results_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper do
+  describe '#same_series_result' do
+    let(:series_title) { 'Monthly Serial' }
+    let(:volume_title) { 'Monthly Serial; V. 13' }
+    let(:volume_title_2) { 'Monthly Serial; V. 14' }
+    let(:non_standard_title) { 'The Monthly Serial; V. 13.' }
+    let(:series_display) { [volume_title, volume_title_2, non_standard_title] }
+    let(:same_series) { helper.same_series_result(series_title, series_display) }
+
+    it 'excludes non-standardized title' do
+      expect(same_series).not_to include(non_standard_title)
+    end
+
+    it 'includes all titles that start with the series name' do
+      expect(same_series).to include(volume_title, volume_title_2)
+    end
+  end
+end

--- a/spec/requests/request_spec.rb
+++ b/spec/requests/request_spec.rb
@@ -331,4 +331,24 @@ describe 'blacklight tests' do
       expect(response.body).to include('/browse/names?q=%E7%A5%9D%E7%A9%86%2C+13th+cent')
     end
   end
+
+  describe 'series_display in search results' do
+    it 'is fetched when doing a more in this series search' do
+      get '/catalog.json?q1=Always+learning.&f1=in_series&search_field=advanced'
+      r = JSON.parse(response.body)
+      expect(r['response']['docs'].select { |d| d['id'] == '7917192' }[0]['series_display']).not_to be_nil
+    end
+    it 'is displayed when doing a series title search' do
+      get '/catalog.json?q3=Heft+%3D+Quaderno+%2F+Merkantilmuseum+Bozen+%3B&f3=series_title&search_field=advanced'
+      r = JSON.parse(response.body)
+      series_title = r['response']['docs'].select { |d| d['id'] == '6139836' }[0]['series_display']
+      get '/catalog?q3=Heft+%3D+Quaderno+%2F+Merkantilmuseum+Bozen+%3B&f3=series_title&search_field=advanced'
+      expect(response.body).to include(series_title.join(', '))
+    end
+    it 'is not included in other search contexts' do
+      get '/catalog.json?q=7917192&search_field=all_fields'
+      r = JSON.parse(response.body)
+      expect(r['response']['docs'].select { |d| d['id'] == '7917192' }[0]['series_display']).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
 - Include series field in search results when doing a "More in this series" or series title search. Advances #623.
 - "More in this series" link wasn't working because of a now fixed Solr index config error. Closes #632. 