### PR TITLE
sort holdings on show page by bibdata library order

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -71,12 +71,12 @@ module ApplicationHelper
     is_journal = document['format'].include?('Journal')
     pub_date = document.key?('pub_date_start_sort') ? document['pub_date_start_sort'] : 0
     online_holdings << links
-    holdings.each do |id, holding|
-      if holding['location_code'].start_with?('elf')
-        online_holdings << process_online_holding(holding, doc_id, id, links.empty?)
-      elsif !holding['location_code'].blank?
-        physical_holdings << process_physical_holding(holding, doc_id, id, is_journal, pub_date)
-      end
+    elf_holdings, other_holdings = holdings.partition { |_id, h| h['location_code'].start_with?('elf') }
+    elf_holdings.each do |id, holding|
+      online_holdings << process_online_holding(holding, doc_id, id, links.empty?)
+    end
+    other_holdings.sort_by { |_id, h| LOCATIONS.keys.index(h['location_code']) }.each do |id, holding|
+      physical_holdings << process_physical_holding(holding, doc_id, id, is_journal, pub_date)
     end
     online = content_tag(:div, online_holdings.html_safe) unless online_holdings.empty?
     physical = content_tag(:div, physical_holdings.html_safe) unless physical_holdings.empty?

--- a/config/initializers/locations_initializer.rb
+++ b/config/initializers/locations_initializer.rb
@@ -9,4 +9,8 @@ unless locations.status != 200
   JSON.parse(locations.body).each do |location|
     LOCATIONS[location['code']] = location.with_indifferent_access
   end
+  LOCATIONS = LOCATIONS.sort_by do |_i, l|
+    [l['library']['order'], l['library']['label'], l['label']]
+  end
+  LOCATIONS = LOCATIONS.to_h.with_indifferent_access
 end

--- a/spec/features/holding_locations_sort_order_spec.rb
+++ b/spec/features/holding_locations_sort_order_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+context 'viewing record with multiple holdings' do
+  it 'shows east asian holding before recap holding' do
+    visit '/catalog/3861539'
+    locations = all('.location-text').map(&:text)
+    expect(locations).to eq ['East Asian Library - Reference', 'ReCAP']
+  end
+end


### PR DESCRIPTION
Closes #327. Sort locations by library order, then library label, holding location label. Firestone, then branches, then off-site.