### PR TITLE
mfhd availability use enum_display value, add space before due date

### DIFF
--- a/app/assets/javascripts/availability.js.coffee.erb
+++ b/app/assets/javascripts/availability.js.coffee.erb
@@ -92,11 +92,11 @@ class AvailabilityUpdater
         status = title_case(item['status'])
         label = status_label(status)
         if holding_label != item['label'] || item['temp_loc']
-          li = "<li>#{item['enum'] || 'Item'}: #{item['label']} - #{status_display(status, label)}</li>"
+          li = "<li>#{item['enum_display'] || 'Item'}: #{item['label']} - #{status_display(status, label)}</li>"
           ul = ul + li
         if (status not in available_statuses && status != on_site_status)
           unless holding_label != item['label'] || item['temp_loc']
-            li = "<li>#{item['enum'] || 'Item'}: #{status_display(status, label, item['due_date'])}</li>"
+            li = "<li>#{item['enum_display'] || 'Item'}: #{status_display(status, label, item['due_date'])}</li>"
             ul = ul + li
           span = $("*[data-holding-id='#{holding_id}'] .availability-icon")
           txt = if status.match(on_site_unavailable)
@@ -178,7 +178,7 @@ class AvailabilityUpdater
     if status.match(label) || status.match(on_site_status)
       status
     else
-      "#{label} #{due_date(date_due)}(#{status})"
+      "#{label} #{due_date(date_due)} (#{status})"
   due_date = (date_string) ->
     return "" unless date_string?
     " - #{date_string}"


### PR DESCRIPTION
enum_display concatenates the enumeration and chronology for availability display.
There should be a space between the due date and the voyager status.