### PR TITLE
Add solr wrapper rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@
 require File.expand_path('../config/application', __FILE__)
 
 require 'rubocop/rake_task'
+require 'solr_wrapper/rake_task'
 
 Rails.application.load_tasks
 


### PR DESCRIPTION
Adds various solr wrapper rake tasks. Sometimes things get janky and solr wrapper won't start because 'there is already a blacklight-core'. Simply run `rake solr:clean` et voilà.