### PR TITLE
'Select all' label for charged items needs to be seen by all devices

### DIFF
--- a/app/views/account/_charged_items.html.erb
+++ b/app/views/account/_charged_items.html.erb
@@ -3,7 +3,7 @@
     <table class="table table-striped table-bordered account--charged_items">
       <thead>
         <tr>
-          <th><% if (!@account.has_blocks?) %><label><input type="checkbox" id="select-all-renew"/> <span class="sr-only">Select all</span></label><% end %></th>
+          <th><% if (!@account.has_blocks?) %><label><input type="checkbox" id="select-all-renew"/> <span>Select all</span></label><% end %></th>
           <th>Item</th>
           <th>Call number</th>
           <th>Status</th>


### PR DESCRIPTION
Circulation staff requested that we make this label viewable to all users.