### PR TITLE
Ensures that `OmniauthCallbacksController` cleans patron barcodes of whitespace characters used for authentication

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  # include Blacklight::Folders::User
   validates :username, presence: true
   validates :uid, length: { is: 14 }, format: { with: /\A([\d]{14})\z/ },
                   if: :barcode_provider?
@@ -16,14 +15,20 @@ class User < ApplicationRecord
   # Method added by Blacklight; Blacklight uses #to_s on your
   # user class to get a user-displayable login/identifier for
   # the account.
+  # @return [String] the user name
   def to_s
     username || 'User'
   end
 
+  # Determines whether or not this is a user which has an identifiable barcode
+  # @return [TrueClass, FalseClass]
   def barcode_provider?
     provider == 'barcode'
   end
 
+  # Retrieves a user authenticated using the CAS
+  # @param access_token []
+  # @return [User,nil]
   def self.from_cas(access_token)
     User.where(provider: access_token.provider, uid: access_token.uid).first_or_create do |user|
       user.uid = access_token.uid
@@ -34,6 +39,9 @@ class User < ApplicationRecord
     end
   end
 
+  # Retrieves a user authenticated using a barcode
+  # @param access_token [] access token containing the barcode accessed using #uid
+  # @return [User,nil]
   def self.from_barcode(access_token)
     User.where(provider: access_token.provider, uid: access_token.uid,
                username: access_token.info.last_name).first_or_initialize do |user|


### PR DESCRIPTION
Resolves #1123 