### PR TITLE
alternative coin format icon

### DIFF
--- a/app/assets/stylesheets/icons/icons.scss
+++ b/app/assets/stylesheets/icons/icons.scss
@@ -183,7 +183,7 @@
 .icon-coin,
 .blacklight-coin .document-thumbnail .default {
     &:before {
-        content: $icon-coins-stack;
+        content: $icon-coins-flat;
     }
 }
 .icon-external {


### PR DESCRIPTION
An attempt to address #1604. I think we can do better than this, but the icon is simpler than the coin stack:
<img width="388" alt="Screen Shot 2019-03-22 at 4 13 34 PM" src="https://user-images.githubusercontent.com/4650153/54828838-b6263d00-4cbd-11e9-8db8-4458fc35741f.png">
