### PR TITLE
Browse list rpp parameter should use values only in [10, 25, 50, 100]

### DIFF
--- a/app/controllers/orangelight/browsables_controller.rb
+++ b/app/controllers/orangelight/browsables_controller.rb
@@ -7,6 +7,7 @@ class Orangelight::BrowsablesController < ApplicationController
   # GET /orangelight/names.json
   def index
     # if rpp isn't specified default is 50
+    # if rpp has values other than 10, 25, 50, 100 then set it to 50
     # previous/next page links need to pass
     # manually set rpp
 
@@ -15,14 +16,14 @@ class Orangelight::BrowsablesController < ApplicationController
       @rpp = 50
       @page_link = '?'
     else
-      @rpp = params[:rpp].to_i
+      rpp_range = [10, 25, 50, 100]
+      @rpp = if rpp_range.include? params[:rpp].to_i
+               params[:rpp].to_i
+             else
+               50
+             end
       @page_link = "?rpp=#{@rpp}&"
     end
-    # if params[:page].nil?
-    #   @page=1
-    # else
-    #   @page = params[:page].to_i
-    # end
 
     # @start gets the id of the first entry to display on page
     # specific ids are given based on search results

--- a/spec/requests/orangelight/browse_spec.rb
+++ b/spec/requests/orangelight/browse_spec.rb
@@ -34,14 +34,22 @@ RSpec.describe 'Orangelight Browsables', type: :request do
       expect(r[0]['id']).to eq 7
     end
 
-    it 'shows last complete page if start param > db entries' do
-      get '/browse/subjects.json?rpp=10000'
+    it 'sets rpp=50 if rpp value is not in [10, 25, 50, 100]' do
+      get '/browse/call_numbers.json?rpp=10764433.975.98000'
       r = JSON.parse(response.body)
-      subject_count = r.length
-      rpp = 10
-      get "/browse/subjects.json?start=9999&rpp=#{rpp}"
-      r = JSON.parse(response.body)
-      expect(r[0]['id']).to eq subject_count - rpp + 1
+      expect(r.length).to eq 50
+    end
+
+    it 'shows last complete page if start param > db entries for any accepted rpp' do
+      rpp = [10, 25, 50, 100]
+      rpp.each do |v|
+        get "/browse/call_numbers.json?start=180&rpp=#{v}"
+        r1 = JSON.parse(response.body)
+        get "/browse/call_numbers.json?start=400&rpp=#{v}"
+        r2 = JSON.parse(response.body)
+        expect(r1[0]['id']).to eq r2[0]['id']
+        expect(r1.length).to eq r2.length
+      end
     end
 
     it 'shows the first page if start param < 1' do


### PR DESCRIPTION
Limits rpp parameter in browse list to use values in [10, 25, 50, 100]
closes #1246 