### PR TITLE
Restrict external full-text calls to books and journals.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,7 @@ module ApplicationHelper
   # First argument of link_to is optional display text. If null, the second argument
   # (URL) is the display text for the link.
   # Proxy Base is added to force remote access when appropriate
-  def urlify(electronic_access)
+  def urlify(electronic_access, document)
     urls = ''
     links = JSON.parse(electronic_access)
     links.each do |url, text|
@@ -17,7 +17,7 @@ module ApplicationHelper
       end
       urls << content_tag(:div, link.html_safe, class: 'electronic-access')
     end
-    unless links.keys.any? { |link| /getit\.princeton\.edu/.match(link) } || links.empty?
+    unless links.keys.any? { |link| /getit\.princeton\.edu/.match(link) } || links.empty? || !document.umlaut_fulltext_eligible?
       urls << content_tag(:div, '', :id => 'full_text', :class => ['availability--panel', 'availability_full-text', 'availability_full-text-alternative'], 'data-umlaut-services' => true)
     end
     if links.count > 1
@@ -83,7 +83,7 @@ module ApplicationHelper
   def holding_request_block(document)
     doc_id = document['id']
     holdings = JSON.parse(document['holdings_1display'] || '{}')
-    links = urlify(document['electronic_access_1display'] || '{}')
+    links = urlify(document['electronic_access_1display'] || '{}', document)
     physical_holdings = ''
     online_holdings = ''
     is_journal = document['format'].include?('Journal')

--- a/app/models/concerns/blacklight/solr/document/marc.rb
+++ b/app/models/concerns/blacklight/solr/document/marc.rb
@@ -33,6 +33,18 @@ module Blacklight
           end
         end
 
+        def umlaut_fulltext_eligible?
+          if (umlaut_full_text_formats & self['format'].map!(&:downcase)).empty?
+            false
+          else
+            true
+          end
+        end
+
+        def umlaut_full_text_formats
+          %w(book journal)
+        end
+
         # does we have any standard numbers that can be used by other services
         def standard_numbers?
           std_numbers.any? { |v| key? v }

--- a/app/views/catalog/_show_availability_sidebar.html.erb
+++ b/app/views/catalog/_show_availability_sidebar.html.erb
@@ -10,7 +10,7 @@
   </div>
 <% end %>
 
-<% if online.nil? && document.standard_numbers? %>
+<% if online.nil? && document.standard_numbers? && document.umlaut_fulltext_eligible? %>
   <%= umlaut_services_fulltext(document) %>
 <% end %>
 

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -22,7 +22,7 @@ describe 'Availability' do
   describe 'Electronic Holdings are displayed on a record page', js: true do
     it 'within the online section', unless: in_travis? do
       visit '/catalog/857469'
-      expect(page).to have_selector '.location--online .panel-body a', count: 1
+      expect(page).to have_selector '.location--online .panel-body a', minimum: 1
     end
 
     it 'display umlaut links for marcit record within the online section', unless: in_travis? do

--- a/spec/helpers/holding_block_spec.rb
+++ b/spec/helpers/holding_block_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe ApplicationHelper do
     let(:show_result_journal) { helper.holding_request_block(document_journal) }
     let(:show_result_thesis) { helper.holding_request_block(document_thesis) }
     let(:show_result_thesis_no_request) { helper.holding_request_block(document_thesis_no_request_access) }
-    let(:show_result_marcit) { helper.urlify(electronic_access_marcit) }
+    let(:show_result_marcit) { helper.urlify(electronic_access_marcit, document) }
     let(:show_result_umlaut_w_full_text) { helper.umlaut_services }
     let(:holding_block_json) do
       {

--- a/spec/views/catalog/_show_availability_sidebar.html.erb_spec.rb
+++ b/spec/views/catalog/_show_availability_sidebar.html.erb_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe 'catalog/_show_availability_sidebar.html.erb' do
     end
   end
 
-  context '#umlaut_services for a record without any standard numbers' do
+  context '#umlaut_services for a record without any standard numbers or eligible full-text formats' do
     let(:document) { SolrDocument.new(properties) }
     let(:properties) do
       {
@@ -83,6 +83,79 @@ RSpec.describe 'catalog/_show_availability_sidebar.html.erb' do
       render partial: 'catalog/show_availability_sidebar', locals: { document: document }
       expect(rendered).not_to have_selector '#highlighted_link'
       expect(rendered).not_to have_selector '#excerpts'
+    end
+
+    it 'does not have full-text services' do
+      expect(rendered).not_to have_selector '#full_text'
+    end
+  end
+
+  context 'has standard numbers and an ineligible full-text formats' do
+    let(:document) { SolrDocument.new(properties) }
+    let(:properties) do
+      {
+        'id' => '5',
+        'format' => ['Audio'],
+        'oclc_s' => %w(19590730 301985443),
+        'location_code_s' => ['sa'],
+        'holdings_1display' => "{\"13395\":{\"location\":\"Forrestal Annex - Temporary\",\"library\":\"Forrestal Annex\",\"location_code\":\"anxafst\",\"copy_number\":\"1\",\"call_number\":\"PS3563.A3294 xT3\",\"call_number_browse\":\"PS3563.A3294 xT3\"}}"
+      }
+    end
+    it 'has highlighted links and excerpt umlaut blocks' do
+      render partial: 'catalog/show_availability_sidebar', locals: { document: document }
+      expect(rendered).to have_selector '#highlighted_link'
+      expect(rendered).to have_selector '#excerpts'
+    end
+
+    it 'does not have a full-text services' do
+      render partial: 'catalog/show_availability_sidebar', locals: { document: document }
+      expect(rendered).not_to have_selector '#full_text'
+    end
+  end
+
+  context 'full-text eligible formats and standard numbers' do
+    let(:document) { SolrDocument.new(properties) }
+    let(:properties) do
+      {
+        'id' => '5',
+        'format' => ['Manuscript', 'Book'],
+        'oclc_s' => %w(19590730),
+        'location_code_s' => ['sa'],
+        'holdings_1display' => "{\"13395\":{\"location\":\"Forrestal Annex - Temporary\",\"library\":\"Forrestal Annex\",\"location_code\":\"anxafst\",\"copy_number\":\"1\",\"call_number\":\"PS3563.A3294 xT3\",\"call_number_browse\":\"PS3563.A3294 xT3\"}}"
+      }
+    end
+    it 'has highlighted links and excerpt umlaut blocks' do
+      render partial: 'catalog/show_availability_sidebar', locals: { document: document }
+      expect(rendered).to have_selector '#highlighted_link'
+      expect(rendered).to have_selector '#excerpts'
+    end
+
+    it 'has a full text umlaut block' do
+      render partial: 'catalog/show_availability_sidebar', locals: { document: document }
+      expect(rendered).to have_selector '#full_text'
+    end
+  end
+
+  context '#umlaut_services for a record with a non-marcit online option and ineligible formats' do
+    let(:document) { SolrDocument.new(properties) }
+    let(:properties) do
+      {
+        'id' => '2',
+        'oclc_s' => %w(19590730 301985443),
+        'format' => ['Audio'],
+        'location_code_s' => ['sa'],
+        'electronic_access_1display' => "{\"https://ebrary.com/121331313\":[\"ebrary.com\",\"View Princeton's online holdings\"]}",
+        'holdings_1display' => "{\"9592399\":{\"location\":\"Online - *ONLINE*\",\"library\":\"Online\",\"location_code\":\"elf1\",\"call_number\":\"Electronic Resource\",\"call_number_browse\":\"Electronic Resource\"}}"
+      }
+    end
+    it 'has all umlaut highlighted link and excerpt services' do
+      render partial: 'catalog/show_availability_sidebar', locals: { document: document }
+      expect(rendered).to have_selector '#highlighted_link'
+      expect(rendered).to have_selector '#excerpts'
+    end
+
+    it 'does not have umlaut full-text options' do
+      render partial: 'catalog/show_availability_sidebar', locals: { document: document }
       expect(rendered).not_to have_selector '#full_text'
     end
   end


### PR DESCRIPTION
When other formats pass openURLs the SFX knowledge base produces a lot of noise due to how some vendor products respond to OpenURLs. Restricting calls to only standard number items doesn't help in these cases. This PR  will only make a request for full-text when a standard number is present and the record format is either "Journal or Book." Some of the vendor target databases in SFX only support title level matching, no matter if a standard number is present or not.

Examples:
https://pulsearch.princeton.edu/catalog/9041463
https://pulsearch.princeton.edu/catalog/8044154

The same ids running this branch in dev:
https://pulsearch-dev.princeton.edu/catalog/9041463
https://pulsearch-dev.princeton.edu/catalog/8044154

This isn't a perfect solution. The urlify helper in particular is kind of out of control. If we can update the solr document to try and denote whether or not a given link drawn from a 856 value is a "full-text" option I think we could definitely simplify all the checking for what "linking" services we are trying to federate from umlaut we do in urlify and in in the show_availablility_sidebar partial. 