### PR TITLE
Exclude alternative formats for non-marc records.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -340,8 +340,8 @@ module ApplicationHelper
     end
   end
 
-  def formats_to_exclude
-    holding_id = JSON.parse(@document[:holdings_1display]).first[0]
+  def formats_to_exclude(document)
+    holding_id = JSON.parse(document[:holdings_1display]).first[0]
     if non_voyager?(holding_id)
       [:marc, :marcxml, :refworks_marc_txt, :endnote, :openurl_ctx_kev]
     else

--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -1,5 +1,5 @@
 <% @page_title = t('blacklight.search.show.title', :document_title => document_show_html_title, :application_name => application_name).html_safe %>
-<% content_for(:head) { render_link_rel_alternates(@document, { exclude: formats_to_exclude }) }%>
+<% content_for(:head) { render_link_rel_alternates(@document, { exclude: formats_to_exclude(@document) }) }%>
 
 <div id="document" class="document <%= render_document_class %>" itemscope  itemtype="<%= @document.itemtype %>">
   <div id="doc_<%= @document.id.to_s.parameterize %>">

--- a/spec/helpers/link_tag_formats_spec.rb
+++ b/spec/helpers/link_tag_formats_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper do
+  context 'A voyager record' do
+    describe '#formats_to_exclude' do
+      let(:document) do
+        {
+          'holdings_1display' => %({"9092827":{"location":"Firestone Library","library":"Firestone Library","location_code":"f","call_number":"PS3566.I428 A6 2015","call_number_browse":"PS3566.I428 A6 2015"}})
+        }.with_indifferent_access
+      end
+      it 'does not exclude marc derived export formats' do
+        expect(formats_to_exclude(document).length).to eq(0)
+      end
+    end
+  end
+
+  context 'A non-voyager record' do
+    describe '#formats_to_exclude' do
+      let(:document) do
+        {
+          'holdings_1display' => %({"thesis":{"location":"Online","library":"Online","location_code":"elf1","call_number":"AC102","call_number_browse":"AC102","dspace":true}})
+        }.with_indifferent_access
+      end
+      let(:exclude_formats) do
+        [:marc, :marcxml, :refworks_marc_txt, :endnote, :openurl_ctx_kev]
+      end
+      it 'excludes marc derived export formats' do
+        expect(formats_to_exclude(document).length).to eq(5)
+        expect(formats_to_exclude(document)).to eq(exclude_formats)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds spec to make sure non voyager records don't provide alternative format links to marc based formats. 