### PR TITLE
Removes Open Graph thumbnail URLs

### DIFF
--- a/app/assets/javascripts/book_covers.js.coffee
+++ b/app/assets/javascripts/book_covers.js.coffee
@@ -23,22 +23,7 @@ class BookCoverManager
     true
   fetch_identifiers: (identifiers) ->
     url = "#{@google_url}#{identifiers.join(",")}"
-    $.getJSON(url).done(this.process_results, this.update_open_graph_metadata)
-
-  # Update the Open Graph metadata within <meta> elements
-  # @param {Object} data - Data retrieved from the Google Books API.
-  update_open_graph_metadata: (data) ->
-    for identifier, info of data
-      if info.thumbnail_url?
-        thumbnail_url = info.thumbnail_url.replace(/zoom=./,"zoom=1").replace("&edge=curl","")
-
-        og_image_elements = $('meta[property="og:image"]')
-        if og_image_elements.length
-          og_image_element = $(og_image_elements[0])
-          og_image_element.prop('content', thumbnail_url)
-        else
-          og_image_element = $("<meta property=\"og:image\" content=\"#{thumbnail_url}\">")
-          $("head").append(og_image_element)
+    $.getJSON(url).done(this.process_results)
 
   process_results: (data) ->
     for identifier, info of data

--- a/app/assets/javascripts/plum_viewer_loader.js.coffee
+++ b/app/assets/javascripts/plum_viewer_loader.js.coffee
@@ -10,10 +10,29 @@ class PlumViewerLoader
         .fail( () =>
           this.fetch_viewer_from_ark("https://plum.princeton.edu")
         )
+
+  # Update the Open Graph metadata within <meta> elements
+  # @param {Object} manifest - Data retrieved from a IIIF image resource
+  update_open_graph_metadata: (manifest) ->
+    manifest_url = manifest['url']
+    $.getJSON(manifest_url).done((manifest) =>
+      thumbnail = manifest['thumbnail']
+      thumbnail_url = thumbnail['@id']
+
+      og_image_elements = $('meta[property="og:image"]')
+      if og_image_elements.length
+        og_image_element = $(og_image_elements[0])
+        og_image_element.prop('content', thumbnail_url)
+      else
+        og_image_element = $("<meta property=\"og:image\" content=\"#{thumbnail_url}\">")
+        $("head").append(og_image_element)
+    )
+
   fetch_viewer_from_ark: (repo_url) ->
     $.getJSON("#{repo_url}/iiif/lookup/#{this.ark()}?no_redirect=true")
-      .done( (data) =>
-        this.build_viewer(data['url'])
+      .done( this.update_open_graph_metadata, (manifest) =>
+        manifest_url = manifest['url']
+        this.build_viewer(manifest_url)
       )
   fetch_viewer_with_url: (url) ->
       this.build_viewer(url)

--- a/app/assets/javascripts/plum_viewer_loader.js.coffee
+++ b/app/assets/javascripts/plum_viewer_loader.js.coffee
@@ -11,26 +11,9 @@ class PlumViewerLoader
           this.fetch_viewer_from_ark("https://plum.princeton.edu")
         )
 
-  # Update the Open Graph metadata within <meta> elements
-  # @param {Object} manifest - Data retrieved from a IIIF image resource
-  update_open_graph_metadata: (manifest) ->
-    manifest_url = manifest['url']
-    $.getJSON(manifest_url).done((manifest) =>
-      thumbnail = manifest['thumbnail']
-      thumbnail_url = thumbnail['@id']
-
-      og_image_elements = $('meta[property="og:image"]')
-      if og_image_elements.length
-        og_image_element = $(og_image_elements[0])
-        og_image_element.prop('content', thumbnail_url)
-      else
-        og_image_element = $("<meta property=\"og:image\" content=\"#{thumbnail_url}\">")
-        $("head").append(og_image_element)
-    )
-
   fetch_viewer_from_ark: (repo_url) ->
     $.getJSON("#{repo_url}/iiif/lookup/#{this.ark()}?no_redirect=true")
-      .done( this.update_open_graph_metadata, (manifest) =>
+      .done((manifest) =>
         manifest_url = manifest['url']
         this.build_viewer(manifest_url)
       )

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,6 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
 
     <!-- OpenGraph metadata when sharing links, e.g., on FB -->
-    <meta property="og:image" content="<%= asset_url 'pul_orange-icon-only.png' %>" />
     <meta property="og:title" content="<%= render_page_title %>" />
 
     <!-- Mobile IE allows us to activate ClearType technology for smoothing fonts for easy reading -->

--- a/spec/features/browsing_item_spec.rb
+++ b/spec/features/browsing_item_spec.rb
@@ -2,19 +2,38 @@
 
 require 'rails_helper'
 
-describe 'browsing a catalog item' do
+describe 'browsing a catalog item', js: true do
   before do
     stub_holding_locations
   end
 
   it 'renders an accessible icon for citing the item' do
     visit 'catalog/3478898'
-    expect(page).to have_selector '.icon-cite[aria-hidden="true"]'
+    expect(page).to have_selector '.icon-cite[aria-hidden="true"]', visible: false
   end
 
   it 'renders an accessible icon for sending items to a printer' do
     visit 'catalog/3478898'
-    expect(page).to have_selector '.icon-share[aria-hidden="true"]'
-    expect(page).to have_selector '.icon-print[aria-hidden="true"]'
+    expect(page).to have_selector '.icon-share[aria-hidden="true"]', visible: false
+    expect(page).to have_selector '.icon-print[aria-hidden="true"]', visible: false
+  end
+
+  it 'links to the PUL branding for a standard Open Graph' do
+    visit 'catalog/3478898'
+    expect(page).to have_css 'meta[property="og:image"][content*="/assets/pul_orange-icon-only"]', visible: false
+  end
+
+  context 'when the Document links to a resource on books.google.com' do
+    it 'uses the books.google.com API to retrieve the thumbnail URL' do
+      visit 'catalog/9741216'
+      expect(page).to have_css 'meta[property="og:image"][content^="https://books.google.com/books/content"]', visible: false
+    end
+  end
+
+  context 'when the Document links to a IIIF Manifest' do
+    it 'uses a IIIF image server to retrieve the thumbnail URL' do
+      visit 'catalog/4705307'
+      expect(page).to have_css 'meta[property="og:image"][content$="-intermediate_file.jp2/full/!200,150/0/default.jpg"]', visible: false
+    end
   end
 end

--- a/spec/features/browsing_item_spec.rb
+++ b/spec/features/browsing_item_spec.rb
@@ -17,23 +17,4 @@ describe 'browsing a catalog item', js: true do
     expect(page).to have_selector '.icon-share[aria-hidden="true"]', visible: false
     expect(page).to have_selector '.icon-print[aria-hidden="true"]', visible: false
   end
-
-  it 'links to the PUL branding for a standard Open Graph' do
-    visit 'catalog/3478898'
-    expect(page).to have_css 'meta[property="og:image"][content*="/assets/pul_orange-icon-only"]', visible: false
-  end
-
-  context 'when the Document links to a resource on books.google.com' do
-    it 'uses the books.google.com API to retrieve the thumbnail URL' do
-      visit 'catalog/9741216'
-      expect(page).to have_css 'meta[property="og:image"][content^="https://books.google.com/books/content"]', visible: false
-    end
-  end
-
-  context 'when the Document links to a IIIF Manifest' do
-    it 'uses a IIIF image server to retrieve the thumbnail URL' do
-      visit 'catalog/4705307'
-      expect(page).to have_css 'meta[property="og:image"][content$="-intermediate_file.jp2/full/!200,150/0/default.jpg"]', visible: false
-    end
-  end
 end


### PR DESCRIPTION
Resolves #1196 by updating the `<meta>` elements within the `<head>` in order to expose thumbnails as Open Graph image metadata (please see http://ogp.me/#metadata)