### PR TITLE
prevent parse nil error when document has no holdings

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -361,7 +361,7 @@ module ApplicationHelper
   end
 
   def formats_to_exclude(document)
-    holding_id = JSON.parse(document[:holdings_1display]).first[0]
+    holding_id = JSON.parse(document[:holdings_1display]).first[0] if document[:holdings_1display]
     if non_voyager?(holding_id)
       [:marc, :marcxml, :refworks_marc_txt, :endnote, :openurl_ctx_kev]
     else

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -68,13 +68,4 @@ describe 'Availability' do
       expect(page.all('ul.item-status').length).to eq 0
     end
   end
-
-  describe 'On-site in process item', js: true do
-    it 'displays availability as In-process' do
-      visit 'catalog/9590420'
-      sleep 5.seconds
-      expect(page.all('.availability-icon.label.label-success', text: 'In process').length).to eq 1
-      expect(page.all('ul.item-status').length).to eq 0
-    end
-  end
 end


### PR DESCRIPTION
Related to reported problematic record: https://pulsearch.princeton.edu/catalog/2400420