### PR TITLE
adjusts show availability panel layout

### DIFF
--- a/app/assets/stylesheets/components/lists.scss
+++ b/app/assets/stylesheets/components/lists.scss
@@ -15,6 +15,10 @@
     margin-right: 2em;
 }
 
+.restrictions-list {
+  margin-bottom: 0;
+}
+
 .example dt {
     float: left;
     display: inline;

--- a/app/services/physical_holdings_markup_builder.rb
+++ b/app/services/physical_holdings_markup_builder.rb
@@ -209,7 +209,7 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
     restricted_items.uniq!
 
     children = restricted_items.join
-    content_tag(:ul, children.html_safe, class: 'item-list')
+    content_tag(:ul, children.html_safe, class: 'restrictions-list item-list')
   end
 
   def self.open_location?(location)

--- a/app/views/catalog/_show_availability_sidebar.html.erb
+++ b/app/views/catalog/_show_availability_sidebar.html.erb
@@ -14,19 +14,22 @@
   <%= umlaut_services_fulltext(document) %>
 <% end %>
 
-<% document_linked_records = document.linked_records(field: 'other_version_s', query_field: 'other_version_s') %>
-<% unless document_linked_records.empty? %>
-  <div class="location--panel location--linked">
+<% unless holding_requests_adapter.restrictions.flatten.empty? %>
+  <div class="restrictions--panel">
     <div class="panel panel-default">
-      <div class="panel-heading"><%= t('blacklight.holdings.linked') %></div>
+      <div class="panel-heading"><%= 'Restrictions' %></div>
       <div class="panel-body">
-        <%= render 'show_linked_records', linked_records: document_linked_records %>
+        <% holding_requests_adapter.sorted_physical_holdings.each do |_id, holding| %>
+          <% if holding_requests_adapter.scsb_holding?(holding) && !holding_requests_adapter.empty_holding?(holding) %>
+            <%= PhysicalHoldingsMarkupBuilder.scsb_list(holding) %>
+          <% end %>
+        <% end %>
       </div>
     </div>
   </div>
 <% end %>
 
-<% unless physical.nil? %>
+<% unless physical.empty? %>
   <div class="location--panel location--holding">
     <div class="panel panel-default">
       <div class="panel-heading"><%= t('blacklight.holdings.print') %></div>
@@ -37,16 +40,13 @@
   </div>
 <% end %>
 
-<% unless holding_requests_adapter.sorted_physical_holdings.empty? %>
-  <div class="restrictions--panel">
+<% document_linked_records = document.linked_records(field: 'other_version_s', query_field: 'other_version_s') %>
+<% unless document_linked_records.empty? %>
+  <div class="location--panel location--linked">
     <div class="panel panel-default">
-      <div class="panel-heading"><%= 'Restrictions' %></div>
+      <div class="panel-heading"><%= t('blacklight.holdings.linked') %></div>
       <div class="panel-body">
-        <% holding_requests_adapter.sorted_physical_holdings.each do |_id, holding| %>
-          <% if holding_requests_adapter.scsb_holding?(holding) && !holding_requests_adapter.empty_holding?(holding) %>
-            <%= PhysicalHoldingsMarkupBuilder.scsb_list(holding) %>
-          <% end %>
-        <% end %>
+        <%= render 'show_linked_records', linked_records: document_linked_records %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
 - Hides the restrictions and copies in libraries panel if they are empty.
 - Moves the Other Versions below the Copies in Library Panel
 - Restrictions appear above the Copies in Library panel