### PR TITLE
fixes action_view logger nil error

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -234,4 +234,25 @@ module BlacklightHelper
     def core_url
       Blacklight.default_index.connection.uri.to_s.gsub(%r{^.*\/solr}, '/solr')
     end
+
+    # Temporary Logging Fix in order to suppress action_view messages
+    def find_document_show_template_with_view(view_type, base_name, format, locals)
+      document_partial_path_templates.each do |str|
+        partial = str % { action_name: base_name, format: format, index_view_type: view_type }
+        Blacklight.logger.debug "Looking for document partial #{partial}"
+        template = lookup_context.find_all(partial, lookup_context.prefixes + [''], true, locals.keys + [:document], {}).first
+        return template if template
+      end
+      nil
+    end
+
+    def find_document_index_template_with_view(view, locals)
+      document_index_path_templates.each do |str|
+        partial = str % { index_view_type: view }
+        Blacklight.logger.debug "Looking for document index partial #{partial}"
+        template = lookup_context.find_all(partial, lookup_context.prefixes + [''], true, locals.keys + [:documents], {}).first
+        return template if template
+      end
+      nil
+    end
 end


### PR DESCRIPTION
Specifies logger in debug statements to prevent errors due to https://github.com/pulibrary/orangelight/commit/1e937344e629592d7122dc2933cb70d4bace1d94