### PR TITLE
Handling cases where BlacklightAdvancedSearch::ParsingNestingParser#process_query encounters a nil advanced config. Hash

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -253,6 +253,11 @@ RSpec/ExampleLength:
   Exclude:
     - 'spec/**/*'
 
+RSpec/VerifiedDoubles:
+  Exclude:
+    - 'spec/helpers/blacklight_advanced_search/parsing_nesting_spec.rb'
+    - 'spec/views/catalog/_sort_and_per_page.html.erb_spec.rb'
+
 Rails/UnknownEnv:
   Exclude:
     - 'app/controllers/application_controller.rb'

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -179,7 +179,7 @@ module BlacklightAdvancedSearch
     # @return [Array<String>]
     def process_query(_params, config)
       if config.advanced_search.nil?
-        Blacklight.logger.error "Failed to parse the advanced search, advanced search config. settings are not accessible for: #{config}"
+        Blacklight.logger.error "Failed to parse the advanced search, config. settings are not accessible for: #{config}"
         return []
       end
 

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -173,7 +173,16 @@ end
 
 module BlacklightAdvancedSearch
   module ParsingNestingParser
+    # Iterates through the keyword queries and appends each operator the extracting queries
+    # @param [ActiveSupport::HashWithIndifferentAccess] _params
+    # @param [Blacklight::Configuration] config
+    # @return [Array<String>]
     def process_query(_params, config)
+      if config.advanced_search.nil?
+        Blacklight.logger.error "Failed to parse the advanced search, advanced search config. settings are not accessible for: #{config}"
+        return []
+      end
+
       queries = []
       ops = keyword_op
       keyword_queries.each do |field, query|

--- a/spec/helpers/blacklight_advanced_search/parsing_nesting_spec.rb
+++ b/spec/helpers/blacklight_advanced_search/parsing_nesting_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe BlacklightAdvancedSearch::ParsingNestingParser do
 
       it 'logs an error and returns an empty query' do
         expect(queries).to be_empty
-        expect(Blacklight.logger).to have_received(:error).with(/Failed to parse the advanced search, advanced search config\. settings are not accessible for\:/)
+        expect(Blacklight.logger).to have_received(:error).with(/Failed to parse the advanced search, config\. settings are not accessible for\:/)
       end
     end
   end

--- a/spec/helpers/blacklight_advanced_search/parsing_nesting_spec.rb
+++ b/spec/helpers/blacklight_advanced_search/parsing_nesting_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BlacklightAdvancedSearch::ParsingNestingParser do
+  describe '#process_query' do
+    subject(:queries) { process_query(_params, config) }
+
+    let(:_params) { instance_double(ActiveSupport::HashWithIndifferentAccess) }
+    # instance_double cannot be used to stub #advanced_search for Blacklight::Configuration
+    let(:config) { double('Blacklight::Configuration') }
+    let(:advanced_search) { instance_double(Blacklight::OpenStructWithHashAccess) }
+    let(:keyword_queries) do
+      {
+        'title' => 'anything',
+        'all_fields' => '(something) OR (anything)'
+      }
+    end
+
+    before do
+      allow(config).to receive(:advanced_search).and_return(advanced_search)
+      allow(self).to receive(:local_param_hash).with('all_fields', config).and_return({})
+      allow(self).to receive(:local_param_hash).with('title', config).and_return("spellcheck.dictionary": 'title', qf: '$title_qf', pf: '$title_pf')
+      allow(self).to receive(:keyword_op).and_return([])
+      allow(self).to receive(:keyword_queries).and_return(keyword_queries)
+    end
+
+    it 'appends the operators to the queries' do
+      allow(advanced_search).to receive(:[]).with(:query_parser).and_return('edismax')
+      expect(queries).to include('_query_:"{!edismax spellcheck.dictionary=title qf=$title_qf pf=$title_pf}anything"  _query_:"{!dismax mm=1}something anything"')
+    end
+
+    context 'when the query parser is not specified in the advanced search' do
+      let(:advanced_search) { nil }
+
+      before do
+        allow(Blacklight.logger).to receive(:error)
+      end
+
+      it 'logs an error and returns an empty query' do
+        expect(queries).to be_empty
+        expect(Blacklight.logger).to have_received(:error).with(/Failed to parse the advanced search, advanced search config\. settings are not accessible for\:/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #1310 