### PR TITLE
remove pulsearch urls

### DIFF
--- a/app/models/concerns/blacklight/document/dublin_core.rb
+++ b/app/models/concerns/blacklight/document/dublin_core.rb
@@ -48,7 +48,7 @@ module Blacklight
                  'xmlns:rdf' => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
                  'xmlns:dc' => 'http://purl.org/dc/elements/1.1/',
                  'xmlns:xsi' => 'http://www.w3.org/2001/XMLSchema-instance') do
-          xml.tag!('rdf:Description', 'rdf:about' => "https://pulsearch.princeton.edu/catalog/#{id}") do
+          xml.tag!('rdf:Description', 'rdf:about' => "https://catalog.princeton.edu/catalog/#{id}") do
             to_semantic_values.select { |field, _values| dublin_core_field_name? field }.each do |field, values|
               Array.wrap(values).each do |v|
                 xml.tag! "dc:#{field}", v

--- a/app/models/concerns/blacklight/solr/document/marc.rb
+++ b/app/models/concerns/blacklight/solr/document/marc.rb
@@ -183,7 +183,7 @@ module Blacklight
             # canonical identifier for the citation?
             ctx.referent.add_identifier("https://bibdata.princeton.edu/bibliographic/#{id}")
             # add pulsearch refererrer
-            ctx.referrer.add_identifier('info:sid/pulsearch.princeton.edu:generator')
+            ctx.referrer.add_identifier('info:sid/catalog.princeton.edu:generator')
             ctx.referent.add_identifier("info:oclcnum/#{self['oclc_s'].first}") unless self['oclc_s'].nil?
             ctx.referent.add_identifier("info:lccn/#{self['lccn_s'].first}") unless self['lccn_s'].nil?
             ctx

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -22,6 +22,6 @@
     <li><strong>New Features and Fixes.</strong> The aforementioned community is always refining and adding new features to Blacklight. When a feature does not exist in the application or something is broken, we are able to build or fix it without having to wait for a vendor to do it for us.</li>
   </ul>
 
-  <p>We will continue to update and refine this service based on feedback from the Princeton community. If you notice something wrong, or think something could be improved, please <a href="https://pulsearch.princeton.edu/feedback">send us feedback</a>.</p>
+  <p>We will continue to update and refine this service based on feedback from the Princeton community. If you notice something wrong, or think something could be improved, please <a href="https://catalog.princeton.edu/feedback">send us feedback</a>.</p>
 
 </div>

--- a/config/robots.yml
+++ b/config/robots.yml
@@ -1,6 +1,6 @@
 # Configuration file for generation robots.txt
 defaults: &defaults
-  sitemap_url: https://pulsearch.princeton.edu/sitemap.xml.gz
+  sitemap_url: https://catalog.princeton.edu/sitemap.xml.gz
   disallowed_paths:
     - '/*?q=*'
     - '/*?f*'

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,6 @@
 User-agent: *
 Crawl-delay: 10
-Sitemap: https://pulsearch.princeton.edu/sitemap.xml.gz
+Sitemap: https://catalog.princeton.edu/sitemap.xml.gz
 Disallow: /*?q=*
 Disallow: /*?f*
 Disallow: /requests

--- a/spec/services/robots_generator_service_spec.rb
+++ b/spec/services/robots_generator_service_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe RobotsGeneratorService do
       expect(service_class).to have_received(:new).with(path: path, disallowed_paths: disallowed_paths)
       expect(service).to have_received(:insert_group).with(user_agent: '*')
       expect(service).to have_received(:insert_crawl_delay).with(10)
-      expect(service).to have_received(:insert_sitemap).with('https://pulsearch.princeton.edu/sitemap.xml.gz')
+      expect(service).to have_received(:insert_sitemap).with('https://catalog.princeton.edu/sitemap.xml.gz')
       expect(service).to have_received(:generate)
       expect(service).to have_received(:write)
     end


### PR DESCRIPTION
I found some stray instances of pulsearch.princeton.edu urls in the site, most notably referred to in the [robots.txt](https://catalog.princeton.edu/robots.txt)