### PR TITLE
update chrome on ci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,17 @@ jobs:
           name: Install dependencies
           command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs 4 --retry 3
 
-      - run: sudo apt update && sudo apt install postgresql-client phantomjs
+      - run: sudo apt update
+
+      - run:
+          name: Install Chrome
+          command: |
+            wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+            sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+            sudo apt-get update
+            sudo apt-get -y install google-chrome-stable
+
+      - run: sudo apt install postgresql-client phantomjs
 
       - save_cache:
           key: orangelight-{{ checksum "Gemfile.lock" }}


### PR DESCRIPTION
Hopefully addresses:
```
 Selenium::WebDriver::Error::SessionNotCreatedError:
        session not created: This version of ChromeDriver only supports Chrome version 74
          (Driver info: chromedriver=74.0.3729.6 (255758eccf3d244491b8a1317aa76e1ce10d57e9-refs/branch-heads/3729@{#29}),platform=Linux 4.15.0-1035-aws x86_6
```