### PR TITLE
Ensures that whitespaces are escaped for `left_anchor` queries and that advanced searches are enclosed by quotes

### DIFF
--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -106,12 +106,10 @@ module BlacklightAdvancedSearch
 
         return @keyword_queries unless @params[:search_field] == ::AdvancedController.blacklight_config.advanced_search[:url_key]
 
-        # spaces need to be stripped from the query because they don't get properly stripped in Solr
-        ###### TO GET STARTS WITH TO WORK #######
-        q1 = %w[left_anchor in_series].include?(@params[:f1]) ? @params[:q1].delete(' ') : @params[:q1]
-        q2 = @params[:f2] == 'left_anchor' ? @params[:q2].delete(' ') : @params[:q2]
-        q3 = @params[:f3] == 'left_anchor' ? @params[:q3].delete(' ') : @params[:q3]
-        #########################################
+        # Spaces need to be stripped from the query because they don't get properly stripped in Solr
+        q1 = %w[left_anchor in_series].include?(@params[:f1]) ? escape_quotes(@params[:q1]) : @params[:q1]
+        q2 = @params[:f2] == 'left_anchor' ? escape_quotes(@params[:q2]) : @params[:q2]
+        q3 = @params[:f3] == 'left_anchor' ? escape_quotes(@params[:q3]) : @params[:q3]
 
         been_combined = false
         @keyword_queries[@params[:f1]] = q1 if @params[:q1].present?
@@ -139,6 +137,16 @@ module BlacklightAdvancedSearch
 
       @keyword_queries
     end
+
+    private
+
+      # Escape quotes for any given advanced search query
+      # @param query [String] the query within which quotes are being escaped
+      # @return [String] the escaped query
+      def escape_quotes(query)
+        cleaned_query = query.gsub(/"+/, '')
+        '"' + cleaned_query + '"'
+      end
   end
 end
 

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -17,11 +17,12 @@ module BlacklightHelper
     solr_parameters[:q] = solr_parameters[:q].delete('?')
   end
 
-  # This is needed because white space tokenizes regardless of filters
-  def left_anchor_strip(solr_parameters)
+  # Escape all whitespace characters within Solr queries specifying left anchor query facets
+  # @param solr_parameters [Blacklight::Solr::Request] the parameters for the Solr query
+  def left_anchor_escape_whitespace(solr_parameters)
     return unless solr_parameters[:q] && solr_parameters[:q].include?('{!qf=$left_anchor_qf pf=$left_anchor_pf}')
-    newq = solr_parameters[:q].gsub('{!qf=$left_anchor_qf pf=$left_anchor_pf}', '')
-    solr_parameters[:q] = '{!qf=$left_anchor_qf pf=$left_anchor_pf}' + newq.delete(' ')
+    query = solr_parameters[:q].gsub('{!qf=$left_anchor_qf pf=$left_anchor_pf}', '')
+    solr_parameters[:q] = '{!qf=$left_anchor_qf pf=$left_anchor_pf}' + query.gsub(/(\s)/, '\\\\\1')
   end
 
   def pul_holdings(solr_parameters)

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -6,7 +6,7 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   self.default_processor_chain += %i[cleanup_boolean_operators add_advanced_search_to_solr
                                      cjk_mm wildcard_char_strip only_home_facets
-                                     left_anchor_strip course_reserve_filters
+                                     left_anchor_escape_whitespace course_reserve_filters
                                      series_title_results pul_holdings]
 
   def cleanup_boolean_operators(solr_parameters)

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -7,11 +7,11 @@ describe BlacklightHelper do
     allow(self).to receive(:blacklight_params).and_return(blacklight_params)
   end
 
-  describe '#left_anchor_strip' do
-    it 'strips white spaces before sending :q to solr' do
-      query = { q: '{!qf=$left_anchor_qf pf=$left_anchor_pf}searching for' }
-      left_anchor_strip(query)
-      expect(query[:q]).to eq '{!qf=$left_anchor_qf pf=$left_anchor_pf}searchingfor'
+  describe '#left_anchor_escape_whitespace' do
+    it 'escapes white spaces before sending :q to solr' do
+      query = { q: '{!qf=$left_anchor_qf pf=$left_anchor_pf}searching for a test value' }
+      left_anchor_escape_whitespace(query)
+      expect(query[:q]).to eq '{!qf=$left_anchor_qf pf=$left_anchor_pf}searching\ for\ a\ test\ value'
     end
   end
 


### PR DESCRIPTION
Resolves #924 (but is blocked from full resolution by https://github.com/pulibrary/pul_solr/pull/40)