### PR TITLE
Speed up browse searching.

### DIFF
--- a/app/controllers/orangelight/browsables_controller.rb
+++ b/app/controllers/orangelight/browsables_controller.rb
@@ -28,7 +28,7 @@ class Orangelight::BrowsablesController < ApplicationController
     @start = first_model_id
 
     unless query_param.nil?
-      search_result = model_param.where('sort <= ?', search_term).last
+      search_result = model_param.where('sort <= ?', search_term).order('sort').last
 
       unless search_result.nil?
         @search_result = search_result.label


### PR DESCRIPTION
Doing .last in AR runs a query which is "ORDER BY id DESC limit 1", but
this particular query in postgres reverses the entire index first and
then does an index scan. Since it's already using the sort index for the
WHERE, it can just use that for ordering, which will be in the proper
order.

This query runs in .095ms vs 2 seconds on the production DB.