### PR TITLE
adds relevance score as a tiebreaker for sort fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -462,11 +462,11 @@ class CatalogController < ApplicationController
     # whether the sort is ascending or descending (it must be asc or desc
     # except in the relevancy case).
     config.add_sort_field 'score desc, pub_date_start_sort desc, title_sort asc', label: 'relevance'
-    config.add_sort_field 'pub_date_start_sort desc, title_sort asc', label: 'year (newest first)'
-    config.add_sort_field 'pub_date_start_sort asc, title_sort asc', label: 'year (oldest first)'
-    config.add_sort_field 'author_sort asc, title_sort asc', label: 'author'
-    config.add_sort_field 'title_sort asc, pub_date_start_sort desc', label: 'title'
-    config.add_sort_field 'cataloged_tdt desc, title_sort asc', label: 'date cataloged'
+    config.add_sort_field 'pub_date_start_sort desc, title_sort asc, score desc', label: 'year (newest first)'
+    config.add_sort_field 'pub_date_start_sort asc, title_sort asc, score desc', label: 'year (oldest first)'
+    config.add_sort_field 'author_sort asc, title_sort asc, score desc', label: 'author'
+    config.add_sort_field 'title_sort asc, pub_date_start_sort desc, score desc', label: 'title'
+    config.add_sort_field 'cataloged_tdt desc, title_sort asc, score desc', label: 'date cataloged'
 
     # If there are more than this many search results, no spelling ("did you
     # mean") suggestion is offered.


### PR DESCRIPTION
Based on catalog-feedback ticket from Darwin, this search returned a SCSB item before a Voyager item: https://catalog.princeton.edu/catalog?utf8=%E2%9C%93&f1=all_fields&q1=&op2=AND&f2=author&q2=diabelli&op3=AND&f3=title&q3=sonatin*&f_inclusive%5Bformat%5D%5B%5D=Musical+score&range%5Bpub_date_start_sort%5D%5Bbegin%5D=&range%5Bpub_date_start_sort%5D%5Bend%5D=&sort=pub_date_start_sort+desc%2C+title_sort+asc&search_field=advanced&commit=Search

The Princeton item had a higher relevance score, but a different sort field was used. This PR adds relevance score as a tiebreaker for the other sort fields when the other sort-by fields are identical.