### PR TITLE
Restructuring the FiggyManifestManager JavaScript in order to query for thumbnails in batch from GraphQL

### DIFF
--- a/app/assets/javascripts/figgy.es6
+++ b/app/assets/javascripts/figgy.es6
@@ -1,10 +1,8 @@
 
 window.jQuery(document).ready(() => {
-
-  window.jQuery(".document-thumbnail[data-bib-id]").each((idx, element) => {
-    const thumbnail = FiggyManifestManager.buildThumbnail(element)
-    thumbnail.render()
-  })
+  const $elements = window.jQuery(".document-thumbnail[data-bib-id]")
+  const thumbnails = FiggyManifestManager.buildThumbnailSet($elements)
+  thumbnails.render()
 
   window.jQuery(".document-viewers").each((idx, element) => {
      const viewerSet = FiggyManifestManager.buildViewers(element)

--- a/app/javascript/orangelight/load-resources-by-bib-ids.js
+++ b/app/javascript/orangelight/load-resources-by-bib-ids.js
@@ -1,0 +1,45 @@
+
+import apollo from './graphql-client.js'
+import gql from 'graphql-tag'
+
+async function loadResourcesByBibIds(bibIds) {
+
+  const query = gql`
+    query GetResourcesByBibIds($bibIds: [String!]!) {
+      resourcesByBibids(bibIds: $bibIds) {
+         id,
+         thumbnail {
+           iiifServiceUrl,
+           thumbnailUrl
+         },
+         url,
+         members {
+           id
+         },
+         ... on ScannedResource {
+           manifestUrl,
+           sourceMetadataIdentifier
+         },
+         ... on ScannedMap {
+           manifestUrl,
+           sourceMetadataIdentifier
+         }
+      }
+    }`
+
+  const variables = {
+    bibIds: bibIds
+  }
+
+  try {
+    const response = await apollo.query({
+      query, variables
+    })
+    return response.data
+  } catch(err) {
+    console.error(err)
+    return null
+  }
+}
+
+export default loadResourcesByBibIds


### PR DESCRIPTION
Resolves #1534 (but is blocked by pulibrary/figgy/pull/2378)