### PR TITLE
Call number accessions

### DIFF
--- a/lib/orangelight/string_functions.rb
+++ b/lib/orangelight/string_functions.rb
@@ -1,7 +1,7 @@
 module StringFunctions
   class << self
     def cn_normalize(str)
-      Lcsort.normalize(str) || str.upcase
+      Lcsort.normalize(str.gsub(/x([A-Z])/, '\1')) || str.upcase
     end
 
     def oclc_normalize(oclc, _opts = { prefix: false })

--- a/lib/orangelight/string_functions.rb
+++ b/lib/orangelight/string_functions.rb
@@ -1,11 +1,23 @@
 module StringFunctions
   class << self
     def cn_normalize(str)
-      Lcsort.normalize(str.gsub(/x([A-Z])/, '\1')) || str.upcase
+      if /^CD \d+$/ =~ str # the normalizer thinks "CD 104" is valid LC
+        accession_number(str)
+      else
+        Lcsort.normalize(str.gsub(/x([A-Z])/, '\1')) || accession_number(str)
+      end
     end
 
     def oclc_normalize(oclc, _opts = { prefix: false })
       oclc.gsub(/\D/, '').to_i.to_s
+    end
+
+    private
+
+    def accession_number(str)
+      norm = str.upcase
+      norm = norm.gsub('CD-', 'CD') # cds should file together regardless of dash
+      norm.gsub(/(\d+)$/) { |c| format('%07d', c) } # normalize number to 7-digits
     end
   end
 end

--- a/spec/lib/orangelight/string_functions_spec.rb
+++ b/spec/lib/orangelight/string_functions_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe StringFunctions do
+  describe '#cn_normalize' do
+    describe 'LC call numbers' do
+      it 'LC call numbers with a lowercase x normalize the same as cns without it' do
+        expect(StringFunctions.cn_normalize('BP190.5.W35 xF3')).to eq StringFunctions.cn_normalize('BP190.5.W35 F3')
+      end
+      it 'lowercase x remains when it does not immediately precede a cutter letter' do
+        expect(StringFunctions.cn_normalize('BP190.5.W35 F3x')).to include('X')
+      end
+    end
+
+    describe 'accession numbers' do
+      it 'alphabetic characters are made upper case' do
+        microfiche = StringFunctions.cn_normalize('MICROFICHE')
+        microfilm = StringFunctions.cn_normalize('microfilm')
+        microfilm_1 = StringFunctions.cn_normalize('MICROFILM 1')
+        expect(microfiche..microfilm_1).to cover microfilm
+      end
+    end
+  end
+end

--- a/spec/lib/orangelight/string_functions_spec.rb
+++ b/spec/lib/orangelight/string_functions_spec.rb
@@ -4,19 +4,28 @@ RSpec.describe StringFunctions do
   describe '#cn_normalize' do
     describe 'LC call numbers' do
       it 'LC call numbers with a lowercase x normalize the same as cns without it' do
-        expect(StringFunctions.cn_normalize('BP190.5.W35 xF3')).to eq StringFunctions.cn_normalize('BP190.5.W35 F3')
+        expect(described_class.cn_normalize('BP190.5.W35 xF3')).to eq described_class.cn_normalize('BP190.5.W35 F3')
       end
       it 'lowercase x remains when it does not immediately precede a cutter letter' do
-        expect(StringFunctions.cn_normalize('BP190.5.W35 F3x')).to include('X')
+        expect(described_class.cn_normalize('BP190.5.W35 F3x')).to include('X')
+      end
+      it 'valid LC call numbers starting with LC are normalized as such' do
+        expect(described_class.cn_normalize('CD102 .D575 2008')).to eq Lcsort.normalize('CD102 .D575 2008')
       end
     end
 
     describe 'accession numbers' do
       it 'alphabetic characters are made upper case' do
-        microfiche = StringFunctions.cn_normalize('MICROFICHE')
-        microfilm = StringFunctions.cn_normalize('microfilm')
-        microfilm_1 = StringFunctions.cn_normalize('MICROFILM 1')
+        microfiche = described_class.cn_normalize('MICROFICHE')
+        microfilm = described_class.cn_normalize('microfilm')
+        microfilm_1 = described_class.cn_normalize('MICROFILM 1')
         expect(microfiche..microfilm_1).to cover microfilm
+      end
+      it 'CD and CD- file the same' do
+        expect(described_class.cn_normalize('CD 4032')).to eq described_class.cn_normalize('CD- 4032')
+      end
+      it 'the number is sorted as an integer' do
+        expect(described_class.cn_normalize('18th-25')).to be < described_class.cn_normalize('18th-24000')
       end
     end
   end

--- a/spec/requests/orangelight/browse_spec.rb
+++ b/spec/requests/orangelight/browse_spec.rb
@@ -46,13 +46,6 @@ RSpec.describe 'Orangelight Browsables', type: :request do
   end
 
   describe 'Browse Call Number Search' do
-    it 'includes non LC call numbers in search' do
-      get '/browse/call_numbers.json?q=microfilm'
-      r = JSON.parse(response.body)
-      q_normalized = StringFunctions.cn_normalize('microfilm')
-      expect(r[2]['sort']..r[3]['sort']).to cover q_normalized
-    end
-
     it 'escapes call number browse link urls' do
       get '/browse/call_numbers?q=Islamic+Manuscripts%2C+New+Series+no.+1948'
       expect(response.body).to include('/catalog/?f[call_number_browse_s][]=Islamic+Manuscripts%2C+New+Series+no.+1948')


### PR DESCRIPTION
Improves call number normalizer to do the following:
 - Strip out a lower case 'x' in an LC call number when it appears directly before a cutter letter. Closes #248.
 - Treat call numbers with the format "CD ###" as an accession number and not an LC call number.
 - Accession numbers with the format "CD" and "CD-" file the same.
 - The number in the accession number is formatted to sort correctly with other numbers up through 7 digits. Closes #670.