### PR TITLE
Update holding locations initializer

### DIFF
--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -49,7 +49,7 @@ module AdvancedHelper
     locations = {}
     non_code_items = []
     facet_items.each do |item|
-      holding_loc = LOCATIONS[item.value]
+      holding_loc = Orangelight.locations[item.value]
       holding_loc.nil? ? non_code_items << item : add_holding_loc(item, holding_loc, locations)
     end
     library_facet_values(non_code_items, locations)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -106,7 +106,7 @@ module ApplicationHelper
     elf_holdings.each do |id, holding|
       online_holdings << process_online_holding(holding, doc_id, id, links.empty?)
     end
-    other_holdings.sort_by { |_id, h| LOCATIONS.keys.index(h['location_code']) }.each do |id, holding|
+    other_holdings.sort_by { |_id, h| Orangelight.locations.keys.index(h['location_code']) }.each do |id, holding|
       physical_holdings << process_physical_holding(holding, doc_id, id, is_journal, pub_date)
     end
     online = content_tag(:div, online_holdings.html_safe) unless online_holdings.empty?
@@ -131,7 +131,7 @@ module ApplicationHelper
 
   def process_physical_holding(holding, bib_id, holding_id, is_journal, pub_date)
     info = ''
-    location_rules = LOCATIONS[holding['location_code'].to_sym]
+    location_rules = Orangelight.locations[holding['location_code'].to_sym]
     cn_value = holding['call_number_browse'] || holding['call_number']
     if (holding_loc = holding_location_label(holding)).present?
       location = content_tag(:span, holding_loc, class: 'location-text', data:
@@ -319,7 +319,7 @@ module ApplicationHelper
     holdings_hash = JSON.parse(document['holdings_1display'] || '{}')
     scsb_multiple = false
     holdings_hash.first(2).each do |id, holding|
-      location = LOCATIONS[holding['location_code'].to_sym]
+      location = Orangelight.locations[holding['location_code'].to_sym]
       check_availability = true
       info = ''
       if holding['library'] == 'Online'
@@ -491,13 +491,13 @@ module ApplicationHelper
   end
 
   def render_location_code(value)
-    location = LOCATIONS[value.to_sym]
+    location = Orangelight.locations[value.to_sym]
     location.nil? ? value : "#{value}: #{location_full_display(location)}"
   end
 
   def holding_location_label(holding)
     loc_code = holding['location_code']
-    location = LOCATIONS[loc_code.to_sym] unless loc_code.nil?
+    location = Orangelight.locations[loc_code.to_sym] unless loc_code.nil?
     location.nil? ? holding['location'] : location_full_display(location)
   end
 

--- a/config/initializers/locations_initializer.rb
+++ b/config/initializers/locations_initializer.rb
@@ -1,16 +1,11 @@
-# initialize location data
+# initialize holding location data
+require 'holding_locations'
 
-require 'faraday'
-
-locations = Faraday.get("#{ENV['bibdata_base']}/locations/holding_locations.json")
-
-unless locations.status != 200
-  locations_hash = {}.with_indifferent_access
-  JSON.parse(locations.body).each do |location|
-    locations_hash[location['code']] = location.with_indifferent_access
+module Orangelight
+  def locations
+    @locations = HoldingLocations.load if @locations.blank?
+    @locations
   end
-  sorted_locations = locations_hash.sort_by do |_i, l|
-    [l['library']['order'], l['library']['label'], l['label']]
-  end
-  LOCATIONS = sorted_locations.to_h.with_indifferent_access
+
+  module_function :locations
 end

--- a/lib/holding_locations.rb
+++ b/lib/holding_locations.rb
@@ -1,0 +1,27 @@
+require 'faraday'
+
+# Fetches holding locations json from bibdata, and returns a sorted hash.
+module HoldingLocations
+  def load
+    response = Faraday.get("#{ENV['bibdata_base']}/locations/holding_locations.json")
+    return {} unless response.status == 200
+
+    sorted_locations(response)
+  end
+
+  private
+
+    def sorted_locations(response)
+      locations_hash = {}.with_indifferent_access
+      JSON.parse(response.body).each do |location|
+        locations_hash[location['code']] = location.with_indifferent_access
+      end
+      sorted = locations_hash.sort_by do |_i, l|
+        [l['library']['order'], l['library']['label'], l['label']]
+      end
+
+      sorted.to_h.with_indifferent_access
+    end
+
+    module_function :load, :sorted_locations
+end

--- a/spec/lib/holding_locations_spec.rb
+++ b/spec/lib/holding_locations_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe HoldingLocations do
+  describe '#load' do
+    subject { described_class.load }
+
+    let(:response) { instance_double(Faraday::Response, status: status, body: body) }
+    let(:status) { 200 }
+    let(:body) { '[{"label":"African American Studies Reading Room","code":"aas","library":{"label":"Firestone Library","code":"firestone","order":1}}]' }
+
+    before { allow(Faraday).to receive(:get).and_return(response) }
+    context 'with a successful response from bibdata' do
+      it 'returns the holdings location hash' do
+        expect(subject).to include('aas')
+      end
+    end
+
+    context 'with an unsuccessful response from bibdata' do
+      let(:status) { 500 }
+
+      it 'returns an empty hash' do
+        expect(subject).to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Moves locations hash from global constant to method in the Orangelight namespace.
- Creates helper module for fetching locations data to make testing easier.
- Returns an empty hash when bibdata does not return the request for whatever reason. On the next attempt to access locations data, a new request to bibdata is made.

Closes #1003 