### PR TITLE
autocomplete form off, recently added advanced, articles+, help page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -17,6 +17,7 @@ class CatalogController < ApplicationController
     config.advanced_search[:query_parser] ||= 'edismax'
     config.advanced_search[:form_solr_parameters] ||= {}
     config.advanced_search[:form_solr_parameters]['facet.field'] ||= %w(format language_facet advanced_location_s)
+    config.advanced_search[:form_solr_parameters]['facet.query'] ||= ''
     config.advanced_search[:form_solr_parameters]['facet.limit'] ||= -1
     config.advanced_search[:form_solr_parameters]['facet.pivot'] ||= ''
 

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -7,7 +7,7 @@
 <div class="other-resources">
     <h3>Other Library Resources</h3>
     <ul>
-        <li><a href="http://princeton.summon.serialssolutions.com/advanced" target="_blank">Articles &amp; Full Text</a></li>
+        <li><a href="http://princeton.summon.serialssolutions.com/advanced" target="_blank">Articles+</a></li>
         <li><a href="http://library.princeton.edu/research/databases" target="_blank">Databases</a></li>
         <li><a href="http://getit.princeton.edu/" target="_blank">E-Journal Titles</a></li>
         <li><a href="http://catalog.princeton.edu/" target="_blank"><%= t('blacklight.voyager') %></a></li>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -12,7 +12,7 @@
         </span>
       <% end %>
         <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
-        <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search_q q form-control", id: "q", autofocus: should_autofocus_on_search_box?, data: { autocomplete_enabled: autocomplete_enabled?, autocomplete_path: blacklight.suggest_index_path }  %>
+        <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search_q q form-control", id: "q", autofocus: should_autofocus_on_search_box?, autocomplete: 'off', data: { autocomplete_enabled: autocomplete_enabled?, autocomplete_path: blacklight.suggest_index_path }  %>
 
       <span class="input-group-btn">
         <button type="submit" class="btn btn-primary search-btn" id="search">

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -88,8 +88,8 @@
       </li>
       <li>
         <dl>
-          <dt class="tip-heading">Note</dt>
-          <dd>Truncation and wildcards are not supported - word-stemming is done automatically.
+          <dt class="tip-heading">Truncation and Wildcards</dt>
+          <dd>English terms are automatically stemmed to include plural and singular forms, as well as common suffix and tense variations. An asterisk may also be used to truncate any term from either the beginning or end of the word.
           </dd>
         </dl>
       </li>


### PR DESCRIPTION
Removes recently added facet from advanced. Closes #709
Updates articles and full text label. Closes #699 
Disables autocomplete on search form. Updates help page to remove inaccuracy about wildcards.