### PR TITLE
word wrap due date at end of line

### DIFF
--- a/app/assets/stylesheets/components/availability.scss
+++ b/app/assets/stylesheets/components/availability.scss
@@ -13,6 +13,7 @@
     font-size: 12px;
     padding: 0;
     margin-right: 0;
+    white-space: normal;
 
     &.label-default {
       color: #777;


### PR DESCRIPTION
(On small screens)
Before:
![due-date-no-wrap](https://cloud.githubusercontent.com/assets/4650153/24121048/25c3a142-0d8d-11e7-83e7-ba35a956e8ea.png)
After:
![due-date-normal-wrap](https://cloud.githubusercontent.com/assets/4650153/24121054/296c64e6-0d8d-11e7-8e86-ed1e642bc5c4.png)

