### PR TITLE
send wildcard character for left-anchor search to solr

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -20,13 +20,17 @@ module BlacklightHelper
   end
 
   # Escape all whitespace characters within Solr queries specifying left anchor query facets
+  # Ends all left-anchor searches with wildcards for matches that begin with search string
   # @param solr_parameters [Blacklight::Solr::Request] the parameters for the Solr query
   def left_anchor_escape_whitespace(solr_parameters)
     return unless solr_parameters[:q]&.include?('{!qf=$left_anchor_qf pf=$left_anchor_pf}')
     query = solr_parameters[:q].gsub('{!qf=$left_anchor_qf pf=$left_anchor_pf}', '')
-    # Escape any remaining whitespace
+    # Escape any remaining whitespace and solr operator characters
     query.gsub!(/(\s)/, '\\\\\1')
+    query.gsub!(/(["\{\}\[\]\^\~])/, '\\\\\1')
+    query.gsub!(/[\(\)]/, '')
     solr_parameters[:q] = '{!qf=$left_anchor_qf pf=$left_anchor_pf}' + query
+    solr_parameters[:q] += '*' unless query.end_with?('*')
   end
 
   def pul_holdings(solr_parameters)

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -2,13 +2,13 @@
 # each environment can have a jetty_path with absolute or relative
 # (to app root) path to a jetty/solr install. This is used
 # by the rake tasks that start up solr automatically for testing
-# and by rake solr:marc:index.  
+# and by rake solr:marc:index.
 #
 # jetty_path is not used by a running Blacklight application
 # at all. In general you do NOT need to deploy solr in Jetty, you can deploy it
-# however you want.  
+# however you want.
 # jetty_path is only required for rake tasks that need to know
-# how to start up solr, generally for automated testing. 
+# how to start up solr, generally for automated testing.
 
 development:
   adapter: solr

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -10,10 +10,15 @@ describe BlacklightHelper do
   end
 
   describe '#left_anchor_escape_whitespace' do
-    it 'escapes white spaces before sending :q to solr' do
+    it 'escapes white spaces before sending :q to solr along with wildcard character' do
       query = { q: '{!qf=$left_anchor_qf pf=$left_anchor_pf}searching for a test value' }
       left_anchor_escape_whitespace(query)
-      expect(query[:q]).to eq '{!qf=$left_anchor_qf pf=$left_anchor_pf}searching\ for\ a\ test\ value'
+      expect(query[:q]).to eq '{!qf=$left_anchor_qf pf=$left_anchor_pf}searching\ for\ a\ test\ value*'
+    end
+    it 'only a single wildcard character is included when user supplies the wildcard in query' do
+      query = { q: '{!qf=$left_anchor_qf pf=$left_anchor_pf}searching for a test value*' }
+      left_anchor_escape_whitespace(query)
+      expect(query[:q]).to eq '{!qf=$left_anchor_qf pf=$left_anchor_pf}searching\ for\ a\ test\ value*'
     end
   end
 


### PR DESCRIPTION
Updates left-anchor implementation to send wildcard character to solr. Updated implementation required Solr operator characters to be escaped before being sent to Solr.

Removes quotes from left-anchor searches in advanced search. For the other advanced search fields, removes the first instance of a quotation mark when there are an odd number of them to prevent a Solr parsing error.