### PR TITLE
Validate key in users_params hash

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -25,6 +25,10 @@ class CatalogController < ApplicationController
     redirect_to '/', :flash => { :error => 'The start year must be before the end year.' }
   end
 
+  rescue_from ActionController::BadRequest do
+    redirect_to '/', :flash => { :error => 'This is not a valid request.' }
+  end
+
   configure_blacklight do |config|
     # default advanced config values
     config.advanced_search ||= Blacklight::OpenStructWithHashAccess.new

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -7,13 +7,19 @@ module BlacklightHelper
   require './lib/orangelight/string_functions'
 
   # (see Blacklight::SearchHelper#search_results)
+
+  # raise a BadRequest error if ActionController params have key with leading or trailing whitespaces
+  def user_params_valid(params)
+    params.each { |k| raise ActionController::BadRequest if ((k[0].match?(/\s/) || k[-1].match?(/\s/)) && (k.is_a? String)) == true }
+  end
+
   def search_results(user_params)
     raise ActionController::BadRequest if excessive_paging?(user_params)
+    user_params_valid(user_params)
 
     builder = search_builder.with(user_params)
     builder.page = user_params[:page] if user_params[:page]
     builder.rows = (user_params[:per_page] || user_params[:rows]) if user_params[:per_page] || user_params[:rows]
-
     builder = yield(builder) if block_given?
     response = repository.search(builder)
 

--- a/spec/features/searching_spec.rb
+++ b/spec/features/searching_spec.rb
@@ -65,4 +65,13 @@ describe 'searching' do
       expect(page).to have_content 'The start year must be before the end year.'
     end
   end
+
+  context 'raise flash error if BadRequest', js: true do
+    it 'will display a flash message if there is a BadRequest error' do
+      visit '/catalog/range_limit?%20%20%20%20range_end=1990&%20%20%20%20range_field=pub_date_start_sort&%20%20%20%20range_start=1981'
+      expect { page }.not_to raise_error
+      expect(page).to have_current_path('/')
+      expect(page).to have_content 'This is not a valid request.'
+    end
+  end
 end

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -139,4 +139,13 @@ describe BlacklightHelper do
       expect(excessive_paging?(params)).to be true
     end
   end
+
+  describe '#user_params_valid' do
+    it 'will raise a BadRequest for params key leading and trailing whitespaces' do
+      params['   range_end'] = '1990'
+      params[' range_field'] = 'pub_date_start_sort'
+      params['  range_start  '] = '1981'
+      expect { user_params_valid(params) }.to raise_error(ActionController::BadRequest)
+    end
+  end
 end


### PR DESCRIPTION
1. Validate key in user_params hash. If there is one with trailing or leading whitespaces raise a Bad Request and rescue the error; Display a flash error and redirect to '/'.
2. Rescue all the BadRequest errors; Redirect to '/'; Display a flash error message.

closes #1389  