### PR TITLE
Capitalization consistent, show 2 before browse result, exact match clickable

### DIFF
--- a/app/assets/javascripts/data-tables.js.coffee
+++ b/app/assets/javascripts/data-tables.js.coffee
@@ -2,7 +2,7 @@ jQuery ->
   $(".data-table").DataTable(
     {
       language: {
-        search: "Search by Course, Instructor, or Department:"
+        search: "Search by course, instructor, or department:"
       }
     }
   )

--- a/app/assets/javascripts/orangelight.js
+++ b/app/assets/javascripts/orangelight.js
@@ -119,4 +119,7 @@ $(document).ready(function() {
             }
         }
     });
+    $('.clickable-row').on("click",function(){
+      window.location = $(this).data('href');
+    });
 });

--- a/app/assets/stylesheets/components/browse.scss
+++ b/app/assets/stylesheets/components/browse.scss
@@ -31,3 +31,7 @@
 .browse .alert {
   border-radius: 0;
 }
+
+.clickable-row {
+  cursor: pointer;
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -82,7 +82,7 @@ class CatalogController < ApplicationController
                                      collapse: false, home: true, solr_params: { 'facet.mincount' => Blacklight.blacklight_yml['mincount'] || 1 }
 
     # num_segments and segments set to defaults here, included to show customizable features
-    config.add_facet_field 'pub_date_start_sort', label: 'Publication Year', single: true, range: {
+    config.add_facet_field 'pub_date_start_sort', label: 'Publication year', single: true, range: {
       num_segments: 10,
       assumed_boundaries: [1100, Time.now.year + 1],
       segments: true
@@ -93,16 +93,16 @@ class CatalogController < ApplicationController
     config.add_facet_field 'subject_era_facet', label: 'Subject: Era', limit: true
     config.add_facet_field 'lc_1letter_facet', label: 'Classification', limit: 25, show: false, sort: 'index'
     config.add_facet_field 'author_s', label: 'Author', limit: true, show: false
-    config.add_facet_field 'class_year_s', label: 'PU Class Year', limit: true, show: false
+    config.add_facet_field 'class_year_s', label: 'PU class year', limit: true, show: false
     config.add_facet_field 'lc_rest_facet', label: 'Full call number code', limit: 25, show: false, sort: 'index'
-    config.add_facet_field 'recently_added_facet', label: 'Recently Added', home: true, query: {
-      weeks_1: { label: 'Within 1 Week', fq: 'cataloged_tdt:[NOW/DAY-7DAYS NOW/DAY+1DAY]' },
-      weeks_2: { label: 'Within 2 Weeks', fq: 'cataloged_tdt:[NOW/DAY-14DAYS NOW/DAY+1DAY]' },
-      weeks_3: { label: 'Within 3 Weeks', fq: 'cataloged_tdt:[NOW/DAY-21DAYS NOW/DAY+1DAY]' },
-      months_1: { label: 'Within 1 Month', fq: 'cataloged_tdt:[NOW/DAY-1MONTH NOW/DAY+1DAY]' },
-      months_2: { label: 'Within 2 Months', fq: 'cataloged_tdt:[NOW/DAY-2MONTHS NOW/DAY+1DAY]' },
-      months_3: { label: 'Within 3 Months', fq: 'cataloged_tdt:[NOW/DAY-3MONTHS NOW/DAY+1DAY]' },
-      months_6: { label: 'Within 6 Months', fq: 'cataloged_tdt:[NOW/DAY-6MONTHS NOW/DAY+1DAY]' }
+    config.add_facet_field 'recently_added_facet', label: 'Recently added', home: true, query: {
+      weeks_1: { label: 'Within 1 week', fq: 'cataloged_tdt:[NOW/DAY-7DAYS NOW/DAY+1DAY]' },
+      weeks_2: { label: 'Within 2 weeks', fq: 'cataloged_tdt:[NOW/DAY-14DAYS NOW/DAY+1DAY]' },
+      weeks_3: { label: 'Within 3 weeks', fq: 'cataloged_tdt:[NOW/DAY-21DAYS NOW/DAY+1DAY]' },
+      months_1: { label: 'Within 1 month', fq: 'cataloged_tdt:[NOW/DAY-1MONTH NOW/DAY+1DAY]' },
+      months_2: { label: 'Within 2 months', fq: 'cataloged_tdt:[NOW/DAY-2MONTHS NOW/DAY+1DAY]' },
+      months_3: { label: 'Within 3 months', fq: 'cataloged_tdt:[NOW/DAY-3MONTHS NOW/DAY+1DAY]' },
+      months_6: { label: 'Within 6 months', fq: 'cataloged_tdt:[NOW/DAY-6MONTHS NOW/DAY+1DAY]' }
     }
 
     config.add_facet_field 'instrumentation_facet', label: 'Instrumentation', limit: true
@@ -114,7 +114,7 @@ class CatalogController < ApplicationController
 
     config.add_facet_field 'classification_pivot_field', label: 'Classification', pivot: %w(lc_1letter_facet lc_rest_facet)
     config.add_facet_field 'sudoc_facet', label: 'SuDocs', limit: true, sort: 'index'
-    config.add_facet_field 'advanced_location_s', label: 'Holding Location', show: false,
+    config.add_facet_field 'advanced_location_s', label: 'Holding location', show: false,
                                                   helper_method: :render_location_code
 
     # Have BL send all facet field names to Solr, which has been the default
@@ -405,7 +405,7 @@ class CatalogController < ApplicationController
     config.add_sort_field 'pub_date_start_sort asc, title_sort asc', label: 'year (oldest first)'
     config.add_sort_field 'author_sort asc, title_sort asc', label: 'author'
     config.add_sort_field 'title_sort asc, pub_date_start_sort desc', label: 'title'
-    config.add_sort_field 'cataloged_tdt desc, title_sort asc', label: 'catalog date'
+    config.add_sort_field 'cataloged_tdt desc, title_sort asc', label: 'date cataloged'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.

--- a/app/controllers/orangelight/browsables_controller.rb
+++ b/app/controllers/orangelight/browsables_controller.rb
@@ -40,6 +40,7 @@ class Orangelight::BrowsablesController < ApplicationController
         @exact_match = search_term == search_result.sort
         @match = search_result.id
         @start = search_result.id - 1
+        @start -= 1 if @exact_match
         @start = 1 if @start < 1
         @query = params[:q]
         # @prev = @start/@rpp+1
@@ -72,10 +73,7 @@ class Orangelight::BrowsablesController < ApplicationController
     @prev = @start - @rpp
     @prev = 1 if @prev < 1
     @next = @start + @rpp
-    # @prev ||= @start/@rpp
-    # @next = @start/@rpp+2
     @orangelight_browsables = params[:model].where(id: @start..@page_last)
-    # @orangelight_browsables = params[:model].order(:label).offset(@start).limit(@page_last-@start)
 
     if @model == 'names'
       @facet = 'author_s'
@@ -83,7 +81,7 @@ class Orangelight::BrowsablesController < ApplicationController
       @facet = 'subject_facet'
     end
 
-    @list_name = params[:model].name.demodulize.titleize
+    @list_name = params[:model].name.demodulize.tableize.humanize
 
     respond_to do |format|
       format.html # index.html.erb

--- a/app/views/account/_available_items.html.erb
+++ b/app/views/account/_available_items.html.erb
@@ -1,12 +1,12 @@
-<h2 class="section-heading" id="items-available">Items Available for Pickup</h2>
+<h2 class="section-heading" id="items-available">Items available for pickup</h2>
 <% if (!@account.avail_items.nil?) %>
   <table class="table table-striped table-bordered account--available_items">
     <thead>
       <tr>
-        <th><label><input type="checkbox" id="select-all-available"/> <span class="sr-only">Select All</span></label></th>
+        <th><label><input type="checkbox" id="select-all-available"/> <span class="sr-only">Select all</span></label></th>
         <th>Item</th>
-        <th>Request Expiration Date</th>
-        <th>Pickup Location</th>
+        <th>Request expiration date</th>
+        <th>Pickup location</th>
       </tr>
     </thead>
     <tbody>

--- a/app/views/account/_blocks.html.erb
+++ b/app/views/account/_blocks.html.erb
@@ -2,8 +2,8 @@
   <table class="table table-striped table-bordered account--blocks">
     <thead>
       <tr>
-        <td>Block Group</td>
-        <td>Block Count</td>
+        <td>Block group</td>
+        <td>Block count</td>
         <td>Reason</td>
       </tr>
     </thead>

--- a/app/views/account/_charged_items.html.erb
+++ b/app/views/account/_charged_items.html.erb
@@ -3,11 +3,11 @@
     <table class="table table-striped table-bordered account--charged_items">
       <thead>
         <tr>
-          <th><% if (!@account.has_blocks?) %><label><input type="checkbox" id="select-all-renew"/> <span class="sr-only">Select All</span></label><% end %></th>
+          <th><% if (!@account.has_blocks?) %><label><input type="checkbox" id="select-all-renew"/> <span class="sr-only">Select all</span></label><% end %></th>
           <th>Item</th>
-          <th>Call Number</th>
+          <th>Call number</th>
           <th>Status</th>
-          <th>Due Date</th>
+          <th>Due date</th>
           <th>Message</th>
         </tr>
       </thead>
@@ -47,7 +47,7 @@
         <% end %>
       </tbody>
     </table>
-    <%= button_tag "Renew selected items", class: 'btn btn-primary', data: { disable_with: "Submitting Renewal Requests <span class='icon-spinner pulse'></span>" } %>
+    <%= button_tag "Renew selected items", class: 'btn btn-primary', data: { disable_with: "Submitting renewal requests <span class='icon-spinner pulse'></span>" } %>
   <% end %>
 <% else %>
   <p><%= I18n.t('blacklight.account.no_pickup_items') %></p>

--- a/app/views/account/_demerits.html.erb
+++ b/app/views/account/_demerits.html.erb
@@ -1,5 +1,5 @@
 <% if (!@account.demerits.nil?) %>
-  <h2 class="section-heading">Account Demerits</h2>
+  <h2 class="section-heading">Account demerits</h2>
   <table class="table table-striped table-bordered account--demerits">
     <tbody>
     <% @account.demerits.each do |demerit| %>

--- a/app/views/account/_fines_fees.html.erb
+++ b/app/views/account/_fines_fees.html.erb
@@ -1,4 +1,4 @@
-<h2 class="section-heading" id="fines-fees">Fines and Fees</h2>
+<h2 class="section-heading" id="fines-fees">Fines and fees</h2>
 <% if (!@account.fines_fees.nil?) %>
   <table class="table table-striped table-bordered account--fines">
     <caption>Fines may be paid at the Firestone Circulation Desk or email <a href="mailto:fstcirc@princeton.edu">fstcirc@princeton.edu</a> for additional payment options.</caption>
@@ -6,7 +6,7 @@
       <tr>
         <td>Date</td>
         <td>Title</td>
-        <td>Fee / Posting Type</td>
+        <td>Fee/Posting type</td>
         <td>Fee</td>
         <td>Balance</td>
       </tr>
@@ -22,7 +22,7 @@
       </tr>
     <% end %>
     <tr class="account--fines_total">
-      <td colspan="4">Total Due:</td>
+      <td colspan="4">Total due:</td>
       <td><%= display_account_balance(@account.fines_fees.last) %></td>
     </tr>
     </tbody>

--- a/app/views/account/_patron_info.html.erb
+++ b/app/views/account/_patron_info.html.erb
@@ -1,8 +1,8 @@
-<h2 class="section-heading">Account Information</h2>
+<h2 class="section-heading">Account information</h2>
 
 <dl class="account--patron_info">
   <dt>Name</dt>
   <dd><%= @patron["first_name"] %> <%= @patron["last_name"] %></dd>
-  <dt>Current Barcode</dt>
+  <dt>Current barcode</dt>
   <dd><%= @patron["barcode"] %></dd>
 </dl>

--- a/app/views/account/_request_items.html.erb
+++ b/app/views/account/_request_items.html.erb
@@ -3,10 +3,10 @@
     <table class="table table-striped table-bordered account--requests">
       <thead>
         <tr>
-          <th><label><input type="checkbox" id="select-all-requests"/> <span class="sr-only">Select All</span></label></th>
+          <th><label><input type="checkbox" id="select-all-requests"/> <span class="sr-only">Select all</span></label></th>
           <th>Item</th>
-          <th>Request Expiration Date</th>
-          <th>Pickup Location</th>
+          <th>Request expiration date</th>
+          <th>Pickup location</th>
         </tr>
       </thead>
       <tbody>
@@ -32,6 +32,6 @@
   <% end %>
   <%= render 'available_items' %>
   <% if (!@account.request_items.nil?) or (!@account.avail_items.nil?) %>
-    <%= button_tag "Cancel Requests", class: 'btn btn-primary', data: { disable_with: "Submitting Cancellation Request <span class='icon-spinner pulse'></span>" } %>
+    <%= button_tag "Cancel requests", class: 'btn btn-primary', data: { disable_with: "Submitting cancellation request <span class='icon-spinner pulse'></span>" } %>
   <% end %>
 <% end %>

--- a/app/views/account/index.html.erb
+++ b/app/views/account/index.html.erb
@@ -4,18 +4,18 @@
   <p>If you have questions, please email <a href="mailto:fstcirc@princeton.edu">fstcirc@princeton.edu</a> or call (609) 258-3202.</p>
   <% if(@patron) %>
     <ul class="nav nav-pills">
-      <li><a href="#charged-items">Charged Items</a></li>
-      <li><a href="#outstanding-requests">Outstanding Requests</a></li>
-      <li><a href="#items-available">Items Available for Pickup</a></li>
-      <li><a href="#fines-fees">Fines and Fees</a></li>
+      <li><a href="#charged-items">Charged items</a></li>
+      <li><a href="#outstanding-requests">Outstanding requests</a></li>
+      <li><a href="#items-available">Items available for pickup</a></li>
+      <li><a href="#fines-fees">Fines and fees</a></li>
     </ul>
-    <h2 class="section-heading">Patron Blocks</h2>
+    <h2 class="section-heading">Patron blocks</h2>
     <%= render 'blocks' %>
     <%= render 'patron_info' %>
     <%= render 'demerits' %>
-    <h2 class="section-heading" id="charged-items">Charged Items</h2>
+    <h2 class="section-heading" id="charged-items">Charged items</h2>
     <%= render 'charged_items' %>
-    <h2 class="section-heading" id="outstanding-requests">Outstanding Requests</h2>
+    <h2 class="section-heading" id="outstanding-requests">Outstanding requests</h2>
     <%= render 'request_items' %>
     <%= render 'fines_fees' %>
   <% end %>

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,7 +1,7 @@
 <div class="welcome-message">
     <h2>Princeton University Library Catalog</h2>
-    <p>Welcome to the New Catalog. <%= link_to 'Learn more about the project', page_path('about') %>.</p>
-    <p><a class="intro_tour" href="javascript:void(0);" onclick="startIntro();">Take a tour of the new catalog interface!</a></p>
+    <p>Welcome to the <%= t('blacklight.orangelight')%>. <%= link_to 'Learn more about the project', page_path('about') %>.</p>
+    <p><a class="intro_tour" href="javascript:void(0);" onclick="startIntro();">Take a tour of the <%= t('blacklight.orangelight')%> interface!</a></p>
 </div>
 <hr>
 <div class="other-resources">
@@ -9,9 +9,9 @@
     <ul>
         <li><a href="http://princeton.summon.serialssolutions.com/advanced" target="_blank">Articles+</a></li>
         <li><a href="http://library.princeton.edu/research/databases" target="_blank">Databases</a></li>
-        <li><a href="http://getit.princeton.edu/" target="_blank">E-Journal Titles</a></li>
+        <li><a href="http://getit.princeton.edu/" target="_blank">E-journal titles</a></li>
         <li><a href="http://catalog.princeton.edu/" target="_blank"><%= t('blacklight.voyager') %></a></li>
-        <li><a href="http://pudl.princeton.edu/" target="_blank">Digital Collections</a></li>
+        <li><a href="http://pudl.princeton.edu/" target="_blank">Digital collections</a></li>
         <li><a href="http://findingaids.princeton.edu" target="_blank">Finding Aids</a></li>
     </ul>
 </div>

--- a/app/views/catalog/librarian_view.html.erb
+++ b/app/views/catalog/librarian_view.html.erb
@@ -1,6 +1,6 @@
 <div class="pagination-search-widgets">
     <div class="col-md-12">
-    <%= link_to "Back to Item", solr_document_path(@document), :class => "btn btn-default" %>
+    <%= link_to "Back to item", solr_document_path(@document), :class => "btn btn-default" %>
     </div>
 </div>
 

--- a/app/views/course_reserves/index.html.erb
+++ b/app/views/course_reserves/index.html.erb
@@ -1,6 +1,6 @@
 <div class="well well-lg">
   <h1>Course Reserves</h1>
-  Search for your Course, Instructor, or Department below. Please note that every reserve location has its own loan and shelving policies. Consult library staff in the Firestone Reserve Room and at branch library circulation desks for assistance.
+  Search for your course, instructor, or department below. Please note that every reserve location has its own loan and shelving policies. Consult Library staff in the Firestone Reserve Room or at branch library circulation desks for assistance.
 </div>
 <table class="table data-table" data-page-length="25">
   <thead>

--- a/app/views/feedback/_form.html.erb
+++ b/app/views/feedback/_form.html.erb
@@ -1,10 +1,10 @@
 <%= simple_form_for(@feedback_form, url: '/feedback', id: 'feedback_form', remote: true, class: "form-horizontal" ) do |f| %>
   <fieldset class="form-group">
     <label class="control-label col-sm-2" for="name">
-      Your Name
+      Your name
     </label>
     <div class="col-sm-10">
-      <%= f.text_field :name, class: 'form-control', error: 'Please Provide a Name' %>
+      <%= f.text_field :name, class: 'form-control', error: 'Please provide a name' %>
       <% unless @feedback_form.errors[:name].empty? %>
         <span class="glyphicon glyphicon-remove form-control-feedback" aria-hidden="true"></span>
         <span id="inputError2Status" class="sr-only">(error)</span>
@@ -14,10 +14,10 @@
   </fieldset>
   <fieldset class="form-group">
     <label class="control-label col-sm-2" for="email">
-      Your Email
+      Your email
     </label>
     <div class="col-sm-10">
-      <%= f.email_field :email, class: 'form-control', error: 'Please Provide valid email address', value: @user_email %>
+      <%= f.email_field :email, class: 'form-control', error: 'Please provide a valid email address', value: @user_email %>
       <% unless @feedback_form.errors[:email].empty? %>
         <span class="glyphicon glyphicon-remove form-control-feedback" aria-hidden="true"></span>
         <span id="inputError2Status" class="sr-only">(error)</span>
@@ -27,7 +27,7 @@
   </fieldset>
   <fieldset class="form-group">
     <label class="control-label col-sm-2" for="message">
-      Questions or Comments
+      Questions or comments
     </label>
     <div class="col-sm-10">
       <%= f.text_area :message, class: 'form-control', rows: '5', error: 'Please describe the problem you encountered or ask a question.' %>
@@ -38,10 +38,10 @@
   </fieldset>
   <fieldset class="form-group blacklight-feedback-hidden">
     <label class="control-label col-sm-2" for="feedback_desc">
-      If you are a Human do not fill in this value
+      If you are a human do not fill in this value
     </label>
     <div class="col-sm-10">
-      <%= f.text_field :feedback_desc, class: 'form-control', error: 'Please Describe' %>
+      <%= f.text_field :feedback_desc, class: 'form-control', error: 'Please describe' %>
     </div>
   </fieldset>
 

--- a/app/views/feedback/_return.html.erb
+++ b/app/views/feedback/_return.html.erb
@@ -1,7 +1,2 @@
 <p><%= I18n.t('blacklight.feedback.confirmation') %></p>
-<div class="button--start-over">
-  <a class="catalog_startOverLink btn btn-primary icon-refresh" id="startOverLink" href="/">Start Over</a>
-</div>
-
 <%= link_to "#{t('blacklight.feedback.return')}", @feedback_form.current_url, class: 'btn btn-default icon-moveback' %>
-

--- a/app/views/feedback/new.html.erb
+++ b/app/views/feedback/new.html.erb
@@ -1,6 +1,6 @@
 <%= render 'shared/start_over_row' %>
 <div class="col-sm-12">
-  <h1 class="page-heading">Send Us Feedback</h1>
+  <h1 class="page-heading">Feedback</h1>
   <small>*All fields are required</small>
 </div>
 

--- a/app/views/orangelight/browsables/browse.html.erb
+++ b/app/views/orangelight/browsables/browse.html.erb
@@ -1,5 +1,5 @@
 
 
-<h3> Browse by <%=link_to "Name", "/browse/names"%> | <%=link_to "Subject", "/browse/subjects"%> | <%=link_to "Call Number", "/browse/call_numbers"%> </h1>
+<h3> Browse by <%=link_to "name", "/browse/names"%> | <%=link_to "subject", "/browse/subjects"%> | <%=link_to "call number", "/browse/call_numbers"%> </h1>
 
 

--- a/app/views/orangelight/browsables/index.html.erb
+++ b/app/views/orangelight/browsables/index.html.erb
@@ -6,7 +6,7 @@
 </div>
 
 <div class="browse-header">
-  <h1 class="page-heading col-md-6"> Browse by <%="#{@list_name}" %></h1>
+  <h1 class="page-heading col-md-6"> Browse by <%="#{@list_name.downcase}" %></h1>
   <div class="col-md-6">
     <div class="prev_next_links btn-group pull-right">
       <nav aria-label="top pager" class="browse-pager">
@@ -42,7 +42,7 @@
       <% @orangelight_browsables.each_with_index do |orangelight_name, i| %>
 
         <% if orangelight_name.id == @match && @exact_match %>
-          <li class="alert alert-info">
+          <li class="alert alert-info clickable-row" data-href="/catalog/?f[<%=@facet%>][]=<%=CGI.escape orangelight_name.label%>">
             <strong>
         <% else %>
           <li class="row-<%=i.even? ? 'odd' : 'even' %>">
@@ -74,14 +74,14 @@
       <th>Location</th>
       <th>Title</th>
       <th>Creator</th>
-      <th>Publication Info</th>
+      <th>Publication info</th>
     </tr>
   </thead>
 
   <tbody >
     <% @orangelight_browsables.each_with_index do |orangelight_name, i| %>
       <% if orangelight_name.id == @match && @exact_match %>
-        <tr class="alert alert-info">
+        <tr class="alert alert-info clickable-row" data-href="/catalog/<%=orangelight_name.bibid%>">
           <strong>
       <% else %>
         <tr class="row-<%=i.even? ? 'odd' : 'even' %>">

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -1,6 +1,6 @@
 <div class="col-sm-12 start-over-row">
   <div class="button--start-over">
-    <a class="catalog_startOverLink btn btn-primary icon-refresh" id="startOverLink" href="/">Start Over</a>
+    <a class="catalog_startOverLink btn btn-primary icon-refresh" id="startOverLink" href="/"><%=t('blacklight.search.start_over')%></a>
   </div>
 </div>
 <div class="container release-notes col-md-12">

--- a/app/views/pages/help.html.erb
+++ b/app/views/pages/help.html.erb
@@ -1,6 +1,6 @@
 <div class="col-sm-12 start-over-row">
   <div class="button--start-over">
-    <a class="catalog_startOverLink btn btn-primary icon-refresh" id="startOverLink" href="/">Start Over</a>
+    <a class="catalog_startOverLink btn btn-primary icon-refresh" id="startOverLink" href="/"><%=t('blacklight.search.start_over')%></a>
   </div>
 </div>
 <div class="col-md-12">
@@ -9,7 +9,7 @@
     <ul class="list--search-tips">
       <li>
         <dl>
-          <dt class="tip-heading">Keyword Searching</dt>
+          <dt class="tip-heading">Keyword searching</dt>
           <dd>Combine keywords and attributes to find specific items.
             <dl class="example">
               <dt>Examples:</dt>
@@ -25,7 +25,7 @@
       </li>
       <li>
         <dl>
-          <dt class="tip-heading">Phrase Searching</dt>
+          <dt class="tip-heading">Phrase searching</dt>
           <dd>Use quotation marks to search as a phrase.
             <dl class="example">
               <dt>Examples:</dt>
@@ -41,7 +41,7 @@
       </li>
       <li>
         <dl>
-          <dt class="tip-heading">Requiring Words and Phrases</dt>
+          <dt class="tip-heading">Requiring words and phrases</dt>
           <dd>Use "+" before a term to make it required. (Otherwise results matching only some of your terms may be included).
             <dl class="example">
               <dt>Example:</dt>
@@ -56,7 +56,7 @@
       </li>
       <li>
         <dl>
-          <dt class="tip-heading">Excluding Words or Phrases</dt>
+          <dt class="tip-heading">Excluding words or phrases</dt>
           <dd>Use "-" before a word or phrase to exclude it.
             <dl class="example">
               <dt>Example:</dt>
@@ -71,7 +71,7 @@
       </li>
       <li>
         <dl>
-          <dt class="tip-heading">Joining Queries</dt>
+          <dt class="tip-heading">Joining queries</dt>
           <dd>Use "OR", "AND", and "NOT" to create complex boolean logic. You can use parentheses in your complex expressions. Use the
             <%= link_to('Advanced Search', '/advanced') %>
             to join across mulitple fields.
@@ -88,7 +88,7 @@
       </li>
       <li>
         <dl>
-          <dt class="tip-heading">Truncation and Wildcards</dt>
+          <dt class="tip-heading">Truncation and wildcards</dt>
           <dd>English terms are automatically stemmed to include plural and singular forms, as well as common suffix and tense variations. An asterisk may also be used to truncate any term from either the beginning or end of the word.
           </dd>
         </dl>

--- a/app/views/shared/_anouncement.html.erb
+++ b/app/views/shared/_anouncement.html.erb
@@ -1,5 +1,6 @@
 <div class="col-xs-12 col-lg-12 alert alert-warning announcement">
   <div class="container">
+    <p>The Main Catalog and Request System is unavailable through Wednesday 8/17. If you need to request offsite items from ReCAP, the Annex, or another inaccessible location please contact the <a href="/services/privileges/circulation-policies">Firestone Circulation Department</a>.</p>
     <p><strong>This is Beta Software.&ensp;</strong><a title="Feedback on New Catalog" href="/feedback">Please send us a note</a> if you have feedback or think you have found an error.
     </p>
   </div>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -3,10 +3,11 @@ en:
     application_name: 'Catalog | Princeton University Library'
     welcome: 'Welcome!'
     voyager: 'Main Catalog'
+    orangelight: 'New Catalog'
     umlaut: 'Findit @ Princeton'
     account:
-      inaccessible: 'Your library account is not available'
-      no_requests: 'You have no outstanding requests'
+      inaccessible: 'Your library account is not available.'
+      no_requests: 'You have no outstanding requests.'
       no_pickup_items: 'You have no items available for pickup.'
       no_fines_fees: 'No outstanding fines or fees.'
       no_blocks: 'No current blocks on your account.'
@@ -21,21 +22,27 @@ en:
       cancel_success: 'We were able to cancel your request.'
       cancel_fail: 'We were unable to cancel your request.'
       cancel_no_items: 'No requests selected for cancellation.'
+    bookmarks:
+      clear:
+        action_title: 'Clear bookmarks'
     feedback:
       success: 'Your comments have been submitted'
       error: 'Please fill in the required form values.'
-      return: 'Back to the Previous Page.'
+      return: 'Back to the previous page.'
       confirmation: 'Thank you for your comments. They are helpful as we work to improve this new Library service.'
     holdings:
       paging_request: 'Paging request only'
       online: 'Online'
-      print: 'Copies In Library'
+      print: 'Copies in Library'
       stackmap: 'Where to find it'
       browse: 'Browse related items'
       search_missing: 'No holdings available for this record'
-      missing: 'There are no holdings available for this record. Please consult a library staff member at the nearest Circulation Desk.'
+      missing: 'There are no holdings available for this record. Please consult a library staff member at the nearest circulation desk.'
     search:
-      edit_search: 'Edit Search'
+      edit_search: 'Edit search'
+      start_over: 'Start over'
+      librarian_view:
+        title: 'Staff view'
     header_links:
       login: 'Login'
       course_reserves: 'Course Reserves'
@@ -59,3 +66,11 @@ en:
         subject:
           one: 'PU Library Catalog Shared Record'
           other: 'PU Library Catalog Shared Records'
+    saved_searches:
+      clear:
+        action_title: 'Clear saved searches'
+    search_history:
+      clear:
+        action_title: 'Clear search history'
+    tools:
+      librarian_view: 'Staff view'

--- a/spec/features/browsables_spec.rb
+++ b/spec/features/browsables_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 describe 'Browsables' do
   describe 'Browse by Call Number' do
     it 'displays two browse entries before exact match' do
-      visit 'browse/call_numbers?q=PL856.U673+A61213+2011'
-      expect(page.all('tr')[3][:class]).to eq('alert alert-info')
+      visit 'browse/call_numbers?q=PL856.U673+A61213+2011&rpp=10'
+      expect(page.all('tr')[3][:class]).to eq('alert alert-info clickable-row')
     end
   end
 end

--- a/spec/features/header_links_spec.rb
+++ b/spec/features/header_links_spec.rb
@@ -25,7 +25,7 @@ describe 'Tools links' do
       end
     end
 
-    ['SMS', 'Email', 'Librarian View', 'Cite', I18n.t('blacklight.voyager')].each do |link_text|
+    ['SMS', 'Email', I18n.t('blacklight.tools.librarian_view'), 'Cite', I18n.t('blacklight.voyager')].each do |link_text|
       it "#{link_text} appears for record view" do
         within '#main-container' do
           find_link(link_text)

--- a/spec/views/account/account_spec.rb
+++ b/spec/views/account/account_spec.rb
@@ -37,8 +37,8 @@ describe 'Your Account', type: :feature do
     end
 
     it 'Displays item charged out with due dates' do
-      expect(page).to have_content 'Charged Items'
-      expect(page).to have_content 'Due Date'
+      expect(page).to have_content 'Charged items'
+      expect(page).to have_content 'Due date'
     end
 
     it 'Displays an unchecked option to renew item request' do
@@ -55,7 +55,7 @@ describe 'Your Account', type: :feature do
     end
 
     it 'Display active requests' do
-      expect(page).to have_content 'Pickup Location'
+      expect(page).to have_content 'Pickup location'
     end
 
     it 'Displays items for pickup' do
@@ -133,7 +133,7 @@ describe 'Your Account', type: :feature do
     end
 
     it 'displays the patrons block' do
-      expect(page).to have_content('Patron Blocks')
+      expect(page).to have_content('Patron blocks')
     end
 
     it "displays the reason for the patron's block" do
@@ -342,13 +342,13 @@ describe 'Your Account', type: :feature do
           .with(headers: { 'User-Agent' => 'Faraday v0.9.2', 'Content-type' => 'application/xml' })
           .to_return(status: 500, body: 'bad thing happened', headers: {})
         check('cancel-7114238')
-        click_button('Cancel Requests')
+        click_button('Cancel requests')
         wait_for_ajax
         expect(page).to have_content(I18n.t('blacklight.account.cancel_fail'))
       end
 
       it 'but no requests are selected for cancellation' do
-        click_button('Cancel Requests')
+        click_button('Cancel requests')
         wait_for_ajax
         expect(page).to have_content(I18n.t('blacklight.account.cancel_no_items'))
       end
@@ -359,7 +359,7 @@ describe 'Your Account', type: :feature do
           .to_return(status: 200, body: voyager_cancel_response_avail_item, headers: {})
         check('cancel-7114238')
         expect(find('#cancel-7114238')).to be_checked
-        click_button('Cancel Requests')
+        click_button('Cancel requests')
         wait_for_ajax
         expect(page).to have_content(I18n.t('blacklight.account.cancel_success'))
         expect(page).to have_no_selector('#cancel-7114238')
@@ -372,7 +372,7 @@ describe 'Your Account', type: :feature do
           .to_return(status: 200, body: voyager_cancel_response_request_item, headers: {})
         check('cancel-42289')
         expect(find('#cancel-42289')).to be_checked
-        click_button('Cancel Requests')
+        click_button('Cancel requests')
         wait_for_ajax
         expect(page).to have_content(I18n.t('blacklight.account.cancel_success'))
         expect(page).to have_selector('#cancel-7114238')
@@ -384,7 +384,7 @@ describe 'Your Account', type: :feature do
         expect(find('#cancel-7114238')).to be_checked
         check('cancel-42289')
         expect(find('#cancel-42289')).to be_checked
-        click_button('Cancel Requests')
+        click_button('Cancel requests')
         wait_for_ajax
         expect(page).to have_content(I18n.t('blacklight.account.cancel_success'))
         expect(page).to have_no_selector('#cancel-7114238')

--- a/spec/views/feedback/feedback_spec.rb
+++ b/spec/views/feedback/feedback_spec.rb
@@ -8,7 +8,7 @@ describe 'Feedback Form', type: :feature do
     end
 
     it 'Displays an empty form' do
-      expect(page).to have_content 'Send Us Feedback'
+      expect(page).to have_content 'Feedback'
       expect(page).to have_field 'feedback_form_name'
       expect(page).to have_field 'feedback_form_email'
       expect(page).to have_field 'feedback_form_message'


### PR DESCRIPTION
Updates capitalizations per John Logan's suggestions. Closes #665.
Shows 2 results before browse matches.
Makes entire browse match row clickable. Closes #604.