### PR TITLE
OnlineHoldingsMarkupBuilder.urlify needs to flatten electronic access text values

### DIFF
--- a/app/services/online_holdings_markup_builder.rb
+++ b/app/services/online_holdings_markup_builder.rb
@@ -44,7 +44,8 @@ class OnlineHoldingsMarkupBuilder < HoldingRequestsBuilder
     markup = ''
 
     electronic_access = adapter.doc_electronic_access
-    electronic_access.each do |url, texts|
+    electronic_access.each do |url, electronic_texts|
+      texts = electronic_texts.flatten
       link = electronic_access_link(url, texts)
       link = "#{texts[1]}: " + link if texts[1]
       link = "<li>#{link}</li>" if electronic_access.count > 1

--- a/spec/services/online_holdings_markup_builder_spec.rb
+++ b/spec/services/online_holdings_markup_builder_spec.rb
@@ -118,5 +118,17 @@ RSpec.describe OnlineHoldingsMarkupBuilder do
         expect(urlified_markup).to include ENV['proxy_base']
       end
     end
+
+    context '.urlify with multiple, nested electronic access titles' do
+      let(:electronic_access_url) { 'http://hdl.handle.net/1802/27831' }
+
+      before do
+        allow(adapter).to receive(:doc_electronic_access).and_return(electronic_access_url => [['I am a label'], ['I am another label']])
+      end
+
+      it 'flattens the set of electronic access titles' do
+        expect(urlified_markup).to include ENV['proxy_base']
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves #1168 