### PR TITLE
removes reserves course data encoding call

### DIFF
--- a/app/repositories/course_reserve_repository.rb
+++ b/app/repositories/course_reserve_repository.rb
@@ -11,10 +11,6 @@ class CourseReserveRepository
     private
 
       def courses_json
-        courses_data.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '?')
-      end
-
-      def courses_data
         Faraday.get("#{ENV['bibdata_base']}/courses").body
       end
   end


### PR DESCRIPTION
Would you mind taking a look at this @tpendragon? Removing the encoder function call allows the instructor's name to render properly: https://pulsearch.princeton.edu/catalog?f%5Bcourse%5D%5B%5D=MAT+104%3A+Calculus+II&f%5Binstructor%5D%5B%5D=G%3F%3Fmez-Serrano+et+al.%2C+&search_field=all_fields