### PR TITLE
Switch to bd test system as API Base per Relais approved workaround.

### DIFF
--- a/config/initializers/borrow_direct.rb
+++ b/config/initializers/borrow_direct.rb
@@ -7,6 +7,7 @@ BorrowDirect::Defaults.library_symbol = 'PRINCETON'
 
 BorrowDirect::Defaults.api_key = ENV['BD_AUTH_KEY']
 
-BorrowDirect::Defaults.api_base = BorrowDirect::Defaults::PRODUCTION_API_BASE
+BorrowDirect::Defaults.api_base = 'https://bdtest.relais-host.com'
+# BorrowDirect::Defaults.api_base = BorrowDirect::Defaults::PRODUCTION_API_BASE
 BorrowDirect::Defaults.find_item_patron_barcode = ENV['BD_FIND_BARCODE']
 BorrowDirect::Defaults.timeout = 60

--- a/config/requests.yml
+++ b/config/requests.yml
@@ -7,7 +7,7 @@ defaults: &defaults
   stackmap_base: https://bibdata.princeton.edu/locations/map
   voyager_api_base: https://catalog.princeton.edu:7014
   pulsearch_base: https://pulsearch.princeton.edu
-  aeon_base: https://library.princeton.edu/aeon/aeon.dll?
+  aeon_base: https://lib-aeon.princeton.edu/aeon/aeon.dll?
   gfa_base: http://libweb5.princeton.edu/ReCAPNoUI/Default.aspx
   ill_base: https://lib-illiad.princeton.edu/illiad/illiad.dll/OpenURL
   scsb_base: https://uat-recap.htcinc.com:9093

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -35,12 +35,12 @@ describe 'Availability' do
   describe 'Physical Holdings in temp locations', js: true do
     it 'displays temp location on search results along with call number' do
       visit '/catalog?q=7917192'
-      expect(page).to have_selector '.library-location', text: 'Lewis Library - Term Loan Reserves'
+      expect(page).to have_selector '.library-location', text: 'Lewis Library - Course Reserve'
       expect(page).to have_selector '.library-location', text: 'QA303.2 .W45 2014'
     end
     it 'displays temp location and copy on record show' do
       visit 'catalog/7917192'
-      expect(page).to have_selector 'h3.library-location', text: 'Lewis Library - Term Loan Reserves'
+      expect(page).to have_selector 'h3.library-location', text: 'Lewis Library - Course Reserve'
     end
   end
 


### PR DESCRIPTION
Also use aeon direct system URL per another work around for e-commerce rollout.