### PR TITLE
Overriding Blacklight::Catalog#facet and handling cases where display information for a faceted field cannot be retrieved

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,7 @@ Metrics/AbcSize:
     - 'app/services/physical_holdings_markup_builder.rb'
     - 'app/services/online_holdings_markup_builder.rb'
     - 'app/helpers/catalog_helper.rb'
+    - 'app/controllers/catalog_controller.rb'
 
 Metrics/BlockNesting:
   Exclude:

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -495,6 +495,7 @@ class CatalogController < ApplicationController
   end
 
   # @see Blacklight::Catalog#facet
+  # @see https://github.com/projectblacklight/blacklight/blob/v6.13.0/app/controllers/concerns/blacklight/catalog.rb#L68
   # displays values and pagination links for a single facet field
   def facet
     @facet = blacklight_config.facet_fields[params[:id]]

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -493,4 +493,23 @@ class CatalogController < ApplicationController
   rescue ActionController::BadRequest
     render file: Rails.public_path.join('x400.html'), layout: true, status: :bad_request
   end
+
+  # @see Blacklight::Catalog#facet
+  # displays values and pagination links for a single facet field
+  def facet
+    @facet = blacklight_config.facet_fields[params[:id]]
+    raise ActionController::RoutingError, 'Not Found' unless @facet
+    @response = get_facet_field_response(@facet.key, params)
+    @display_facet = @response.aggregations[@facet.field]
+    raise ActionController::RoutingError, 'Not Found' unless @display_facet
+    @pagination = facet_paginator(@facet, @display_facet)
+    respond_to do |format|
+      format.html do
+        # Draw the partial for the "more" facet modal window:
+        return render layout: false if request.xhr?
+        # Otherwise draw the facet selector for users who have javascript disabled.
+      end
+      format.json
+    end
+  end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -72,4 +72,14 @@ RSpec.describe CatalogController do
       expect(response.status).to eq(400)
     end
   end
+
+  describe 'rendering facet values and links' do
+    context 'when the display information cannot be retrieved for the facet' do
+      it 'renders an error message' do
+        expect do
+          get :facet, params: { id: 'publication_place_facet', f: { 'format' => ['Audio'] }, '++++f' => { 'lc_1letter_facet' => ['M+-+Music'] } }
+        end.to raise_error(ActionController::RoutingError, 'Not Found')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #1338 