### PR TITLE
Update figgy manifest manager to use orangelight_id graphql queries

### DIFF
--- a/app/javascript/orangelight/figgy_manifest_manager.js
+++ b/app/javascript/orangelight/figgy_manifest_manager.js
@@ -1,6 +1,6 @@
 
-import loadResourcesByBibId from './load-resources-by-bib-id'
-import loadResourcesByBibIds from './load-resources-by-bib-ids'
+import loadResourcesByOrangelightId from './load-resources-by-orangelight-id'
+import loadResourcesByOrangelightIds from './load-resources-by-orangelight-ids'
 
 class FiggyViewer {
   // There may be more than one ARK minted which resolves to the same manifested resource
@@ -105,7 +105,7 @@ class FiggyViewerSet {
       return null;
     }
 
-    const resources = data.resourcesByBibid
+    const resources = data.resourcesByOrangelightId
     return resources
   }
 
@@ -162,12 +162,12 @@ class FiggyThumbnailSet {
       return null;
     }
 
-    const resources = data.resourcesByBibids
+    const resources = data.resourcesByOrangelightIds
     this.resources = resources
 
     // Cache the thumbnail URLs
     for (let resource of this.resources) {
-      const bibId = resource.sourceMetadataIdentifier
+      const bibId = resource.orangelightId
       this.thumbnails[bibId] = resource.thumbnail
     }
     return this.resources
@@ -203,7 +203,7 @@ class FiggyThumbnailSet {
 class FiggyManifestManager {
 
   static buildThumbnailSet($elements) {
-    return new FiggyThumbnailSet($elements, loadResourcesByBibIds, window.jQuery)
+    return new FiggyThumbnailSet($elements, loadResourcesByOrangelightIds, window.jQuery)
   }
 
   // Build multiple viewers
@@ -212,7 +212,7 @@ class FiggyManifestManager {
     const bibId = $element.data('bib-id')
     const arks = $element.data('arks') || []
 
-    return new FiggyViewerSet(element, loadResourcesByBibId, bibId.toString(), arks, window.jQuery)
+    return new FiggyViewerSet(element, loadResourcesByOrangelightId, bibId.toString(), arks, window.jQuery)
   }
 }
 

--- a/app/javascript/orangelight/graphql-client.js
+++ b/app/javascript/orangelight/graphql-client.js
@@ -17,7 +17,8 @@ const fragmentMatcher = new IntrospectionFragmentMatcher({
           name: "Resource",
           possibleTypes: [
             { name: "ScannedResource" },
-            { name: "ScannedMap" }
+            { name: "ScannedMap" },
+            { name: "Coin" }
           ],
         },
       ],

--- a/app/javascript/orangelight/load-resources-by-orangelight-id.js
+++ b/app/javascript/orangelight/load-resources-by-orangelight-id.js
@@ -1,11 +1,11 @@
 import apollo from './graphql-client.js'
 import gql from 'graphql-tag'
 
-async function loadResourcesByBibId(bibId) {
+async function loadResourcesByOrangelightId(id) {
 
   const query = gql`
-    query GetResourcesByBibId($bibId: String!) {
-      resourcesByBibid(bibId: $bibId) {
+    query GetResourcesByOrangelightId($id: String!) {
+      resourcesByOrangelightId(id: $id) {
          id,
          thumbnail {
            iiifServiceUrl,
@@ -20,12 +20,15 @@ async function loadResourcesByBibId(bibId) {
          },
          ... on ScannedMap {
            manifestUrl
+         },
+         ... on Coin {
+           manifestUrl
          }
       }
     }`
 
   const variables = {
-    bibId: bibId
+    id: id
   }
 
   try {
@@ -39,4 +42,4 @@ async function loadResourcesByBibId(bibId) {
   }
 }
 
-export default loadResourcesByBibId
+export default loadResourcesByOrangelightId

--- a/app/javascript/orangelight/load-resources-by-orangelight-ids.js
+++ b/app/javascript/orangelight/load-resources-by-orangelight-ids.js
@@ -2,11 +2,11 @@
 import apollo from './graphql-client.js'
 import gql from 'graphql-tag'
 
-async function loadResourcesByBibIds(bibIds) {
+async function loadResourcesByOrangelightIds(ids) {
 
   const query = gql`
-    query GetResourcesByBibIds($bibIds: [String!]!) {
-      resourcesByBibids(bibIds: $bibIds) {
+    query GetResourcesByOrangelightIds($ids: [String!]!) {
+      resourcesByOrangelightIds(ids: $ids) {
          id,
          thumbnail {
            iiifServiceUrl,
@@ -18,17 +18,21 @@ async function loadResourcesByBibIds(bibIds) {
          },
          ... on ScannedResource {
            manifestUrl,
-           sourceMetadataIdentifier
+           orangelightId
          },
          ... on ScannedMap {
            manifestUrl,
-           sourceMetadataIdentifier
+           orangelightId
+         },
+         ... on Coin {
+           manifestUrl,
+           orangelightId
          }
       }
     }`
 
   const variables = {
-    bibIds: bibIds
+    ids: ids
   }
 
   try {
@@ -42,4 +46,4 @@ async function loadResourcesByBibIds(bibIds) {
   }
 }
 
-export default loadResourcesByBibIds
+export default loadResourcesByOrangelightIds

--- a/spec/views/catalog/show.html.erb_spec.rb
+++ b/spec/views/catalog/show.html.erb_spec.rb
@@ -43,6 +43,13 @@ RSpec.describe 'catalog/show' do
     end
   end
 
+  context 'when entries describe a coin', js: true do
+    xit 'will render a viewer when coins are in figgy production' do
+      visit 'catalog/coin-2'
+      expect(page).to have_selector('div#view')
+    end
+  end
+
   describe 'the location for physical holdings', js: true do
     context 'if physical holding information is recorded in the entry' do
       it 'is not rendered' do


### PR DESCRIPTION
Closes #1571 

![screenshot 2019-03-01 14 24 42](https://user-images.githubusercontent.com/784196/53668305-20a50980-3c39-11e9-8525-0ab04d65ad57.png)
![screenshot 2019-03-01 14 25 06](https://user-images.githubusercontent.com/784196/53668311-239ffa00-3c39-11e9-86b6-019f80f96a37.png)
