### PR TITLE
Ajax update to remove empty div

### DIFF
--- a/app/views/shared/_viewer_uv.html.erb
+++ b/app/views/shared/_viewer_uv.html.erb
@@ -14,7 +14,7 @@
                 }
                 if (ark_length === 1) {
                     elem1 = document.querySelector('div#view_1.intrinsic-container.intrinsic-container-16x9');
-                    elem1.parentNode.removeChild(elem);
+                    elem1.parentNode.removeChild(elem1);
                 }
             }
 
@@ -50,14 +50,13 @@
                                     result.push(JSON.parse(oReq[i].response)["url"]);
                                     callback(i, result);
                                 } else {
-                                    elem1 = document.querySelector('div#view_1.intrinsic-container.intrinsic-container-16x9');
-                                    if (elem1) {
-                                        elem1.parentNode.removeChild(elem1);
-                                    }
-                                    elem = document.querySelector('div#view.intrinsic-container.intrinsic-container-16x9');
-                                    if (elem) {
-                                       elem.parentNode.removeChild(elem);
-                                    }
+                                    if (i === 0) {
+                                            elem = document.querySelector('div#view.intrinsic-container.intrinsic-container-16x9');
+                                            elem.parentNode.removeChild(elem);
+                                        } else {
+                                            elem1 = document.querySelector('div#view_1.intrinsic-container.intrinsic-container-16x9');
+                                            elem1.parentNode.removeChild(elem1);
+                                        }
                                 }
                             }
                         };

--- a/app/views/shared/_viewer_uv.html.erb
+++ b/app/views/shared/_viewer_uv.html.erb
@@ -2,7 +2,7 @@
     $(document).ready(function(){
         //figgy ajax call using bibid arks
         let arkView = document.getElementById("ark_array_id");
-        let result_length, url,result=[], iframeUv3View = [], i, divFrameView = [], onlineTag = [], oReq = [], arkOnline = [], ark_array, ark_length, elem;
+        let result_length, url,result=[], iframeUv3View = [], i, divFrameView = [], onlineTag = [], oReq = [], arkOnline = [], ark_array, ark_length, elem1, elem;
 
         if (arkView) {
             ark_array = JSON.parse(arkView.dataset.ark);
@@ -13,8 +13,8 @@
                     createElements(i);
                 }
                 if (ark_length === 1) {
-                    elem = document.querySelector('div#view_1.intrinsic-container.intrinsic-container-16x9');
-                    elem.parentNode.removeChild(elem);
+                    elem1 = document.querySelector('div#view_1.intrinsic-container.intrinsic-container-16x9');
+                    elem1.parentNode.removeChild(elem);
                 }
             }
 
@@ -50,8 +50,14 @@
                                     result.push(JSON.parse(oReq[i].response)["url"]);
                                     callback(i, result);
                                 } else {
-                                    elem = document.querySelector('div#view_1.intrinsic-container.intrinsic-container-16x9');
-                                    elem.parentNode.removeChild(elem);
+                                    elem1 = document.querySelector('div#view_1.intrinsic-container.intrinsic-container-16x9');
+                                    if (elem1) {
+                                        elem1.parentNode.removeChild(elem1);
+                                    }
+                                    elem = document.querySelector('div#view.intrinsic-container.intrinsic-container-16x9');
+                                    if (elem) {
+                                       elem.parentNode.removeChild(elem);
+                                    }
                                 }
                             }
                         };


### PR DESCRIPTION
Updates Ajax viewer to remove the empty div when there is a 404 response.
The 2 divs for the ajax viewer pre-exist in the show page when there are arks in the marc record. This update will remove an empty div that might exist because of a 404 response from figgy. 