### PR TITLE
Update all references to catalog.princeton.edu to https.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -430,7 +430,7 @@ module ApplicationHelper
   end
 
   def voyager_url(bibid)
-    "http://catalog.princeton.edu/cgi-bin/Pwebrecon.cgi?BBID=#{bibid}"
+    "https://catalog.princeton.edu/cgi-bin/Pwebrecon.cgi?BBID=#{bibid}"
   end
 
   def current_year

--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -10,7 +10,7 @@
         <li><a href="http://princeton.summon.serialssolutions.com/advanced" target="_blank">Articles+</a></li>
         <li><a href="http://library.princeton.edu/research/databases" target="_blank">Databases</a></li>
         <li><a href="http://getit.princeton.edu/" target="_blank">E-journal titles</a></li>
-        <li><a href="http://catalog.princeton.edu/" target="_blank"><%= t('blacklight.voyager') %></a></li>
+        <li><a href="https://catalog.princeton.edu/" target="_blank"><%= t('blacklight.voyager') %></a></li>
         <li><a href="http://pudl.princeton.edu/" target="_blank">Digital collections</a></li>
         <li><a href="http://findingaids.princeton.edu" target="_blank">Finding Aids</a></li>
     </ul>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -26,7 +26,7 @@
 
                 <li class="leaf">
                     <a class="footer-link" href=
-                    "http://catalog.princeton.edu" title=
+                    "https://catalog.princeton.edu" title=
                     "Access the library's main catalog">Main Catalog</a>
                 </li>
 

--- a/config/requests.yml
+++ b/config/requests.yml
@@ -5,7 +5,7 @@ defaults: &defaults
   bibdata_base: https://bibdata.princeton.edu
   proxy_base: http://library.princeton.edu/resolve/lookup?url=
   stackmap_base: https://bibdata.princeton.edu/locations/map
-  voyager_api_base: http://catalog.princeton.edu:7014
+  voyager_api_base: https://catalog.princeton.edu:7014
   pulsearch_base: https://pulsearch.princeton.edu
   aeon_base: https://library.princeton.edu/aeon/aeon.dll?
 development:


### PR DESCRIPTION
To be deployed when the voyager opac and web services are changed over to https by default. 