### PR TITLE
disable autocorrect

### DIFF
--- a/app/views/advanced/_guided_search_fields.html.erb
+++ b/app/views/advanced/_guided_search_fields.html.erb
@@ -5,7 +5,7 @@
     <%= select_tag('f1', options_for_select(advanced_key_value, guided_field(:f1, 'all_fields')), :class=>"search_field") %>
     <div name="row1">
       <label for='q1' class='sr-only'>Advanced search terms</label>
-      <%= text_field_tag "q1", label_tag_default_for(:q1), :class => 'form-control', autocorrect: "off", autocapitalize: "off", spellcheck: "false" %>
+      <%= text_field_tag "q1", label_tag_default_for(:q1), :class => 'form-control', autocorrect: "off", autocapitalize: "off", autocomplete: "off", spellcheck: "false" %>
     </div>
   </div>
   <div class="search-operators" role="radiogroup" aria-label="Search operators">
@@ -18,7 +18,7 @@
     <%= select_tag('f2', options_for_select(advanced_key_value, guided_field(:f2, 'author')), :class=>"search_field") %>
     <div name="row2">
       <label for='q2' class='sr-only'>Advanced search terms - second parameter</label>
-      <%= text_field_tag "q2", label_tag_default_for(:q2), :class => 'form-control', autocorrect: "off", autocapitalize: "off", spellcheck: "false" %>
+      <%= text_field_tag "q2", label_tag_default_for(:q2), :class => 'form-control', autocorrect: "off", autocapitalize: "off", autocomplete: "off", spellcheck: "false" %>
     </div>
   </div>
   <div class="search-operators" role="radiogroup" aria-label="Search operators">

--- a/app/views/catalog/_search_form.html.erb
+++ b/app/views/catalog/_search_form.html.erb
@@ -13,7 +13,7 @@
       <% end %>
       <span class="input-group">
         <label for="q" class="sr-only"><%= t('blacklight.search.form.search.label') %></label>
-        <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search_q q form-control", id: "q", autofocus: should_autofocus_on_search_box?, autocomplete: 'off', data: { autocomplete_enabled: autocomplete_enabled?, autocomplete_path: blacklight.suggest_index_path }  %>
+        <%= text_field_tag :q, params[:q], placeholder: t('blacklight.search.form.search.placeholder'), class: "search_q q form-control", id: "q", autofocus: should_autofocus_on_search_box?, autocorrect: "off", autocapitalize: "off", autocomplete: "off", data: { autocomplete_enabled: autocomplete_enabled?, autocomplete_path: blacklight.suggest_index_path }  %>
 
         <span class="input-group-btn">
           <button type="submit" class="btn btn-primary search-btn" id="search">


### PR DESCRIPTION
Closes #1591. 
Makes the regular and advanced search consistent: autocorrect, autocomplete, autocapitalize off