### PR TITLE
no request button for always_requestable, improve multi-item availability, sort by holding location

### DIFF
--- a/app/assets/javascripts/availability.js.coffee.erb
+++ b/app/assets/javascripts/availability.js.coffee.erb
@@ -3,11 +3,11 @@ jQuery ->
 class AvailabilityUpdater
   constructor: ->
     this.request_availability()
-  availability_url: "https://bibdata.princeton.edu/availability"
+  availability_url: "<%= ENV['bibdata_base'] %>/availability"
   id = ''
   on_site_status = 'On-site'
   on_site_unavailable = 'On-site - '
-  circ_desk = 'Check with front desk'
+  circ_desk = 'See front desk'
   available_statuses = ['Not charged', 'On shelf']
   returned_statuses = ['Discharged']
   in_process_statuses = ['In process']
@@ -40,8 +40,11 @@ class AvailabilityUpdater
         location = $("*[data-location='true'][data-holding-id='#{holding_id}']")
         location.text(availability_info['on_reserve'])
       this.get_issues(holding_id) if $(".journal-current-issues").length > 0
-      if availability_info['more_items'] and !availability_info['status'].match(on_site_status)
-        this.apply_record_icon(availability_element, "All items available")
+      if availability_info['more_items']
+        if title_case(availability_info['status']).match(on_site_status)
+          this.apply_record_icon(availability_element, "On-site access")
+        else
+          this.apply_record_icon(availability_element, "All items available")
         this.get_more_items(holding_id)
       else
         this.apply_record_icon(availability_element, availability_info['status'])
@@ -55,7 +58,7 @@ class AvailabilityUpdater
   apply_record: (record_id, holding_records) ->
     for holding_id, availability_info of holding_records
       if availability_info['on_reserve']
-        location = $("*[data-location='true'][data-record-id='#{record_id}'][data-holding-id='#{holding_id}']")
+        location = $("*[data-location='true'][data-record-id='#{record_id}'][data-holding-id='#{holding_id}'] .results_location")
         location.text(availability_info['on_reserve'])
       this.record_needs_more_info(record_id) if availability_info['more_items']
       availability_element = $("*[data-availability-record='true'][data-record-id='#{record_id}'][data-holding-id='#{holding_id}'] .availability-icon")
@@ -68,18 +71,26 @@ class AvailabilityUpdater
     req.success (data) ->
       ul = "<ul class=\"item-status\">"
       for key, item of data
-        if item['status'] != "Not Charged"
-          li = "<li>#{item['enum'] || 'Item'}: #{title_case(item['status'])}</li>"
+        status = title_case(item['status'])
+        label = status_label(status)
+        if status not in available_statuses && status != on_site_status
+          li = "<li>#{item['enum'] || 'Item'}: #{status_display(status, label)}</li>"
           ul = ul + li
           span = $("*[data-holding-id='#{holding_id}'] .availability-icon")
-          txt = "Some items not available"
+          txt = if status.match(on_site_unavailable)
+            circ_desk
+          else if label not in unavailable_labels && span.text() != "Some items not available"
+            "Some items may not be available"
+          else
+            "Some items not available"
           span.text(txt)
           span.attr("title", "Availability: " + txt)
           span.attr("data-original-title", "Availability: " + txt)
-          span.removeClass("label-success")
-          span.addClass("label-default")
+          if !status.match(on_site_unavailable)
+            span.removeClass("label-success")
+            span.addClass("label-default")
       ul = ul + "</ul>"
-      element.append(ul)
+      element.append(ul) if ul != "<ul class=\"item-status\"></ul>"
   get_issues: (holding_id) ->
     url = "#{@availability_url}?mfhd_serial=#{holding_id}"
     req = $.getJSON url
@@ -102,19 +113,7 @@ class AvailabilityUpdater
   apply_record_icon: (availability_element, status) ->
     status = title_case(status)
     availability_element.addClass("label")
-    label = switch
-      when status in available_statuses then 'Available'
-      when status in returned_statuses then 'Returned'
-      when status == 'In transit discharged' then 'In transit'
-      when status in in_process_statuses then 'In process'
-      when status in checked_out_statuses then 'Checked out'
-      when status in missing_statuses then 'Missing'
-      when status.match(on_site_unavailable) then circ_desk
-      when status.match(on_site_status) then 'On-site access'
-      when status.match('Order received') then 'Order received'
-      when status.match('Pending order') then 'Pending order'
-      when status.match('On-order') then 'On-order'
-      else status
+    label = status_label(status)
     availability_element.text(label)
     if label in unavailable_labels
       availability_element.addClass("label-danger")
@@ -133,5 +132,24 @@ class AvailabilityUpdater
     availability_element.attr('data-toggle', 'tooltip')
   record_ids: ->
     $("*[data-availability-record='true'][data-record-id]").map((_, x) -> $(x).attr("data-record-id"))
+  status_label = (status) ->
+    switch
+      when status in available_statuses then 'Available'
+      when status in returned_statuses then 'Returned'
+      when status == 'In transit discharged' then 'In transit'
+      when status in in_process_statuses then 'In process'
+      when status in checked_out_statuses then 'Checked out'
+      when status in missing_statuses then 'Missing'
+      when status.match(on_site_unavailable) then circ_desk
+      when status.match(on_site_status) then 'On-site access'
+      when status.match('Order received') then 'Order received'
+      when status.match('Pending order') then 'Pending order'
+      when status.match('On-order') then 'On-order'
+      else status
+  status_display = (status, label) ->
+    if status.match(label) || status.match(on_site_status)
+      status
+    else
+      "#{label} (#{status})"
   title_case = (str) ->
     str[0].toUpperCase() + str[1..str.length - 1].toLowerCase()

--- a/app/assets/stylesheets/components/availability.scss
+++ b/app/assets/stylesheets/components/availability.scss
@@ -53,7 +53,7 @@
   }
 
   .btn {
-    margin-top: .4em;
+    margin-top: .9em;
   }
 
   .holding-block {
@@ -165,7 +165,6 @@
   }
 
   .location-services {
-    margin-top: 1em;
     display: none;
   }
 }

--- a/config/initializers/locations_initializer.rb
+++ b/config/initializers/locations_initializer.rb
@@ -2,7 +2,7 @@
 
 require 'faraday'
 
-locations = Faraday.get('https://bibdata.princeton.edu/locations/holding_locations.json')
+locations = Faraday.get("#{ENV['bibdata_base']}/locations/holding_locations.json")
 
 unless locations.status != 200
   LOCATIONS = {}.with_indifferent_access

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -38,15 +38,25 @@ describe 'Availability' do
   end
 
   describe 'Physical Holdings in temp locations', js: true do
-    it 'displays temp location on search results' do
+    it 'displays temp location on search results along with call number' do
       visit '/catalog?q=7917192'
       sleep 5.seconds
       expect(page.all('.library-location', text: 'Lewis Library - Course Reserve').length).to be > 0
+      expect(page.all('.library-location', text: 'QA303.2 .W45 2014').length).to be > 0
     end
     it 'displays temp location and copy on record show' do
       visit 'catalog/7917192'
       sleep 5.seconds
       expect(page.all('h3.library-location', text: 'Lewis Library - Course Reserve').length).to be > 0
+    end
+  end
+
+  describe 'On-site multiple items all available', js: true do
+    it 'display availability as on-site and does not display individual items' do
+      visit 'catalog/2238036'
+      sleep 5.seconds
+      expect(page.all('.availability-icon.label.label-warning', text: 'On-site access').length).to eq 1
+      expect(page.all('ul.item-status').length).to eq 0
     end
   end
 end


### PR DESCRIPTION
 - Allow temp location to display along with call number in results page. Closes #668.
 - Add Orangelight labels to Voyager terms in multi-item availability. Closes #429. 
 - Adds "Some items may not be available" label for availability. Closes #430. 
 - Displays embargoed theses as "Unavailable." Closes pulibrary/orangetheses#33.
 - Updated availability and location files to use bibdata env variable.