### PR TITLE
Locator firestone no cn

### DIFF
--- a/app/services/stackmap_location_factory.rb
+++ b/app/services/stackmap_location_factory.rb
@@ -12,7 +12,7 @@ class StackmapLocationFactory
   # @param library [String] the library in which the holding is located
   # @return [Boolean] Exclude stackmap url if return value is true
   def exclude?(call_number:, library:)
-    excluded?(library) || call_number.nil?
+    excluded?(library) || call_number?(call_number, library)
   end
 
   private
@@ -29,5 +29,11 @@ class StackmapLocationFactory
         'Rare Books and Special Collections',
         'ReCAP'
       ].include?(library)
+    end
+
+    # Exclude the stackmap link for records without call numbers,
+    # unless they are in Firestone (other locator works without a call number)
+    def call_number?(call_number, library)
+      call_number.nil? && library != 'Firestone Library'
     end
 end

--- a/app/services/stackmap_service.rb
+++ b/app/services/stackmap_service.rb
@@ -33,7 +33,7 @@ class StackmapService
       if by_title_locations.include? @loc
         @document['title_display']
       else
-        @cn || @document['call_number_browse_s'].first
+        @cn || @document['call_number_browse_s']&.first
       end
     end
 

--- a/spec/helpers/locations_spec.rb
+++ b/spec/helpers/locations_spec.rb
@@ -4,18 +4,21 @@ require 'rails_helper'
 
 RSpec.describe ApplicationHelper do
   describe '#locate_url helper method' do
-    let(:stackmap_location) { 'f' }
+    let(:stackmap_location) { 'mus' }
+    let(:locator_location) { 'f' }
     let(:stackmap_ineligible_location) { 'annexa' }
     let(:bib) { { id: '123456' } }
     let(:call_number) { 'RCPXR-6136516' }
-    let(:stackmap_library) { 'Firestone' }
+    let(:locator_library) { 'Firestone Library' }
+    let(:stackmap_library) { 'Mendel Music Library' }
     let(:stackmap_ineligible_library) { 'Fine Annex' }
 
+    before { stub_holding_locations }
+
     it 'Returns a Stackmap Link for a Mapping Location' do
-      stub_holding_locations
-      stackmap_link = locate_url(stackmap_location, bib, call_number, stackmap_library)
+      stackmap_link = locate_url(locator_location, bib, call_number, locator_library)
       expect(stackmap_link).to be_truthy
-      expect(stackmap_link).to include("?loc=#{stackmap_location}&id=#{bib[:id]}")
+      expect(stackmap_link).to include("?loc=#{locator_location}&id=#{bib[:id]}")
     end
 
     it 'Does not return a stackmap link for an inaccessible location' do
@@ -26,6 +29,11 @@ RSpec.describe ApplicationHelper do
     it 'Does not return a stackmap link when there is no call number' do
       stackmap_link = locate_url(stackmap_location, bib, nil, stackmap_library)
       expect(stackmap_link).to be_nil
+    end
+
+    it 'Returns a locator link when there is no call number for Firestone' do
+      locator_link = locate_url(locator_location, bib, nil, locator_library)
+      expect(locator_link).to include("?loc=#{locator_location}&id=#{bib[:id]}")
     end
   end
 

--- a/spec/services/stackmap_service_spec.rb
+++ b/spec/services/stackmap_service_spec.rb
@@ -7,12 +7,13 @@ RSpec.describe StackmapService::Url do
 
   let(:url_service) { described_class.new(document: document, loc: location, cn: call_number) }
   let(:document) { SolrDocument.new(properties) }
+  let(:doc_cn) { ['doc call number'] }
   let(:call_number) { nil }
   let(:properties) do
     {
       id: '1234567',
       title_display: 'Title',
-      call_number_browse_s: ['doc call number']
+      call_number_browse_s: doc_cn
     }
   end
 
@@ -34,6 +35,20 @@ RSpec.describe StackmapService::Url do
         expect(subject).to eq("https://library.princeton.edu/locator/index.php?loc=#{location}&id=#{properties[:id]}&embed=true")
       end
     end
+
+    describe 'firestone, doc has no call number' do
+      let(:location) { 'f' }
+      let(:doc_cn) { nil }
+
+      it 'resolves to embeded firestone locator with loc and bibid' do
+        expect(subject).to eq("https://library.princeton.edu/locator/index.php?loc=#{location}&id=#{properties[:id]}&embed=true")
+      end
+
+      it 'preferred_callno returns nil' do
+        expect(url_service.preferred_callno).to be_nil
+      end
+    end
+
     describe 'mendel, call number provided' do
       let(:location) { 'mus' }
       let(:call_number) { 'Q43.2' }
@@ -55,6 +70,7 @@ RSpec.describe StackmapService::Url do
         expect(subject).to include({ callno: properties[:call_number_browse_s].first }.to_query)
       end
     end
+
     describe 'by title location' do
       let(:location) { 'sprps' }
 


### PR DESCRIPTION
Closes #1619 and closes #1618.
Locator link displays and catalog stackmap route renders when call number is missing:
https://catalog-staging.princeton.edu/catalog/3337382/
https://catalog-staging.princeton.edu/catalog/3337382/stackmap?loc=prne