### PR TITLE
Adjusts the show Document view to render title_citation_display as the primary title and only elements of title_display as the the secondary title

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,7 @@ Metrics/ClassLength:
     - 'app/services/holding_requests_adapter.rb'
     - 'app/services/physical_holdings_markup_builder.rb'
     - 'lib/orangelight/voyager_patron_client.rb'
+    - 'app/models/solr_document.rb'
 
 Metrics/CyclomaticComplexity:
   Exclude:
@@ -83,6 +84,7 @@ Metrics/LineLength:
     - 'spec/services/online_holdings_markup_builder_spec.rb'
     - 'spec/services/holding_requests_adapter_spec.rb'
     - 'app/repositories/course_reserve_repository.rb'
+    - 'spec/features/browsing_item_spec.rb'
 
 Metrics/MethodLength:
   Exclude:

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -140,6 +140,45 @@ module BlacklightHelper
       link_to('[Browse]', "/browse/names?q=#{CGI.escape name}", class: 'browse-related-name', 'data-toggle' => 'tooltip', 'data-original-title' => "Search: #{name}", title: "Browse: #{name}")
   end
 
+  # Build the presenter used for rendering the show View of the Document
+  # @return [Blacklight::Presenters::ShowPresenter]
+  def document_show_presenter
+    show_presenter(@document)
+  end
+
+  # Access the text directionality of the title field for the Document
+  # @param field [String] the field indexed used as the Document title
+  # @return [String]
+  def document_title_dir(field: 'title_vern_display')
+    field = document_show_presenter.field_value field: field
+    field.dir
+  end
+
+  # Generate the title of the Document using 245$b values
+  # @see SolrDocument#title_remainder_display
+  # @return [String]
+  def document_title
+    @document.title_remainder_display.join(' / ')
+  end
+
+  ##
+  # Render the document "heading" (title) in a content tag
+  # @overload render_document_heading(document, options)
+  #   @param [SolrDocument] document
+  #   @param [Hash] options
+  #   @option options [Symbol] :tag
+  # @overload render_document_heading(options)
+  #   @param [Hash] options
+  #   @option options [Symbol] :tag
+  def render_document_title_without_citation(*args)
+    options = args.extract_options!
+    document = args.first
+    tag = options.fetch(:tag, :h4)
+    document ||= @document
+
+    content_tag(tag, document.title_without_citation, itemprop: 'name')
+  end
+
   ##
   # Render the heading partial for a document
   #

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -143,6 +143,7 @@ class SolrDocument
       output = output.gsub(title_b, '')
     end
 
+    return '' if output.gsub(/[[:punct:]]/, '').strip.empty?
     output
   end
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -46,6 +46,13 @@ class SolrDocument
   ## Adds RIS
   use_extension(Blacklight::Document::Ris)
 
+  # Specify the delimiting characters use in MARC field 245$b
+  # @see https://www.loc.gov/marc/bibliographic/bd245.html
+  # @return [Array<String>]
+  def self.title_b_delimiters
+    %w[/].freeze
+  end
+
   def identifier_data
     values = identifiers.each_with_object({}) do |identifier, hsh|
       hsh[identifier.data_key.to_sym] ||= []
@@ -110,6 +117,33 @@ class SolrDocument
                                                                    root: root_id,
                                                                    solr_field: query_field)
     linked_documents.decorated(display_fields: %w[id])
+  end
+
+  # Generate the title string from the 245$b field values
+  # @return [Array<String>]
+  def title_remainder_display
+    values = fetch(:title_citation_display)
+
+    values.map do |value|
+      output = []
+      self.class.title_b_delimiters.each do |delimiter|
+        output << value.strip.gsub(delimiter, '')
+      end
+      output.join(' ')
+    end
+  end
+
+  # Generate the Document title by removing 245$b from the concatenated 245 subfields
+  # @return [String]
+  def title_without_citation
+    output = fetch(:title_display)
+    title_b_values = fetch(:title_citation_display)
+
+    title_b_values.each do |title_b|
+      output = output.gsub(title_b, '')
+    end
+
+    output
   end
 
   def full_arks

--- a/app/views/catalog/_show_header_default.html.erb
+++ b/app/views/catalog/_show_header_default.html.erb
@@ -6,5 +6,7 @@
       <h1 dir="<%= document_title_dir %>"> <%= document_title %> </h1>
     <% end %>
     <abbr class="unapi-id" title="<%= @document.id %>"></abbr>
-    <%= render_document_title_without_citation(@document, :tag => :h2) %>
+    <% if @document.title_without_citation.present? %>
+      <%= render_document_title_without_citation(@document, :tag => :h2) %>
+    <% end %>
 </div>

--- a/app/views/catalog/_show_header_default.html.erb
+++ b/app/views/catalog/_show_header_default.html.erb
@@ -1,9 +1,10 @@
 
-<div class="col-12 header-row">
-    <% doc_presenter = show_presenter(@document) %>
-    <% if titlevalue = @document['title_vern_display'] %>
-      <h1 dir="<%= titlevalue.dir %>"> <%= titlevalue %> </h1>
+<div class="col-xs-12 header-row">
+    <%# bookmark/folder functions -%>
+
+    <% if document_title.present? %>
+      <h1 dir="<%= document_title_dir %>"> <%= document_title %> </h1>
     <% end %>
     <abbr class="unapi-id" title="<%= @document.id %>"></abbr>
-    <%= render_document_heading(@document, :tag => :h1) %>
+    <%= render_document_title_without_citation(@document, :tag => :h2) %>
 </div>

--- a/spec/features/browsing_item_spec.rb
+++ b/spec/features/browsing_item_spec.rb
@@ -43,4 +43,26 @@ describe 'browsing a catalog item', js: true do
       expect(page).to have_selector '.electronic-access a[href$="3395923#view"]', text: 'Digital content'
     end
   end
+
+  context 'when an entry has a title statement' do
+    before do
+      visit 'catalog/8181849'
+    end
+
+    it 'renders the title and title statement separately' do
+      expect(page).to have_selector '.header-row h1', text: 'Jōmyō genron / 浄名玄論'
+      expect(page).to have_selector '.header-row h2', text: 'Kyōto Kokuritsu Hakubutsukan hen ; kaisetsu Ishihara Harumichi (Hokkaidō Daigaku Meiyo Kyōju), Akao Eikei (Kyōto Kokuritsu Hakubutsukan Gakugeibu Jōseki Kenkyūin).'
+    end
+  end
+
+  context 'when the title_display field is nearly identical to the title_citation_display field' do
+    before do
+      visit 'catalog/4609321'
+    end
+
+    it 'only renders the title_display' do
+      expect(page).to have_selector '.header-row h1', text: 'Bible, Latin'
+      expect(page).not_to have_selector '.header-row h2'
+    end
+  end
 end

--- a/spec/fixtures/current_fixtures.json
+++ b/spec/fixtures/current_fixtures.json
@@ -1342,178 +1342,53 @@
         ]
     },
     {
-        "access_facet": [
-            "In the Library"
-        ],
-        "advanced_location_s": [
-            "whs",
-            "Rare Books and Special Collections"
-        ],
-        "alt_title_246_display": [
-            "Gutenberg Bible",
-            "Mazarin Bible",
-            "Mazarine Bible"
-        ],
-        "author_citation_display": [
-            "Gutenberg, Johann",
-            "Fogel, Johannes",
-            "Predigerkirche (Erfurt, Germany)",
-            "Brinley, George",
-            "Ives, Brayton",
-            "Cole, Hamilton",
-            "Ellsworth, James W."
-        ],
-        "author_roles_1display": [
-            "{\"secondary_authors\":[\"Gutenberg, Johann\",\"Fogel, Johannes\",\"Predigerkirche (Erfurt, Germany)\",\"Brinley, George\",\"Ives, Brayton\",\"Cole, Hamilton\",\"Ellsworth, James W.\"],\"translators\":[],\"editors\":[],\"compilers\":[]}"
-        ],
-        "author_s": [
-            "Gutenberg, Johann, 1397?-1468",
-            "Fogel, Johannes, active 1455-1462",
-            "Predigerkirche (Erfurt, Germany)",
-            "Brinley, George, 1817-1875",
-            "Ives, Brayton, 1840-1914",
-            "Cole, Hamilton",
-            "Ellsworth, James W. (James William), 1849-1925"
-        ],
-        "binding_note_display": [
-            "WHS copy is one of three copies bound in the workshop of Johannes Fogel of Erfurt."
-        ],
-        "call_number_browse_s": [
-            "48.1",
-            "113.2"
-        ],
-        "call_number_display": [
-            "48.1",
-            "113.2"
-        ],
-        "cataloged_tdt": [
-            "2016-12-27T20:52:25Z"
-        ],
-        "cjk_all": [
-            ""
-        ],
-        "cjk_notes": [
-            ""
-        ],
-        "compiled_created_t": [
-            "Bible, Latin."
-        ],
-        "description_display": [
-            "2 v. (324; 319 leaves) ; 40.5 x 28.8 cm. (fol.)"
-        ],
-        "description_t": [
-            "2 v. (324; 319 leaves) ; 40.5 x 28.8 cm. (fol.)"
-        ],
-        "electronic_access_1display": [
-            "{\"https://catalog.princeton.edu/catalog/4609321#view\":[\"Digital content\"],\"https://drive.google.com/open?id=0B3HwfRG3YqiNVVR4bXNvRzNwaGs\":[\"drive.google.com\",\"Curatorial documentation\"],\"iiif_manifest_paths\":{\"http://arks.princeton.edu/ark:/88435/7d278t10z\":\"https://figgy.princeton.edu/concern/scanned_resources/d446107a-bdfd-4a5d-803c-f315b7905bf4/manifest\"}}"
-        ],
-        "format": [
-            "Book"
-        ],
-        "holdings_1display": [
-            "{\"4847980\":{\"location\":\"Rare Books and Special Collections - William H. Scheide Library\",\"library\":\"Rare Books and Special Collections\",\"location_code\":\"whs\",\"copy_number\":\"1\",\"call_number\":\"48.1\",\"call_number_browse\":\"48.1\",\"location_has\":[\"vol.1-2\"]},\"4848993\":{\"location\":\"Rare Books and Special Collections - William H. Scheide Library\",\"library\":\"Rare Books and Special Collections\",\"location_code\":\"whs\",\"copy_number\":\"2\",\"call_number\":\"113.2\",\"call_number_browse\":\"113.2\",\"location_has\":[\"fragment (one leaf from Ezekiel 34)\",\"Princeton copy 2\"]}}"
-        ],
-        "id": [
-            "4609321"
-        ],
-        "language_code_s": [
-            "lat"
-        ],
-        "language_facet": [
-            "Latin"
-        ],
-        "language_iana_s": [
-            "la"
-        ],
-        "location": [
-            "Rare Books and Special Collections"
-        ],
-        "location_code_s": [
-            "whs"
-        ],
-        "location_display": [
-            "Rare Books and Special Collections - William H. Scheide Library"
-        ],
-        "notes_display": [
-            "Commonly known in English as the Gutenberg Bible, also known as the Mazarine Bible.",
-            "WHS copy has 12 leaves supplied from other copies and 5 leaves supplied in facsimile; the 17 leaves are vol. I fo. 1 and vol. II fo. 1, 17, 25, 46, 70, 149, 155, 156, 191, 217, 235, 268, 270, 275, 279, and 305.",
-            "Princeton copy 2: A single imperfect paper leaf from the Gutenberg Bible, the first printed Bible. The leaf is vol. II fo. 122 (the 2nd leaf of quire 13), with text of the last verses of Ezekiel 33, all of Ezekiel 34, and beginning verses of Ezekiel 35. The leaf comes from an otherwise lost copy of the Gutenberg Bible. It is one of nineteen such leaves, all belonging to quires 13 and 14 of volume II, that were cut down to a smaller size and pasted together to create pasteboard for some unidentified bookbinding, probably in the sixteenth century. About a dozen copies of the Gutenberg Bible, most of which were printed on vellum, are known only from fragmentary preservation as bookbinding materials. These cut-down paper leaves came to light when the Vienna bookdealers Gilhofer & Ranschburg offered them leaf by leaf in an auction of 3 April 1911. Two other leaves from this group are at the Library of Congress, a third is at Dartmouth College Library, and a fourth is at the State Library of New South Wales in Sydney. The rubrication of the copy is simple, using only red ink."
-        ],
-        "notes_index": [
-            "Commonly known in English as the Gutenberg Bible, also known as the Mazarine Bible.",
-            "GW 4201.",
-            "Goff B-526.",
-            "WHS copy has 12 leaves supplied from other copies and 5 leaves supplied in facsimile; the 17 leaves are vol. I fo. 1 and vol. II fo. 1, 17, 25, 46, 70, 149, 155, 156, 191, 217, 235, 268, 270, 275, 279, and 305. NjP",
-            "WHS copy has provenance: Predigerkirche, Erfurt, Germany; George Brinley; Brayton Ives; Hamilton Cole; and James W. Ellsworth. NjP",
-            "Princeton copy 2: A single imperfect paper leaf from the Gutenberg Bible, the first printed Bible. The leaf is vol. II fo. 122 (the 2nd leaf of quire 13), with text of the last verses of Ezekiel 33, all of Ezekiel 34, and beginning verses of Ezekiel 35. The leaf comes from an otherwise lost copy of the Gutenberg Bible. It is one of nineteen such leaves, all belonging to quires 13 and 14 of volume II, that were cut down to a smaller size and pasted together to create pasteboard for some unidentified bookbinding, probably in the sixteenth century. About a dozen copies of the Gutenberg Bible, most of which were printed on vellum, are known only from fragmentary preservation as bookbinding materials. These cut-down paper leaves came to light when the Vienna bookdealers Gilhofer & Ranschburg offered them leaf by leaf in an auction of 3 April 1911. Two other leaves from this group are at the Library of Congress, a third is at Dartmouth College Library, and a fourth is at the State Library of New South Wales in Sydney. The rubrication of the copy is simple, using only red ink. NjP",
-            "WHS copy is one of three copies bound in the workshop of Johannes Fogel of Erfurt. NjP",
-            "mlc"
-        ],
-        "number_of_pages_citation_display": [
-            "2 v. (324; 319 leaves)"
-        ],
-        "numeric_id_b": [
-            true
-        ],
-        "other_title_display": [
-            "Gutenberg Bible",
-            "Mazarin Bible",
-            "Mazarine Bible"
-        ],
-        "other_title_index": [
-            "Gutenberg Bible",
-            "Mazarin Bible",
-            "Mazarine Bible"
-        ],
-        "provenance_display": [
-            "WHS copy has provenance: Predigerkirche, Erfurt, Germany; George Brinley; Brayton Ives; Hamilton Cole; and James W. Ellsworth."
-        ],
-        "pub_citation_display": [
-            "Mainz: Johann Gutenberg and Johann Fust"
-        ],
-        "pub_created_display": [
-            "[Mainz : Johann Gutenberg and Johann Fust, before August 1456]."
-        ],
-        "pub_created_s": [
-            "[Mainz : Johann Gutenberg and Johann Fust, before August 1456]."
-        ],
-        "pub_date_display": [
-            "1456"
-        ],
-        "pub_date_start_sort": [
-            "1456"
-        ],
-        "publication_place_facet": [
-            "Germany"
-        ],
-        "references_display": [
-            "GW 4201.",
-            "Goff B-526."
-        ],
-        "related_name_json_1display": [
-            "{\"Printer\":[\"Gutenberg, Johann, 1397?-1468\"],\"Binder\":[\"Fogel, Johannes, active 1455-1462\"],\"Former owner\":[\"Predigerkirche (Erfurt, Germany)\",\"Brinley, George, 1817-1875\",\"Ives, Brayton, 1840-1914\",\"Cole, Hamilton\",\"Ellsworth, James W. (James William), 1849-1925\"]}"
-        ],
-        "title_a_index": [
-            "Bible, Latin"
-        ],
-        "title_citation_display": [
-            "Bible, Latin"
-        ],
-        "title_display": [
-            "Bible, Latin."
-        ],
-        "title_no_h_index": [
-            "Bible, Latin."
-        ],
-        "title_sort": [
-            "Bible, Latin."
-        ],
-        "title_t": [
-            "Bible, Latin."
-        ],
-        "uniform_title_s": [
-            "Bible. Latin. Vulgate. 1456"
-        ]
+        "id": ["4609321"],
+        "numeric_id_b": [true],
+        "cjk_all": [""],
+        "cjk_notes": [""],
+        "author_citation_display": ["Gutenberg, Johann", "Fogel, Johannes", "Predigerkirche (Erfurt, Germany)", "Brinley, George", "Ives, Brayton", "Cole, Hamilton", "Ellsworth, James W."],
+        "author_roles_1display": ["{\"secondary_authors\":[\"Gutenberg, Johann\",\"Fogel, Johannes\",\"Predigerkirche (Erfurt, Germany)\",\"Brinley, George\",\"Ives, Brayton\",\"Cole, Hamilton\",\"Ellsworth, James W.\"],\"translators\":[],\"editors\":[],\"compilers\":[]}"],
+        "author_s": ["Gutenberg, Johann, 1397?-1468", "Fogel, Johannes, active 1455-1462", "Predigerkirche (Erfurt, Germany)", "Brinley, George, 1817-1875", "Ives, Brayton, 1840-1914", "Cole, Hamilton", "Ellsworth, James W. (James William), 1849-1925"],
+        "uniform_title_s": ["Bible. Latin. Vulgate. 1456"],
+        "title_display": ["Bible, Latin."],
+        "title_a_index": ["Bible, Latin"],
+        "title_sort": ["Bible, Latin."],
+        "title_no_h_index": ["Bible, Latin."],
+        "title_t": ["Bible, Latin."],
+        "title_citation_display": ["Bible, Latin"],
+        "compiled_created_t": ["Bible, Latin."],
+        "pub_created_display": ["[Mainz : Johann Gutenberg and Johann Fust, before August 1456]."],
+        "pub_created_s": ["[Mainz : Johann Gutenberg and Johann Fust, before August 1456]."],
+        "pub_citation_display": ["Mainz: Johann Gutenberg and Johann Fust"],
+        "pub_date_display": ["1456"],
+        "pub_date_start_sort": ["1456"],
+        "cataloged_tdt": ["2016-12-27T20:52:25Z"],
+        "format": ["Book"],
+        "electronic_access_1display": ["{\"https://catalog.princeton.edu/catalog/4609321#view\":[\"Digital content\"],\"https://drive.google.com/open?id=0B3HwfRG3YqiNVVR4bXNvRzNwaGs\":[\"drive.google.com\",\"Curatorial documentation\"],\"iiif_manifest_paths\":{\"http://arks.princeton.edu/ark:/88435/7d278t10z\":\"https://figgy.princeton.edu/concern/scanned_resources/d446107a-bdfd-4a5d-803c-f315b7905bf4/manifest\"}}"],
+        "description_display": ["2 v. (324; 319 leaves) ; 40.5 x 28.8 cm. (fol.)"],
+        "description_t": ["2 v. (324; 319 leaves) ; 40.5 x 28.8 cm. (fol.)"],
+        "number_of_pages_citation_display": ["2 v. (324; 319 leaves)"],
+        "notes_index": ["Commonly known in English as the Gutenberg Bible, also known as the Mazarine Bible.", "GW 4201.", "Goff B-526.", "WHS copy has 12 leaves supplied from other copies and 5 leaves supplied in facsimile; the 17 leaves are vol. I fo. 1 and vol. II fo. 1, 17, 25, 46, 70, 149, 155, 156, 191, 217, 235, 268, 270, 275, 279, and 305. NjP", "WHS copy has provenance: Predigerkirche, Erfurt, Germany; George Brinley; Brayton Ives; Hamilton Cole; and James W. Ellsworth. NjP", "Princeton copy 2: A single imperfect paper leaf from the Gutenberg Bible, the first printed Bible. The leaf is vol. II fo. 122 (the 2nd leaf of quire 13), with text of the last verses of Ezekiel 33, all of Ezekiel 34, and beginning verses of Ezekiel 35. The leaf comes from an otherwise lost copy of the Gutenberg Bible. It is one of nineteen such leaves, all belonging to quires 13 and 14 of volume II, that were cut down to a smaller size and pasted together to create pasteboard for some unidentified bookbinding, probably in the sixteenth century. About a dozen copies of the Gutenberg Bible, most of which were printed on vellum, are known only from fragmentary preservation as bookbinding materials. These cut-down paper leaves came to light when the Vienna bookdealers Gilhofer \u0026 Ranschburg offered them leaf by leaf in an auction of 3 April 1911. Two other leaves from this group are at the Library of Congress, a third is at Dartmouth College Library, and a fourth is at the State Library of New South Wales in Sydney. The rubrication of the copy is simple, using only red ink. NjP", "WHS copy is one of three copies bound in the workshop of Johannes Fogel of Erfurt. NjP", "mlc"],
+        "notes_display": ["Commonly known in English as the Gutenberg Bible, also known as the Mazarine Bible.", "WHS copy has 12 leaves supplied from other copies and 5 leaves supplied in facsimile; the 17 leaves are vol. I fo. 1 and vol. II fo. 1, 17, 25, 46, 70, 149, 155, 156, 191, 217, 235, 268, 270, 275, 279, and 305.", "Princeton copy 2: A single imperfect paper leaf from the Gutenberg Bible, the first printed Bible. The leaf is vol. II fo. 122 (the 2nd leaf of quire 13), with text of the last verses of Ezekiel 33, all of Ezekiel 34, and beginning verses of Ezekiel 35. The leaf comes from an otherwise lost copy of the Gutenberg Bible. It is one of nineteen such leaves, all belonging to quires 13 and 14 of volume II, that were cut down to a smaller size and pasted together to create pasteboard for some unidentified bookbinding, probably in the sixteenth century. About a dozen copies of the Gutenberg Bible, most of which were printed on vellum, are known only from fragmentary preservation as bookbinding materials. These cut-down paper leaves came to light when the Vienna bookdealers Gilhofer \u0026 Ranschburg offered them leaf by leaf in an auction of 3 April 1911. Two other leaves from this group are at the Library of Congress, a third is at Dartmouth College Library, and a fourth is at the State Library of New South Wales in Sydney. The rubrication of the copy is simple, using only red ink."],
+        "binding_note_display": ["WHS copy is one of three copies bound in the workshop of Johannes Fogel of Erfurt."],
+        "language_facet": ["Latin"],
+        "publication_place_facet": ["Germany"],
+        "language_code_s": ["lat"],
+        "language_iana_s": ["la"],
+        "provenance_display": ["WHS copy has provenance: Predigerkirche, Erfurt, Germany; George Brinley; Brayton Ives; Hamilton Cole; and James W. Ellsworth."],
+        "references_display": ["GW 4201.", "Goff B-526."],
+        "related_name_json_1display": ["{\"Printer\":[\"Gutenberg, Johann, 1397?-1468\"],\"Binder\":[\"Fogel, Johannes, active 1455-1462\"],\"Former owner\":[\"Predigerkirche (Erfurt, Germany)\",\"Brinley, George, 1817-1875\",\"Ives, Brayton, 1840-1914\",\"Cole, Hamilton\",\"Ellsworth, James W. (James William), 1849-1925\"]}"],
+        "other_title_index": ["Gutenberg Bible", "Mazarin Bible", "Mazarine Bible"],
+        "other_title_display": ["Gutenberg Bible", "Mazarin Bible", "Mazarine Bible"],
+        "alt_title_246_display": ["Gutenberg Bible", "Mazarin Bible", "Mazarine Bible"],
+        "holdings_1display": ["{\"4847980\":{\"location\":\"Rare Books and Special Collections - William H. Scheide Library\",\"library\":\"Rare Books and Special Collections\",\"location_code\":\"whs\",\"copy_number\":\"1\",\"call_number\":\"48.1\",\"call_number_browse\":\"48.1\",\"location_has\":[\"vol.1-2\"]},\"4848993\":{\"location\":\"Rare Books and Special Collections - William H. Scheide Library\",\"library\":\"Rare Books and Special Collections\",\"location_code\":\"whs\",\"copy_number\":\"2\",\"call_number\":\"113.2\",\"call_number_browse\":\"113.2\",\"location_has\":[\"fragment (one leaf from Ezekiel 34)\",\"Princeton copy 2\"]}}"],
+        "location_code_s": ["whs"],
+        "location": ["Rare Books and Special Collections"],
+        "location_display": ["Rare Books and Special Collections - William H. Scheide Library"],
+        "access_facet": ["In the Library"],
+        "advanced_location_s": ["whs", "Rare Books and Special Collections"],
+        "call_number_display": ["48.1", "113.2"],
+        "call_number_browse_s": ["48.1", "113.2"]
     },
     {
         "access_facet": [

--- a/spec/requests/request_spec.rb
+++ b/spec/requests/request_spec.rb
@@ -160,9 +160,9 @@ describe 'blacklight tests' do
                                     "#{CGI.escape author_vern}\">#{author_vern}</a>")).to eq true
     end
     it 'adds ltr rtl dir for title and other fields in document view' do
-      get '/catalog/4705307/raw'
-      r = JSON.parse(response.body)
-      title_vern = r['title_vern_display']
+      get '/catalog/4705307.json'
+      r = JSON.parse(response.body)['response']['document']
+      title_vern = '[Risālat al-Zawrāʼ]. / [رسالة الزوراء]'
       note = r['notes_display'][0]
       note_vern = r['notes_display'].last
       get '/catalog/4705307'


### PR DESCRIPTION
Resolves #1425 