### PR TITLE
Change position of browsable exact match

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.3.0 # Ruby most recent
+  - 2.3.1
 
 env:
 - TZ=America/New_York
@@ -9,15 +9,12 @@ env:
 jdk:
   - oraclejdk8
 
-cache:
-  directories:
-  - /tmp/solr-6.0.0
-
 before_script:
   - psql -c 'create database orangelight_test;' -U postgres
   - cp config/database.yml.travis config/database.yml
   - RAILS_ENV=test bundle exec rake db:create
   - RAILS_ENV=test bundle exec rake db:migrate
+  - RAILS_ENV=test bundle exec rake db:seed
 
 branches:
   only:

--- a/app/controllers/orangelight/browsables_controller.rb
+++ b/app/controllers/orangelight/browsables_controller.rb
@@ -39,7 +39,7 @@ class Orangelight::BrowsablesController < ApplicationController
         @search_term = search_term
         @exact_match = search_term == search_result.sort
         @match = search_result.id
-        @start = search_result.id - 3
+        @start = search_result.id - 1
         @start = 1 if @start < 1
         @query = params[:q]
         # @prev = @start/@rpp+1

--- a/spec/features/browsables_spec.rb
+++ b/spec/features/browsables_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+describe 'Browsables' do
+  describe 'Browse by Call Number' do
+    it 'displays two browse entries before exact match' do
+      visit 'browse/call_numbers?q=PL856.U673+A61213+2011'
+      expect(page.all('tr')[3][:class]).to eq('alert alert-info')
+    end
+  end
+end

--- a/spec/requests/orangelight/browse_spec.rb
+++ b/spec/requests/orangelight/browse_spec.rb
@@ -1,10 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe 'Orangelight Browsables', type: :request do
-  before(:all) do
-    system 'rake db:seed'
-  end
-
   describe 'Redirect Tests for Browse' do
     it 'browse_name redirects to browse search' do
       get '/catalog?search_field=browse_name&q=velez'
@@ -54,7 +50,7 @@ RSpec.describe 'Orangelight Browsables', type: :request do
       get '/browse/call_numbers.json?q=microfilm'
       r = JSON.parse(response.body)
       q_normalized = StringFunctions.cn_normalize('microfilm')
-      expect(r[3]['sort']..r[4]['sort']).to cover q_normalized
+      expect(r[2]['sort']..r[3]['sort']).to cover q_normalized
     end
 
     it 'escapes call number browse link urls' do


### PR DESCRIPTION
When browsing, the exact match record is now three from the top. Closes #627. 