### PR TITLE
moves excessive paging methods to search builder

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -14,7 +14,6 @@ module BlacklightHelper
   end
 
   def search_results(user_params)
-    raise ActionController::BadRequest if excessive_paging?(user_params)
     user_params_valid(user_params)
 
     builder = search_builder.with(user_params)
@@ -73,12 +72,6 @@ module BlacklightHelper
     solr_parameters[:fl] = 'id,score,author_display,marc_relator_display,format,pub_created_display,'\
                            'title_display,title_vern_display,isbn_s,oclc_s,lccn_s,holdings_1display,'\
                            'electronic_access_1display,cataloged_tdt,series_display'
-  end
-
-  def only_home_facets(solr_parameters)
-    return if search_parameters?(solr_parameters)
-    solr_parameters['facet.field'] = home_facets
-    solr_parameters['facet.pivot'] = []
   end
 
   # only fetch facets when an html page is requested
@@ -272,24 +265,4 @@ module BlacklightHelper
     label = index_presenter(doc).label(field, opts).truncate(length).html_safe
     link_to label, url_for_document(doc), document_link_params(doc, opts)
   end
-
-  private
-
-    ##
-    # Check if any search parameters have been set
-    # @param [ActionController::Parameters] params
-    # @return [Boolean]
-    def search_parameters?(params)
-      !params[:q].nil? || (blacklight_params && blacklight_params[:f].present?) || params[:search_field] == 'advanced'
-    end
-
-    # Determines whether or not the user is requesting an excessively high page of results
-    # @param [ActionController::Parameters] params
-    # @return [Boolean]
-    def excessive_paging?(params)
-      page = params[:page].to_i || 0
-      return false if page <= 1
-      return false if search_parameters?(params) && page < 1000
-      true
-    end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -7,9 +7,10 @@ class SearchBuilder < Blacklight::SearchBuilder
   include BlacklightHelper
 
   self.default_processor_chain += %i[cleanup_boolean_operators add_advanced_search_to_solr
-                                     cjk_mm wildcard_char_strip only_home_facets
-                                     left_anchor_escape_whitespace course_reserve_filters
-                                     series_title_results pul_holdings html_facets]
+                                     cjk_mm wildcard_char_strip excessive_paging_error
+                                     only_home_facets left_anchor_escape_whitespace
+                                     course_reserve_filters series_title_results
+                                     pul_holdings html_facets]
 
   def cleanup_boolean_operators(solr_parameters)
     return add_advanced_parse_q_to_solr(solr_parameters) if run_advanced_parse?(solr_parameters)
@@ -26,5 +27,35 @@ class SearchBuilder < Blacklight::SearchBuilder
     blacklight_params[:q].blank? ||
       !blacklight_params[:q].respond_to?(:to_str) ||
       cleaned_query(solr_parameters[:q]) == solr_parameters[:q]
+  end
+
+  def only_home_facets(solr_parameters)
+    return if search_parameters?
+    solr_parameters['facet.field'] = home_facets
+    solr_parameters['facet.pivot'] = []
+  end
+
+  # Determines whether or not the user is requesting an excessively high page of results
+  # @param [ActionController::Parameters] params
+  # @return [Boolean]
+  def excessive_paging_error(_solr_parameters)
+    raise ActionController::BadRequest if excessive_paging?
+  end
+
+  # Determines whether or not the user is requesting an excessively high page of results
+  # @return [Boolean]
+  def excessive_paging?
+    page = blacklight_params[:page].to_i || 0
+    return false if page <= 1
+    return false if search_parameters? && page < 1000
+    true
+  end
+
+  ##
+  # Check if any search parameters have been set
+  # @return [Boolean]
+  def search_parameters?
+    !blacklight_params[:q].nil? || blacklight_params[:f].present? ||
+      blacklight_params[:search_field] == 'advanced'
   end
 end

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -110,52 +110,6 @@ describe BlacklightHelper do
     end
   end
 
-  describe '#excessive_paging?' do
-    let(:excessive) { 9999 }
-    let(:reasonable) { 123 }
-
-    it 'allows reasonable paging with a search query' do
-      params = { page: reasonable, q: 'anything' }
-      expect(excessive_paging?(params)).to be false
-    end
-
-    it 'allows reasonable paging with a facet query' do
-      params = { page: reasonable }
-      blacklight_params[:f] = 'anything'
-      expect(excessive_paging?(params)).to be false
-    end
-
-    it 'does not allow paging without a search or facet' do
-      params = { page: reasonable }
-      expect(excessive_paging?(params)).to be true
-    end
-
-    it 'does not allow excessive paging with a search query' do
-      params = { page: excessive, q: 'anything' }
-      expect(excessive_paging?(params)).to be true
-    end
-
-    it 'does not allow excessive paging with a facet query' do
-      params = { page: excessive }
-      blacklight_params[:f] = 'anything'
-      expect(excessive_paging?(params)).to be true
-    end
-
-    context 'with nil blacklight_params' do
-      let(:blacklight_params) {}
-
-      it 'does not error if blacklight_params is blank' do
-        params = { page: excessive }
-        expect(excessive_paging?(params)).to be true
-      end
-    end
-
-    it 'allows paging for advanced search' do
-      params = { page: reasonable, search_field: 'advanced' }
-      expect(excessive_paging?(params)).to be false
-    end
-  end
-
   describe '#user_params_valid' do
     it 'will raise a BadRequest for params key leading and trailing whitespaces' do
       params['   range_end'] = '1990'

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SearchBuilder do
+  subject(:search_builder) { described_class.new([]) }
+
+  describe '#excessive_paging' do
+    let(:excessive) { 9999 }
+    let(:reasonable) { 123 }
+
+    it 'allows reasonable paging with a search query' do
+      search_builder.blacklight_params[:page] = reasonable
+      search_builder.blacklight_params[:q] = 'anything'
+      expect(search_builder.excessive_paging?).to be false
+    end
+
+    it 'allows reasonable paging with a facet query' do
+      search_builder.blacklight_params[:page] = reasonable
+      search_builder.blacklight_params[:f] = 'anything'
+      expect(search_builder.excessive_paging?).to be false
+    end
+
+    it 'does not allow paging without a search or facet' do
+      search_builder.blacklight_params[:page] = reasonable
+      expect(search_builder.excessive_paging?).to be true
+    end
+
+    it 'does not allow excessive paging with a search query' do
+      search_builder.blacklight_params[:page] = excessive
+      search_builder.blacklight_params[:q] = 'anything'
+      expect(search_builder.excessive_paging?).to be true
+    end
+
+    it 'does not allow excessive paging with a facet query' do
+      search_builder.blacklight_params[:page] = excessive
+      search_builder.blacklight_params[:f] = 'anything'
+      expect(search_builder.excessive_paging?).to be true
+    end
+
+    it 'allows paging for advanced search' do
+      search_builder.blacklight_params[:page] = reasonable
+      search_builder.blacklight_params[:search_field] = 'advanced'
+      expect(search_builder.excessive_paging?).to be false
+    end
+  end
+end


### PR DESCRIPTION
For some reason blacklight_params doesn't work correctly when in the blacklight_helper file. Moving the paging methods back to the search builder prevents the error of the blacklight_params being undefined.