### PR TITLE
Add multi-column index to orangelight_names

### DIFF
--- a/db/migrate/20181121002728_orangelight_names_multicolumn_index.rb
+++ b/db/migrate/20181121002728_orangelight_names_multicolumn_index.rb
@@ -1,0 +1,5 @@
+class OrangelightNamesMulticolumnIndex < ActiveRecord::Migration[5.1]
+  def change
+    add_index :orangelight_names, [:id, :sort]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181120150710) do
+ActiveRecord::Schema.define(version: 20181121002728) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 20181120150710) do
     t.integer "count"
     t.text "sort"
     t.string "dir"
+    t.index ["id", "sort"], name: "index_orangelight_names_on_id_and_sort"
     t.index ["sort"], name: "index_orangelight_names_on_sort"
   end
 


### PR DESCRIPTION
Improves the query from 1.2s to ~0.12ms in production.