### PR TITLE
allows holding index and supplement notes to display

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -283,22 +283,8 @@ class CatalogController < ApplicationController
     config.add_show_field 'coden_display', label: 'Coden designation'
     config.add_show_field 'standard_no_1display', hash: true
     config.add_show_field 'original_language_display', label: 'Original language'
-    config.add_show_field 'shelving_title_display', label: 'Shelving title'
-    config.add_show_field 'location_has_display', label: 'Location has'
-    config.add_show_field 'location_has_current_display', label: 'Location has (current)'
-    config.add_show_field 'supplements_display', label: 'Supplements'
-    config.add_show_field 'location_notes_display', label: 'Location notes'
     config.add_show_field 'related_name_json_1display', hash: true
     config.add_show_field 'recap_notes_display', label: 'RCP', helper_method: :recap_note
-    # # 'Other version(s)_display'
-    # # 'Contained in_display'
-    # # 'Related record(s)_display'
-    # # 'Holdings information_display'
-    # # 'Item details_display'
-    # # 'Order information_display'
-    # # 'E-items_display'
-    # # 'Status_display'
-    # # 'Linked resources_display'
 
     #     "fielded" search configuration. Used by pulldown among other places.
     #     For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/services/holding_requests_adapter.rb
+++ b/app/services/holding_requests_adapter.rb
@@ -178,6 +178,18 @@ class HoldingRequestsAdapter
     !holding['location_has'].nil?
   end
 
+  # Determine whether or not the holding features a supplements note
+  # @return [TrueClass, FalseClass]
+  def supplements?(holding)
+    !holding['supplements'].nil?
+  end
+
+  # Determine whether or not the holding features an index note
+  # @return [TrueClass, FalseClass]
+  def indexes?(holding)
+    !holding['indexes'].nil?
+  end
+
   # Determine whether or not the holding is for a Voyager
   # @return [TrueClass, FalseClass]
   def voyager_holding?(holding_id)

--- a/app/services/physical_holdings_markup_builder.rb
+++ b/app/services/physical_holdings_markup_builder.rb
@@ -161,6 +161,16 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
     content_tag(:ul, children.html_safe, class: 'location-has')
   end
 
+  def self.supplements_list(holding)
+    children = "#{holding_label('Supplements:')} #{listify_array(holding['supplements'])}"
+    content_tag(:ul, children.html_safe, class: 'holding-supplements')
+  end
+
+  def self.indexes_list(holding)
+    children = "#{holding_label('Indexes:')} #{listify_array(holding['indexes'])}"
+    content_tag(:ul, children.html_safe, class: 'holding-indexes')
+  end
+
   def self.journal_issues_list(holding_id)
     content_tag(:ul, '',
                 class: 'journal-current-issues',
@@ -402,6 +412,8 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
       markup << self.class.shelving_titles_list(holding) if @adapter.shelving_title?(holding)
       markup << self.class.location_notes_list(holding) if @adapter.location_note?(holding)
       markup << self.class.location_has_list(holding) if @adapter.location_has?(holding)
+      markup << self.class.supplements_list(holding) if @adapter.supplements?(holding)
+      markup << self.class.indexes_list(holding) if @adapter.indexes?(holding)
       markup << self.class.journal_issues_list(holding_id) if @adapter.journal?
 
       unless holding_id == 'thesis' && @adapter.pub_date > 2012

--- a/spec/services/physical_holdings_markup_builder_spec.rb
+++ b/spec/services/physical_holdings_markup_builder_spec.rb
@@ -27,6 +27,9 @@ RSpec.describe PhysicalHoldingsMarkupBuilder do
   let(:holding_id) { '3668455' }
   let(:location) { 'Firestone Library' }
   let(:call_number) { 'PS3539.A74Z93 2000' }
+  let(:shelving_title) { ['Shelving title'] }
+  let(:supplements) { ['Supplement note'] }
+  let(:indexes) { ['Index note 1', 'Index note 2'] }
   let(:request_link) { '<a href="/requests/1232432">Request</a>' }
   let(:holding) do
     {
@@ -34,8 +37,11 @@ RSpec.describe PhysicalHoldingsMarkupBuilder do
         location: location,
         library: 'Firestone Library',
         location_code: 'f',
-        call_number: call_number
-      }
+        call_number: call_number,
+        shelving_title: shelving_title,
+        supplements: supplements,
+        indexes: indexes
+      }.with_indifferent_access
     }
   end
   let(:document) { instance_double(SolrDocument) }
@@ -133,6 +139,34 @@ RSpec.describe PhysicalHoldingsMarkupBuilder do
       expect(holding_location_span_markup).to include '<span class="location-text"'
       expect(holding_location_span_markup).to include 'test-location'
       expect(holding_location_span_markup).to include 'data-holding-id="test-holding-id"'
+    end
+  end
+
+  describe '.shelving_title' do
+    let(:shelving_title_markup) { described_class.shelving_titles_list(holding.first[1]) }
+
+    it 'generates the markup for a supplement note' do
+      expect(shelving_title_markup).to include "<li>#{shelving_title[0]}</li>"
+      expect(shelving_title_markup).to include '<ul class="shelving-title">'
+    end
+  end
+
+  describe '.supplements_list' do
+    let(:supplements_list_markup) { described_class.supplements_list(holding.first[1]) }
+
+    it 'generates the markup for a supplement note' do
+      expect(supplements_list_markup).to include "<li>#{supplements[0]}</li>"
+      expect(supplements_list_markup).to include '<ul class="holding-supplements">'
+    end
+  end
+
+  describe '.indexes_list' do
+    let(:indexes_list_markup) { described_class.indexes_list(holding.first[1]) }
+
+    it 'generates the markup for a supplement note' do
+      expect(indexes_list_markup).to include "<li>#{indexes[0]}</li>"
+      expect(indexes_list_markup).to include "<li>#{indexes[1]}</li>"
+      expect(indexes_list_markup).to include '<ul class="holding-indexes">'
     end
   end
 


### PR DESCRIPTION
Adds index and supplement field to display along with the holdings info (example: https://catalog-staging.princeton.edu/catalog/492761)
Removes non-existent fields from catalog controller.