### PR TITLE
Don't allow emails if not logged in.

### DIFF
--- a/app/controllers/concerns/orangelight/catalog.rb
+++ b/app/controllers/concerns/orangelight/catalog.rb
@@ -49,6 +49,18 @@ module Orangelight
       end
     end
 
+    def validate_email_params
+      if current_user.nil?
+        flash[:error] = 'You must be logged in to send an email.'
+      elsif params[:to].blank?
+        flash[:error] = I18n.t('blacklight.email.errors.to.blank')
+      elsif !params[:to].match(Blacklight::Engine.config.email_regexp)
+        flash[:error] = I18n.t('blacklight.email.errors.to.invalid', to: params[:to])
+      end
+
+      flash[:error].blank?
+    end
+
     def user_email
       return current_user.email if current_or_guest_user.provider == 'cas'
     end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -10,10 +10,6 @@ RSpec.describe CatalogController do
     before do
       ActionMailer::Base.deliveries.clear
     end
-    it "doesn't send reply-to when not logged in" do
-      post :email, params: { id: '9741216', to: 'test@test.com' }
-      expect(email.reply_to).to eq []
-    end
     it 'sends reply-to when logged in as a CAS user' do
       sign_in user
 
@@ -22,8 +18,15 @@ RSpec.describe CatalogController do
       expect(email.reply_to).to eq [user.email]
     end
     it 'supports a user-submitted subject line' do
+      sign_in user
+
       post :email, params: { id: '9741216', to: 'test@test.com', subject: ['Subject'] }
       expect(email.subject).to eq 'Subject'
+    end
+    it 'does not send an email if not logged in' do
+      post :email, params: { id: '9741216', to: 'test@test.com' }
+
+      expect(email).to be_nil
     end
   end
   describe '#online_holding_note?' do


### PR DESCRIPTION
The form was protected before, this protects the action.