### PR TITLE
honeybadger alerts for rake tasks

### DIFF
--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -1,3 +1,3 @@
 
 exceptions:
-  rake_rescue: true
+  rescue_rake: true


### PR DESCRIPTION
We had a typo in the honeybadger config to send alerts for rake tasks: https://docs.honeybadger.io/lib/ruby/support/troubleshooting.html#a-rake-task-is-running-in-a-local-terminal

Closes #1652 