### PR TITLE
Including '|' in the app name breaks the refworks export url in blacklight-marc.

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,6 +1,6 @@
 en:
   blacklight:
-    application_name: 'Catalog | Princeton University Library'
+    application_name: 'Princeton University Library Catalog'
     welcome: 'Welcome!'
     voyager: 'Main Catalog'
     orangelight: 'New Catalog'


### PR DESCRIPTION
See https://github.com/projectblacklight/blacklight-marc/blob/2ac8ff4204edd5f7c019c0348064888313511f30/app/helpers/blacklight_marc_helper.rb#L5