### PR TITLE
Updates bootstrap-sass to release 3.4.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,8 +58,8 @@ gem 'omniauth-cas'
 gem 'solr_wrapper', '~> 1.0'
 gem 'yajl-ruby', '>= 1.3.1', require: 'yajl'
 
-# rspec, just like jettywrapper appear necessary for cap currently
 gem 'babel-transpiler'
+gem 'bootstrap-sass', '~> 3.4'
 gem 'capybara'
 gem 'coveralls', require: false
 gem 'ddtrace'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
       io-like (~> 0.3.0)
     arel (8.0.0)
     ast (2.3.0)
-    autoprefixer-rails (9.4.3)
+    autoprefixer-rails (9.4.9)
       execjs
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -133,7 +133,7 @@ GEM
       blacklight (>= 6.0.2)
       jquery-rails
       rails (>= 3.0)
-    bootstrap-sass (3.4.0)
+    bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
     builder (3.2.3)
@@ -406,8 +406,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.0.0)
-      ffi (~> 1.9.6)
+    sassc (2.0.1)
+      ffi (~> 1.9)
       rake
     scrub_rb (1.0.1)
     sdoc (0.4.2)
@@ -512,6 +512,7 @@ DEPENDENCIES
   blacklight_advanced_search (~> 6.0)
   blacklight_range_limit (~> 6.3.2)
   blacklight_unapi!
+  bootstrap-sass (~> 3.4)
   borrow_direct!
   capistrano (~> 3.4.0)
   capistrano-rails (~> 1.1.6)


### PR DESCRIPTION
Ensures that the bootstrap-sass release is pinned to the 3.4.1 release.