### PR TITLE
makes staff_view url and html id tag consistent with label

### DIFF
--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -14,8 +14,8 @@
             <dt class="other-views">Other views:</dt>
             <dd class="classic-views">
               <ul>
-                <li><%= link_to t('blacklight.tools.librarian_view'), librarian_view_solr_document_path(@document), {:id => 'librarianLink'} %></li>
-                <li><%= link_to "#{t('blacklight.voyager')} <span class=\"glyphicon glyphicon-share-alt\"></span>".html_safe, voyager_url(@document.id), {:id => 'librarianLink', :target => "_blank"} %></li>
+                <li><%= link_to t('blacklight.tools.librarian_view'), staff_view_solr_document_path(@document), {:id => 'staffLink'} %></li>
+                <li><%= link_to "#{t('blacklight.voyager')} <span class=\"glyphicon glyphicon-share-alt\"></span>".html_safe, voyager_url(@document.id), {:id => 'voyagerLink', :target => "_blank"} %></li>
               </ul>
             </dd>
           </dl>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   end
   mount Requests::Engine, at: '/requests'
 
+  get 'catalog/:id/staff_view', to: 'catalog#librarian_view', as: 'staff_view_solr_document'
   Blacklight::Marc.add_routes(self)
   root to: 'catalog#index'
 

--- a/spec/requests/request_spec.rb
+++ b/spec/requests/request_spec.rb
@@ -191,13 +191,13 @@ describe 'blacklight tests' do
     end
   end
 
-  describe 'librarian view' do
+  describe 'staff view' do
     it 'marcxml matches bibdata marcxml for record' do
       id = '6574987'
       get "/catalog/#{id}.marcxml"
-      librarian_view = response.body
+      staff_view = response.body
       bibdata = Faraday.get("https://bibdata.princeton.edu/bibliographic/#{id}").body
-      expect(librarian_view).to eq bibdata
+      expect(staff_view).to eq bibdata
     end
   end
 

--- a/spec/routing/catalog_routing_spec.rb
+++ b/spec/routing/catalog_routing_spec.rb
@@ -14,5 +14,8 @@ RSpec.describe CatalogController, type: :routing do
     it 'catalog/isbn/99 routes to #isbn' do
       expect(get: '/catalog/isbn/99').to route_to('catalog#isbn', id: '99')
     end
+    it 'catalog/99/staff_view routes to #librarian_view' do
+      expect(get: '/catalog/99/staff_view').to route_to('catalog#librarian_view', id: '99')
+    end
   end
 end


### PR DESCRIPTION
Closes #775.
@axamei - can you review the changes I made to the ID attributes on the voyager and staff links? They were both `librarianLink`.