### PR TITLE
Provides redirection for cases where clients attempt to query advanced#index with catalog queries

### DIFF
--- a/app/controllers/advanced_controller.rb
+++ b/app/controllers/advanced_controller.rb
@@ -4,7 +4,7 @@ class AdvancedController < BlacklightAdvancedSearch::AdvancedController
   copy_blacklight_config_from(CatalogController)
 
   def index
-    redirect_to '/catalog', params if params[:id]
+    redirect_to '/', params if params[:id]
 
     super
   end

--- a/app/controllers/advanced_controller.rb
+++ b/app/controllers/advanced_controller.rb
@@ -2,4 +2,10 @@
 
 class AdvancedController < BlacklightAdvancedSearch::AdvancedController
   copy_blacklight_config_from(CatalogController)
+
+  def index
+    redirect_to '/catalog', params if params[:id]
+
+    super
+  end
 end

--- a/spec/requests/advanced_search_spec.rb
+++ b/spec/requests/advanced_search_spec.rb
@@ -6,7 +6,7 @@ describe 'Orangelight advanced search', type: :request do
   it 'redirects search requests to the catalog search' do
     get '/advanced?f[subject_facet][]=United+Nations-Decision+making&id=3681146&page=1&per_page=20'
     expect(response.status).to eq(302)
-    expect(response).to redirect_to('/catalog')
+    expect(response).to redirect_to('/')
   end
   it 'renders the advanced search form' do
     get '/advanced?f[subject_facet][]=United+Nations-Decision+making'

--- a/spec/requests/advanced_search_spec.rb
+++ b/spec/requests/advanced_search_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Orangelight advanced search', type: :request do
+  it 'redirects search requests to the catalog search' do
+    get '/advanced?f[subject_facet][]=United+Nations-Decision+making&id=3681146&page=1&per_page=20'
+    expect(response.status).to eq(302)
+    expect(response).to redirect_to('/catalog')
+  end
+  it 'renders the advanced search form' do
+    get '/advanced?f[subject_facet][]=United+Nations-Decision+making'
+    expect(response.status).to eq(200)
+  end
+end


### PR DESCRIPTION
Resolves #1336 by ensuring that catalog query parameters in requests for the advanced search index trigger a redirect response