### PR TITLE
Adds monogram display for coins

### DIFF
--- a/app/assets/javascripts/figgy.es6
+++ b/app/assets/javascripts/figgy.es6
@@ -3,6 +3,9 @@ window.jQuery(document).ready(() => {
   const $elements = window.jQuery(".document-thumbnail[data-bib-id]")
   const thumbnails = FiggyManifestManager.buildThumbnailSet($elements)
   thumbnails.render()
+  const $monogramIds = window.jQuery("p[data-monogram-id]")
+  const monograms = FiggyManifestManager.buildMonogramThumbnails($monogramIds)
+  monograms.renderMonogram()
 
   window.jQuery(".document-viewers").each((idx, element) => {
      const viewerSet = FiggyManifestManager.buildViewers(element)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -141,6 +141,7 @@ class CatalogController < ApplicationController
 
     # Numismatics facets
     config.add_facet_field 'issue_number_s', label: 'Issue', show: false
+    config.add_facet_field 'issue_monogram_title_s', label: 'Monogram', show: false
     config.add_facet_field 'issue_references_s', label: 'References', show: false
     config.add_facet_field 'accession_info_s', label: 'Accession info', show: false
     config.add_facet_field 'analysis_s', label: 'Analysis', show: false

--- a/app/javascript/orangelight/load-resources-by-figgy-ids.js
+++ b/app/javascript/orangelight/load-resources-by-figgy-ids.js
@@ -1,0 +1,32 @@
+import apollo from './graphql-client.js'
+import gql from 'graphql-tag'
+
+async function loadResourcesByFiggyIds(ids) {
+
+  const query = gql`
+    query GetResourcesByFiggyIds($ids: [ID!]!) {
+      resourcesByFiggyIds(ids: $ids) {
+         id,
+         thumbnail {
+           iiifServiceUrl,
+           thumbnailUrl
+         }
+      }
+    }`
+
+  const variables = {
+    ids: ids
+  }
+
+  try {
+    const response = await apollo.query({
+      query, variables
+    })
+    return response.data
+  } catch(err) {
+    console.error(err)
+    return null
+  }
+}
+
+export default loadResourcesByFiggyIds

--- a/app/views/catalog/_show_sidebar.html.erb
+++ b/app/views/catalog/_show_sidebar.html.erb
@@ -2,6 +2,12 @@
   <div class="default"></div>
 <% end %>
 
+<% if monograms = @document['issue_monogram_1display'] %>
+  <h3> Monograms </h3>
+  <% JSON.parse(monograms).each do |monogram,_v| %>
+    <%= content_tag(:p, link_to(monogram['title'], "/?f[issue_monogram_title_s][]=#{CGI.escape monogram['title']}", class: 'search-name', 'data-toggle' => 'tooltip', 'data-original-title' => "Search: #{monogram['title']}", title: "Search: #{monogram['title']}"), data: { 'monogram-id' => monogram['document_id']}) %>
+  <% end %>
+<% end %>
 <% unless @document.more_like_this.empty? %>
   <div class="panel panel-default">
     <div class="panel-heading">More Like This</div>

--- a/spec/fixtures/current_fixtures.json
+++ b/spec/fixtures/current_fixtures.json
@@ -21996,5 +21996,116 @@
         "weight_s": [
             "8.26"
         ]
-    }
+    },
+    {
+"id": "coin-1167",
+"title_display": "Coin: 1167",
+"pub_created_display": "shekel, Tyre",
+"access_facet": [
+"Online",
+"In the Library"
+],
+"call_number_display": [
+"Coin 1167"
+],
+"call_number_browse_s": [
+"Coin 1167"
+],
+"location_code_s": [
+"num"
+],
+"location": [
+"Rare Books and Special Collections"
+],
+"location_display": [
+"Rare Books and Special Collections - Numismatics Collection"
+],
+"format": [
+"Coin"
+],
+"advanced_location_s": [
+"num"
+],
+"find_place_s": [
+null
+],
+"die_axis_s": [
+12
+],
+"size_s": [
+"29"
+],
+"weight_s": [
+"13.86"
+],
+"holdings_1display": "{\"numismatics\":{\"location\":\"Rare Books and Special Collections - Numismatics Collection\",\"library\":\"Rare Books and Special Collections\",\"location_code\":\"num\",\"call_number\":\"Coin 1167\",\"call_number_browse\":\"Coin 1167\"}}",
+"pub_date_start_sort": -79,
+"pub_date_end_sort": -78,
+"issue_object_type_s": [
+"coin"
+],
+"issue_denomination_s": [
+"shekel"
+],
+"issue_denomination_sort": "shekel",
+"issue_number_s": "616",
+"issue_metal_s": [
+"silver"
+],
+"issue_metal_sort": "silver",
+"issue_era_s": [
+"Phoenician Era of Alexander"
+],
+"issue_ruler_s": [
+null
+],
+"issue_master_s": [
+null
+],
+"issue_place_s": [
+"Tyre, Phoenicia, Syria"
+],
+"issue_place_sort": "Tyre, Phoenicia, Syria",
+"issue_obverse_figure_s": [
+"Melqarth"
+],
+"issue_obverse_part_s": [
+"bust"
+],
+"issue_obverse_orientation_s": [
+"right"
+],
+"issue_obverse_figure_description_s": [
+"with side burns, laureate, wearing lion skin knotted around neck; border of dots."
+],
+"issue_reverse_figure_s": [
+"eagler"
+],
+"issue_reverse_part_s": [
+"standing"
+],
+"issue_reverse_orientation_s": [
+"left"
+],
+"issue_reverse_figure_description_s": [
+"with r. foot on beak of ship and palm branch over r. shoulder; l.  date and club, between legs Phoenician letter, r. monogram or letter; border of dots."
+],
+"issue_reverse_legend_s": [
+"ΤΥΡΟΥΙΕΡΑΣ ΚΑΙΑΣΥΛΟΥ"
+],
+"issue_reverse_attributes_s": [
+"a37, Phoenician Letter",
+"a1167, Archaic Monogram"
+],
+"issue_references_s": [
+"BMC.Phoen Tyre 140",
+"Sear  5191v"
+],
+"issue_references_sort": "BMC.Phoen Tyre 140",
+"issue_monogram_title_s": [
+"Archaic Monogram",
+"Phoenician Letter"
+],
+"issue_monogram_1display": "[{\"title\":\"Archaic Monogram\",\"document_id\":\"989fab88-4b19-46c1-8e84-91ea058b2eb6\"},{\"title\":\"Phoenician Letter\",\"document_id\":\"c8a827ac-f7c4-4c77-864c-0a7ff4bb3033\"}]"
+}
 ]

--- a/spec/views/catalog/show.html.erb_spec.rb
+++ b/spec/views/catalog/show.html.erb_spec.rb
@@ -50,6 +50,19 @@ RSpec.describe 'catalog/show' do
     end
   end
 
+  context 'for coins with monograms' do
+    xit 'will render a monogram thumbnail with figgy production coins', js: true do
+      visit 'catalog/coin-1167'
+      expect(page).to have_selector('div#view')
+    end
+
+    it 'displays each monogram label with link to search' do
+      visit 'catalog/coin-1167'
+      expect(page).to have_link('Archaic Monogram', href: '/?f[issue_monogram_title_s][]=Archaic+Monogram')
+      expect(page).to have_link('Phoenician Letter', href: '/?f[issue_monogram_title_s][]=Phoenician+Letter')
+    end
+  end
+
   describe 'the location for physical holdings', js: true do
     context 'if physical holding information is recorded in the entry' do
       it 'is not rendered' do


### PR DESCRIPTION
Co-authored-by: Christina Chortaria <actspatial@gmail.com>

Similar to #1589, coins need to be in production figgy for monogram spec to pass. Closes #1616.

Screenshot (note that the weird white-space of the monogram thumbnails is contained in the monogram image files themselves)
<img width="866" alt="Screen Shot 2019-05-20 at 12 55 24 PM" src="https://user-images.githubusercontent.com/4650153/58038668-944f0800-7afe-11e9-82e5-f808b177caf7.png">
