### PR TITLE
improve barcode login. Closes #663

### DIFF
--- a/app/assets/stylesheets/components/user.scss
+++ b/app/assets/stylesheets/components/user.scss
@@ -4,5 +4,39 @@ address .name, address .street {
 }
 
 .login_actions {
-  margin-top: 5px;
+  padding-left: 15px;
+}
+
+.panel-cas {
+  margin: 0 10px 20px;
+
+  .btn {
+  	margin: auto;
+  	display: block;
+  	width: 200px;
+  }
+
+  p {
+  	margin: 10px 0 0;
+  	text-align: center;
+  }
+}
+
+.panel-barcode {
+  margin: 0 10px 20px;
+
+  .panel-heading p {
+  	margin: 0.4em 0 0;
+  	font-size: 0.9em;
+  	padding-left: 0;
+  }
+
+  label {
+  	text-align: right;
+  }
+
+  p {
+  	margin: 10px 0 0;
+  	padding-left: 15px;
+  }
 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,8 @@
 class User < ActiveRecord::Base
   # include Blacklight::Folders::User
+  validates :username, presence: true
+  validates :uid, length: { is: 14 }, format: { with: /\A([\d]{14})\z/ },
+                  if: "provider == 'barcode'"
 
   # Connects this user object to Blacklights Bookmarks.
   include Blacklight::User

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,32 +1,52 @@
-<div class='col-md-12'>
-<h1 class='page-heading my-account'><%= I18n.t('blacklight.header_links.login') %></h2>
-</div>
-<div class='col-md-6'>
-  <div class='login-button login--cas'>
-    <%= link_to 'Log in with Princeton Net ID', user_cas_omniauth_authorize_path, :class => 'btn btn-primary' %>
+<div class='panel panel-primary panel-cas'>
+  <div class='panel-heading'>
+    <%= content_tag :h2, t('blacklight.login.netid_header'), class: 'panel-title' %>
+  </div>
+  <div class='panel-body'>
+    <%= link_to t('blacklight.login.netid_button'), user_cas_omniauth_authorize_path, :class => 'btn btn-primary' %>
+    <p><%=t('blacklight.login.redirect_text')%></p>
   </div>
 </div>
 
-<div class='col-md-6'>
-  <div class='login-button login--barcode'>
-    <%= link_to 'Log in with Barcode', '#barcode_form', 'data-toggle' => 'collapse',
-        'aria-expanded' => 'false', 'aria-controls' => 'barcode_form', :class => 'btn btn-primary' %>
+<div class='panel panel-default panel-barcode'>
+  <div class='panel-heading'>
+    <%= content_tag :h2, t('blacklight.login.barcode_header'), class: 'panel-title' %>
+    <p><%=t('blacklight.login.barcode_subheader')%></p>
   </div>
-  <%= form_for(:barcode, url: user_barcode_omniauth_callback_path, class: 'simple_form', data: { toggle: 'validator' })  do |f| %>
-    <div id='barcode_form' class="well collapse">
-    <div class='field'>
-      <%= f.label 'Last name' %>
-      <%= text_field_tag 'last_name', '', class: 'form-control', autocomplete: 'off', required: true %>
-    </div>
+  <div class='panel-body'>
+    <%= simple_form_for(@user, url: user_barcode_omniauth_callback_path, class: 'form-horizontal', data: { toggle: 'validator' })  do |f| %>
+        <div class='field form-group col-md-12'>
+          <%= f.label 'Last name', class: 'control-label col-md-2' %>
+          <div class='col-md-5 <%= 'has-error' if flash[:last_name] %>'>
+            <%= text_field_tag 'last_name', '', class: 'form-control', autocomplete: 'off' %>
+            <% if flash[:last_name] %>
+              <span class="glyphicon glyphicon-remove form-control-feedback" aria-hidden="true"></span>
+              <span id="inputError2Status" class="sr-only">(error)</span>
+              <span class="error">Last name can't be blank</span>
+            <% end %>
+          </div>
+        </div>
 
-    <div class='field'>
-      <%= f.label 'Barcode' %>
-      <%= text_field_tag 'barcode', '22101', class: 'form-control', autocomplete: 'off', required: true, maxlength: 14, pattern: '[0-9]{14}' %>
-    </div>
+        <div class='field form-group col-md-12'>
+          <%= f.label 'Barcode', class: 'control-label col-md-2' %>
+          <div class='col-md-5 <%= 'has-error' if flash[:barcode] %>'>
+            <%= text_field_tag 'barcode', '22101', class: 'form-control', autocomplete: 'off' %>
+            <% if flash[:barcode] %>
+              <span class="glyphicon glyphicon-remove form-control-feedback" aria-hidden="true"></span>
+              <span id="inputError2Status" class="sr-only">(error)</span>
+              <span class="error">Barcode must be a 14-digit number</span>
+            <% end %>
+          </div>
+        </div>
 
-    <div class='login_actions'>
-      <%= f.submit 'Log in' %>
+        <div class='login_actions form-group'>
+          <div class='col-md-offset-2 col-md-10'>
+            <%= f.submit 'Log in', class: 'btn btn-default' %>
+          </div>
+        </div>
+    <% end %>
+    <div class='col-md-offset-2 col-md-8'>
+      <p><%=t('blacklight.login.barcode_help').html_safe%></p>
     </div>
   </div>
-  <% end %>
 </div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -41,6 +41,14 @@ en:
       course_reserves: 'Course Reserves'
       search_history: 'Search History'
       account_page: 'Your Account'
+    login:
+      netid_header: 'Faculty, students, and staff'
+      netid_button: 'Log in with netID'
+      redirect_text: 'You will be redirected to the secure Princeton University Central Authentication Service (CAS) login.'
+      barcode_netid: 'Please log in with netID.'
+      barcode_header: 'Other users'
+      barcode_subheader: 'For borrowers without a netID'
+      barcode_help: 'If you cannot login and you have a new ID card, please stop at a circulation desk to have your barcode activated. Contact Firestone Circulation (609-258-3202) or <a href="mailto:fstcirc@princeton.edu">fstcirc@princeton.edu</a> for other problems.'
     email:
       text:
         publish: 'Published/Created: %{value}'

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Users::OmniauthCallbacksController do
   let(:valid_netid_response) { JSON.parse(File.read(fixture_path + '/bibdata_patron_response.json')).with_indifferent_access }
   let(:expired_netid_response) { JSON.parse(File.read(fixture_path + '/bibdata_patron_response_expired.json')).with_indifferent_access }
   let(:guest_response) { JSON.parse(File.read(fixture_path + '/bibdata_patron_response_guest.json')).with_indifferent_access }
-  let(:valid_barcode_user) { FactoryGirl.create(:guest_patron, username: 'Student') }
+  let(:valid_barcode_user) { FactoryGirl.create(:guest_patron) }
   before(:each) { request.env['devise.mapping'] = Devise.mappings[:user] }
 
   describe 'callback response to User object' do
@@ -41,16 +41,22 @@ RSpec.describe Users::OmniauthCallbacksController do
       expect(response).to redirect_to(new_user_session_path)
     end
     it 'valid patron, invalid last name, redirects to login page' do
-      allow(User).to receive(:from_barcode) { FactoryGirl.create(:guest_patron) }
+      allow(User).to receive(:from_barcode) { FactoryGirl.create(:guest_patron, username: 'nope') }
       allow(Bibdata).to receive(:get_patron) { guest_response }
       get :barcode
       expect(response).to redirect_to(new_user_session_path)
     end
-    it 'valid netid barcode redirects to cas login' do
+    it 'valid patron, invalid barcode, redirects to login page' do
+      allow(User).to receive(:from_barcode) { FactoryGirl.build(:guest_patron, uid: 'notabarcode') }
+      allow(Bibdata).to receive(:get_patron) { guest_response }
+      get :barcode
+      expect(response).to redirect_to(new_user_session_path)
+    end
+    it 'valid netid barcode redirects to login page' do
       allow(User).to receive(:from_barcode) { valid_barcode_user }
       allow(Bibdata).to receive(:get_patron) { valid_netid_response }
       get :barcode
-      expect(response).to redirect_to(user_cas_omniauth_authorize_path)
+      expect(response).to redirect_to(new_user_session_path)
     end
     it 'expired netid barcode redirects to account page' do
       allow(User).to receive(:from_barcode) { valid_barcode_user }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -18,6 +18,8 @@ FactoryGirl.define do
     # for patrons without a net ID
     factory :guest_patron do
       provider 'barcode'
+      sequence(:uid) { srand.to_s[2..15] }
+      username 'Student'
     end
   end
 end

--- a/spec/views/account/account_spec.rb
+++ b/spec/views/account/account_spec.rb
@@ -4,7 +4,7 @@ describe 'Your Account', type: :feature do
   context 'User has not signed in' do
     it 'Account information displays as not available' do
       visit('/account')
-      expect(page).to have_content 'Log in with Princeton Net ID'
+      expect(page).to have_content I18n.t('blacklight.login.netid_button')
     end
   end
 


### PR DESCRIPTION
Improves form data validation message and layout to match feedback form.
Valid netID users who attempt logging in with barcode will be redirected back to the login page with a flash message letting them to log in with CAS.