### PR TITLE
Show page layout

### DIFF
--- a/app/assets/javascripts/availability.js.coffee.erb
+++ b/app/assets/javascripts/availability.js.coffee.erb
@@ -73,8 +73,11 @@ class AvailabilityUpdater
       for key, item of data
         status = title_case(item['status'])
         label = status_label(status)
-        if status not in available_statuses && status != on_site_status
-          li = "<li>#{item['enum'] || 'Item'}: #{status_display(status, label)}</li>"
+        if (status not in available_statuses && status != on_site_status) || item['temp_loc']
+          if item['temp_loc']
+            li = "<li>#{item['enum'] || 'Item'}: #{item['label']} - #{status_display(status, label)}</li>"
+          else
+            li = "<li>#{item['enum'] || 'Item'}: #{status_display(status, label)}</li>"
           ul = ul + li
           span = $("*[data-holding-id='#{holding_id}'] .availability-icon")
           txt = if status.match(on_site_unavailable)

--- a/app/assets/stylesheets/components/availability.scss
+++ b/app/assets/stylesheets/components/availability.scss
@@ -157,6 +157,8 @@
 
   li {
     margin-left: 1em;
+    text-indent: -1em;
+    padding-left: 1em;
   }
 
   .holding-label {

--- a/app/assets/stylesheets/components/availability.scss
+++ b/app/assets/stylesheets/components/availability.scss
@@ -98,6 +98,23 @@
   }
 }
 
+.location--linked .panel .panel-body {
+  display: block;
+  padding: 1em 1em 0.5em;
+
+  a {
+    display: inline-block;
+  }
+
+  ul {
+    margin-bottom: 0px;
+  }
+
+  li {
+    margin-bottom: 0.5em;
+  }
+}
+
 .blacklight-holdings .availability-icon.label:hover {
   color: white;
   text-decoration: none;
@@ -108,7 +125,7 @@
 }
 
 .top-panel-heading.panel-heading {
-  padding-left: 0;
+  padding: 0px 15px 10px 0;
 }
 
 .panel-group .panel {

--- a/app/assets/stylesheets/components/facets.scss
+++ b/app/assets/stylesheets/components/facets.scss
@@ -142,3 +142,7 @@ a.more_facets_link {
   font-size: 0.95em;
   line-height: 1.4em;
 }
+
+.facets .facets-heading {
+  margin: 1em 0 0.5em;
+}

--- a/app/assets/stylesheets/components/front-page.scss
+++ b/app/assets/stylesheets/components/front-page.scss
@@ -1,7 +1,11 @@
 @import "variables/breaks";
 
 @media (min-width: $bp-small) {
-    .welcome-message {
-      padding-top: 3em;
-    }
+  .welcome-message {
+    padding-top: 1.15em;
+  }
+}
+
+.welcome-paragraph {
+  margin-bottom: 10px;
 }

--- a/app/assets/stylesheets/components/intro.scss
+++ b/app/assets/stylesheets/components/intro.scss
@@ -11,7 +11,7 @@
   font-size: 11px;
 }
 
-button.btn-account.introjs-showElement {
+.menu--level-1 > ul .btn-account.introjs-showElement {
   color: $blue;
 }
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -260,7 +260,6 @@ class CatalogController < ApplicationController
     config.add_show_field 'publisher_no_display', label: 'Publisher no.'
     config.add_show_field 'lccn_display', label: 'LCCN'
     config.add_show_field 'oclc_s', label: 'OCLC'
-    config.add_show_field 'other_version_s', label: 'Other versions', link_field: 'other_version_s'
     config.add_show_field 'contained_in_s', label: 'Contained in', link_field: 'id'
     config.add_show_field 'related_record_s', label: 'Related record(s)', link_field: 'id'
     config.add_show_field 'coden_display', label: 'Coden designation'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -128,7 +128,6 @@ module ApplicationHelper
                                                 title: 'Availability: Embargoed', 'data-toggle' => 'tooltip')
             end
 
-    info << content_tag(:div, "Copy number: #{holding['copy_number']}".html_safe, class: 'copy-number') unless holding['copy_number'].nil?
     info << content_tag(:ul, "#{holding_label('Shelving title:')} #{listify_array(holding['shelving_title'])}".html_safe, class: 'shelving-title') unless holding['shelving_title'].nil?
     info << content_tag(:ul, "#{holding_label('Location note:')} #{listify_array(holding['location_note'])}".html_safe, class: 'location-note') unless holding['location_note'].nil?
     info << content_tag(:ul, "#{holding_label('Location has:')} #{listify_array(holding['location_has'])}".html_safe, class: 'location-has') unless holding['location_has'].nil?

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,6 +1,6 @@
 <div class="welcome-message">
     <h2>Princeton University Library Catalog</h2>
-    <p>Welcome to the <%= t('blacklight.orangelight')%>. <%= link_to 'Learn more about the project', page_path('about') %>.</p>
+    <p class="welcome-paragraph">Welcome to the <%= t('blacklight.orangelight')%>. <%= link_to 'Learn more about the project', page_path('about') %>.</p>
     <p><a class="intro_tour" href="javascript:void(0);" onclick="startIntro();">Take a tour of the <%= t('blacklight.orangelight')%> interface!</a></p>
 </div>
 <hr>

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -1,5 +1,5 @@
   <%= form_tag search_catalog_url, :method => :get, :class => 'search-query-form form-inline clearfix navbar-form' do %>
-    <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8, :model, :rpp, :start)) %>
+    <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8, :model, :rpp, :start, :introjs)) %>
 
     <div class="input-group">
     <% if search_fields.length > 1 %>

--- a/app/views/catalog/_show_availability_sidebar.html.erb
+++ b/app/views/catalog/_show_availability_sidebar.html.erb
@@ -10,6 +10,24 @@
   </div>
 <% end %>
 
+<% linked_records = linked_records(@document['other_version_s'], @document[:id], 'other_version_s') if @document['other_version_s'] %>
+<% unless linked_records.nil? || linked_records.empty? %>
+  <div class="location--panel location--linked">
+    <div class="panel panel-default">
+      <div class="panel-heading"><%= t('blacklight.holdings.linked') %></div>
+      <div class="panel-body">
+        <% linked_records.each do |records| %>
+          <ul>
+            <% records.each do |link| %>
+              <li><%= link %></li>
+            <% end %>
+          </ul>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>
+
 <% unless physical.nil? %>
   <div class="location--panel location--holding">
     <div class="panel panel-default">

--- a/app/views/catalog/_show_default.html.erb
+++ b/app/views/catalog/_show_default.html.erb
@@ -47,7 +47,3 @@
     <% end %>
   <% end %>
 </dl>
-
-      <%# Example of using extra passed parameters from catalog controller -%>
-      <%# elsif solr_fname == 'language_code_s' %>
-<!--       <dd><%# document_show_fields(document)["language_code_s"].super_duper_info %></dd>  -->

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -32,6 +32,7 @@ en:
       confirmation: 'Thank you for your comments. They are helpful as we work to improve this new Library service.'
     holdings:
       paging_request: 'Paging request only'
+      linked: 'Other versions'
       online: 'Online'
       print: 'Copies in Library'
       stackmap: 'Where to find it'


### PR DESCRIPTION
 - Moves other version links to the side availability panel on show page. Closes #667 
 - Removes copy number from display. Closes #712 
 - Shows temp location for items on reserve when the mfhd has multiple items. Closes #726 
 - Removes extra whitespace between search bar and welcome message on homepage.
 - Makes CSS selector for "Your Account" link more specific so link displays in blue during intro tour.
 - Removes introjs url parameter from search form submissions so intro tour doesn't reactivate.