### PR TITLE
change call number browse fields from string to text

### DIFF
--- a/db/migrate/20161222150444_change_call_number_to_text.rb
+++ b/db/migrate/20161222150444_change_call_number_to_text.rb
@@ -1,0 +1,15 @@
+class ChangeCallNumberToText < ActiveRecord::Migration
+  def up
+    change_column :orangelight_call_numbers, :label, :text
+    change_column :orangelight_call_numbers, :sort, :text
+    change_column :orangelight_call_numbers, :scheme, :text
+    change_column :orangelight_call_numbers, :bibid, :text
+  end
+
+  def down
+    change_column :orangelight_call_numbers, :label, :string
+    change_column :orangelight_call_numbers, :sort, :string
+    change_column :orangelight_call_numbers, :scheme, :string
+    change_column :orangelight_call_numbers, :bibid, :string
+  end
+end


### PR DESCRIPTION
Visual call numbers aren't unique so the bibid which was a string field had a value like this: "?f[call_number_browse_s][]=E+South+08%2FGC014%2FBox+01%2FNormalE+South+08%2FGC014%2FBox+02%2FNormal+..."
which was over the string char number limit