### PR TITLE
Overriding Blacklight::CatalogHelperBehavior#render_search_to_page_title_filter and Blacklight::CatalogHelperBehavior#render_search_to_page_title in order to handle empty facets

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,6 +48,7 @@ Metrics/AbcSize:
     - 'app/services/holding_requests_builder.rb'
     - 'app/services/physical_holdings_markup_builder.rb'
     - 'app/services/online_holdings_markup_builder.rb'
+    - 'app/helpers/catalog_helper.rb'
 
 Metrics/BlockNesting:
   Exclude:
@@ -105,6 +106,7 @@ Metrics/LineLength:
     - 'lib/tasks/server.rake'
     - '**/Gemfile'
     - 'app/controllers/orangelight/browsables_controller.rb'
+    - 'app/helpers/catalog_helper.rb'
 
 Metrics/MethodLength:
   Exclude:

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -31,6 +31,37 @@ module CatalogHelper
     res[0..1]
   end
 
+  # @see Blacklight::CatalogHelperBehavior#render_search_to_page_title_filter
+  # @param [facet]
+  # @param [values]
+  def render_search_to_page_title_filter(facet, values)
+    return '' if values.blank?
+    super(facet, values)
+  end
+
+  # @see Blacklight::CatalogHelperBehavior#render_search_to_page_title
+  # @param [params]
+  def render_search_to_page_title(params)
+    constraints = []
+
+    if params['q'].present?
+      q_label = label_for_search_field(params[:search_field]) unless default_search_field && params[:search_field] == default_search_field[:key]
+
+      constraints += if q_label.present?
+                       [t('blacklight.search.page_title.constraint', label: q_label, value: params['q'])]
+                     else
+                       [params['q']]
+                     end
+    end
+
+    if params['f'].present?
+      new_constraints = params['f'].to_unsafe_h.collect { |key, value| render_search_to_page_title_filter(key, value) }
+      constraints += new_constraints.reject(&:empty?)
+    end
+
+    constraints.join(' / ')
+  end
+
   private
 
     def document_types(document)

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CatalogHelper do
+  let(:blacklight_config) { Blacklight::Configuration.new }
+
+  before do
+    allow(helper).to receive_messages(blacklight_config: blacklight_config)
+  end
+
+  describe '#render_search_to_page_title_filter' do
+    it 'generates the text for faceted search filters' do
+      expect(helper.render_search_to_page_title_filter('format', ['book'])).to eq 'Format: book'
+      expect(helper.render_search_to_page_title_filter(:format, [:book])).to eq 'Format: book'
+    end
+
+    context 'when no values are given for fields being faceted in the search' do
+      it 'generates the text for faceted search filters' do
+        expect(helper.render_search_to_page_title_filter('format', nil)).to eq ''
+        expect(helper.render_search_to_page_title_filter(:format, [])).to eq ''
+      end
+    end
+  end
+
+  describe '#render_search_to_page_title' do
+    let(:params) do
+      ActionController::Parameters.new(
+        f: {
+          format: :book,
+          location: :ReCAP
+        }
+      )
+    end
+
+    it 'generates the text from the faceted search filters' do
+      expect(helper.render_search_to_page_title(params)).to eq 'Format: 4 selected / Location: 5 selected'
+    end
+
+    context 'when no values are given for fields being faceted in the search' do
+      let(:params) do
+        ActionController::Parameters.new(
+          f: {
+            format: nil,
+            location: ''
+          }
+        )
+      end
+
+      it 'generates the text from the faceted search filters' do
+        expect(helper.render_search_to_page_title(params)).to eq ''
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #1334 