### PR TITLE
Ensures that GRAPHQL_API_URL and FIGGY_URL default to the production Figgy installation in the config. files

### DIFF
--- a/config/global/figgy.yml
+++ b/config/global/figgy.yml
@@ -1,2 +1,2 @@
 default:
-  url: <%= ENV['FIGGY_URL'] || 'http://localhost:3000' %>
+  url: <%= ENV['FIGGY_URL'] || 'https://figgy.princeton.edu' %>

--- a/config/global/graphql.yml
+++ b/config/global/graphql.yml
@@ -1,2 +1,2 @@
 default:
-  uri: <%= ENV['GRAPHQL_API_URL'] || 'http://localhost:3000/graphql' %>
+  uri: <%= ENV['GRAPHQL_API_URL'] || 'https://figgy.princeton.edu/graphql' %>


### PR DESCRIPTION
Otherwise users must manually pass these values in when invoking `rails server`