### PR TITLE
redirect voyager urls to blacklight catalog page

### DIFF
--- a/app/controllers/concerns/orangelight/catalog.rb
+++ b/app/controllers/concerns/orangelight/catalog.rb
@@ -18,6 +18,10 @@ module Orangelight
       redirect_to lccn_resolve(params[:id])
     end
 
+    def voyager
+      redirect_to "/catalog/#{params[:BBID]}"
+    end
+
     def redirect_browse
       if params[:search_field] && params[:controller] != 'advanced'
         if params[:search_field] == 'browse_subject' && !params[:id]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do
   get '/catalog/isbn/:id', to: 'catalog#isbn'
   get '/catalog/lccn/:id', to: 'catalog#lccn'
   get '/catalog/issn/:id', to: 'catalog#issn'
+  get '/cgi-bin/Pwebrecon.cgi', to: 'catalog#voyager'
 
   get '/notes' => 'high_voltage/pages#show', id: 'notes'
   get '/help' => 'high_voltage/pages#show', id: 'help'

--- a/spec/requests/request_spec.rb
+++ b/spec/requests/request_spec.rb
@@ -336,6 +336,13 @@ describe 'blacklight tests' do
     end
   end
 
+  describe 'voyager record url pattern' do
+    it 'redirects to blacklight catalog url' do
+      get '/cgi-bin/Pwebrecon.cgi?BBID=12345'
+      expect(response).to redirect_to('/catalog/12345')
+    end
+  end
+
   describe 'mathjax script' do
     it 'is included in search results' do
       get '/?f%5Bformat%5D%5B%5D=Book&q=&search_field=all_fields'


### PR DESCRIPTION
When Orangelight gets moved to catalog.princeton.edu, Voyager urls like `https://catalog.princeton.edu/cgi-bin/Pwebrecon.cgi?BBID=9642463`
will redirect to `https://catalog.princeton.edu/catalog/9642463`