### PR TITLE
Implements Orangelight::Middleware::InvalidParameterHandler for Rack in order to handle invalid HTTP request parameters by transmitting a 400 status response

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,7 @@ AllCops:
     - 'node_modules/**/*'
     - 'config/deploy.rb'
     - 'config/initializers/blacklight_url_helper_behavior.rb'
+    - 'config/environments/**/*'
     - 'spec/views/catalog/_show_availability_sidebar.html.erb_spec.rb'
     - 'node_modules/**/*'
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -107,6 +107,7 @@ Metrics/LineLength:
     - '**/Gemfile'
     - 'app/controllers/orangelight/browsables_controller.rb'
     - 'app/helpers/catalog_helper.rb'
+    - 'lib/orangelight/middleware/invalid_parameter_handler.rb'
 
 Metrics/MethodLength:
   Exclude:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require Rails.root.join('lib', 'orangelight', 'middleware', 'invalid_parameter_handler')
+
 Rails.application.configure do
   # Verifies that versions and hashed value of the package contents in the project's package.json
   config.webpacker.check_yarn_integrity = true
@@ -39,4 +41,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  config.middleware.use Orangelight::Middleware::InvalidParameterHandler
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,5 +41,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-  config.middleware.use Orangelight::Middleware::InvalidParameterHandler
+  config.middleware.insert_after Datadog::Contrib::Rack::TraceMiddleware, Orangelight::Middleware::InvalidParameterHandler
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,5 +103,5 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-  config.middleware.use 'Orangelight::Middleware::InvalidParameterHandler'
+  config.middleware.insert_after Datadog::Contrib::Rack::TraceMiddleware, Orangelight::Middleware::InvalidParameterHandler
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require Rails.root.join('lib', 'orangelight', 'middleware', 'invalid_parameter_handler')
+
 Rails.application.configure do
   # Verifies that versions and hashed value of the package contents in the project's package.json
   config.webpacker.check_yarn_integrity = false
@@ -101,4 +103,5 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+  config.middleware.use 'Orangelight::Middleware::InvalidParameterHandler'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,5 +43,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-  config.middleware.use Orangelight::Middleware::InvalidParameterHandler
+  config.middleware.insert_after Datadog::Contrib::Rack::TraceMiddleware, Orangelight::Middleware::InvalidParameterHandler
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require Rails.root.join('lib', 'orangelight', 'middleware', 'invalid_parameter_handler')
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -41,4 +43,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  config.middleware.use Orangelight::Middleware::InvalidParameterHandler
 end

--- a/lib/orangelight/middleware/invalid_parameter_handler.rb
+++ b/lib/orangelight/middleware/invalid_parameter_handler.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Orangelight
+  module Middleware
+    class InvalidParameterHandler
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        validate_for!(env)
+        @app.call(env)
+      rescue ActionController::BadRequest => bad_request_error
+        raise bad_request_error unless bad_request_error.message.match?(/invalid %-encoding/)
+
+        Rails.logger.error "Invalid parameters passed in the request: #{bad_request_error} within the environment #{@request.inspect}"
+        return bad_request_response
+      end
+
+      private
+
+        def request_for(env)
+          # calling env.dup here prevents bad things from happening
+          @request ||= ActionDispatch::Request.new(env.dup)
+        end
+
+        def validate_for!(env)
+          # calling request.params is sufficient to trigger the error
+          # see https://github.com/rack/rack/issues/337#issuecomment-46453404
+          request_for(env).params
+        end
+
+        def bad_request_status
+          400
+        end
+
+        def bad_request_body
+          'Bad Request'
+        end
+
+        def default_charset
+          ActionDispatch::Response.default_charset
+        end
+
+        def default_content_type
+          'text/html'
+        end
+
+        def request_content_type
+          @request.formats.first || default_content_type
+        end
+
+        def bad_request_headers
+          {
+            'Content-Type' => "#{request_content_type}; charset=#{default_charset}",
+            'Content-Length' => bad_request_body.bytesize.to_s
+          }
+        end
+
+        def bad_request_response
+          [
+            bad_request_status,
+            bad_request_headers,
+            [bad_request_body]
+          ]
+        end
+    end
+  end
+end

--- a/spec/lib/orangelight/middleware/invalid_parameter_handler_spec.rb
+++ b/spec/lib/orangelight/middleware/invalid_parameter_handler_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Orangelight::Middleware::InvalidParameterHandler do
+  describe '#call' do
+    subject(:invalid_parameter_handler) { described_class.new(app) }
+
+    let(:app) { instance_double(Rails::Application) }
+    let(:query_string) do
+      'f%5Blocation%5D%5B%5D=Mudd%2BManuscript%2BLibrary'
+    end
+    let(:env) do
+      {
+        'REQUEST_METHOD' => 'GET',
+        'QUERY_STRING' => query_string,
+        'REQUEST_URI' => "/catalog?#{query_string}",
+        'PATH_INFO' => '/',
+        'HTTP_ACCEPT' => 'application/json',
+        'rack.input' => ''
+      }
+    end
+
+    it 'delegates the response to the app' do
+      allow(app).to receive(:call)
+      invalid_parameter_handler.call(env)
+
+      expect(app).to have_received(:call).with(env)
+    end
+
+    context 'when the HTTP request contains invalid parameters' do
+      let(:query_string) do
+        'f%5Blocation%5D%5B%5D=Mudd%2BManuscript%2BLibrary&%2B%2B%2'
+      end
+
+      before do
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it 'returns a 400 response and logs an error' do
+        status, headers, body = invalid_parameter_handler.call(env)
+
+        expect(body.join).to eq('Bad Request')
+        expect(status).to eq(400)
+        expect(headers['Content-Type']).to eq('application/json; charset=UTF-8')
+        expect(headers['Content-Length']).to eq('11')
+        expect(Rails.logger).to have_received(:error).with(/Invalid parameters passed in the request\: Invalid query parameters\: invalid %\-encoding \(%2B%2B%2\) within the environment/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #1379 