### PR TITLE
Ensures that URLs with encoded "|" characters are properly escaped

### DIFF
--- a/app/services/online_holdings_markup_builder.rb
+++ b/app/services/online_holdings_markup_builder.rb
@@ -36,6 +36,18 @@ class OnlineHoldingsMarkupBuilder < HoldingRequestsBuilder
     markup
   end
 
+  # Method for cleaning URLs
+  # @see https://github.com/pulibrary/orangelight/issues/1185
+  # @param url [String] the URL for an online holding
+  # @return [String] the cleaned URL
+  def self.clean_url(url)
+    if /go\.galegroup\.com.+?%257C/.match? url
+      URI.decode_www_form_component(url)
+    else
+      url
+    end
+  end
+
   # Generate the markup for the electronic access block
   # First argument of link_to is optional display text. If null, the second argument
   # (URL) is the display text for the link.
@@ -48,6 +60,8 @@ class OnlineHoldingsMarkupBuilder < HoldingRequestsBuilder
     electronic_access = adapter.doc_electronic_access
     electronic_access.each do |url, electronic_texts|
       texts = electronic_texts.flatten
+      url = clean_url(url)
+
       link = electronic_access_link(url, texts)
       link = "#{texts[1]}: " + link if texts[1]
       link = "<li>#{link}</li>" if electronic_access.count > 1

--- a/spec/services/online_holdings_markup_builder_spec.rb
+++ b/spec/services/online_holdings_markup_builder_spec.rb
@@ -139,5 +139,17 @@ RSpec.describe OnlineHoldingsMarkupBuilder do
         expect(urlified_markup).to include ENV['proxy_base']
       end
     end
+
+    context 'when a URL contains an encoded "|" character' do
+      let(:gale_go_url) { 'http://go.galegroup.com/ps/i.do?id=GALE%257C9781440840869&v=2.1&u=prin77918&it=etoc&p=GVRL&sw=w' }
+
+      before do
+        allow(adapter).to receive(:doc_electronic_access).and_return(gale_go_url => ['go.galegroup.com'])
+      end
+
+      it 'ensures that the "|" character does not get encoded twice' do
+        expect(urlified_markup).to include 'http://go.galegroup.com/ps/i.do?id=GALE%7C9781440840869'
+      end
+    end
   end
 end


### PR DESCRIPTION
Parses for erroneously-encoded metadata (as found within https://github.com/pulibrary/orangelight/issues/1185)