### PR TITLE
1725 update facets menu bs4

### DIFF
--- a/app/assets/stylesheets/components/facets.scss
+++ b/app/assets/stylesheets/components/facets.scss
@@ -155,3 +155,11 @@ a.more_facets_link {
 .facets .facets-heading {
   margin: 1em 0 0.5em;
 }
+
+.facet-limit {
+  margin-bottom: $spacer;
+
+  .card-body {
+    padding: $spacer;
+  }
+}

--- a/app/assets/stylesheets/variables/typography.scss
+++ b/app/assets/stylesheets/variables/typography.scss
@@ -5,3 +5,5 @@ $font-mono: 'Lucida Console', Monaco, monospace !default;
 $text-color: #000 !default;
 
 $text-small: 12px;
+
+$spacer: 0.5rem;

--- a/app/views/catalog/_facet_layout.html.erb
+++ b/app/views/catalog/_facet_layout.html.erb
@@ -1,12 +1,10 @@
-<div class="panel panel-default facet_limit blacklight-<%= facet_field.key.parameterize %> <%= 'facet_limit-active' if facet_field_in_params?(facet_field.key) %>">
-  <div class="<%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle panel-heading" data-toggle="collapse" data-target="#<%= facet_field_id(facet_field) %>">
-    <h3 class="panel-title facet-field-heading">
-
-      <%= link_to facet_field_label(facet_field.key), "#", :"data-no-turbolink" => true %>
-    </h3>
+<div class="card facet-limit blacklight-<%= facet_field.key.parameterize %> <%= 'facet_limit-active' if facet_field_in_params?(facet_field.key) %>">
+  <div class="card-header <%= "collapsed" if should_collapse_facet?(facet_field) %> collapse-toggle facet-field-heading" aria-expanded="false" data-toggle="collapse" data-target="#<%= facet_field_id(facet_field) %>">
+    <%= link_to facet_field_label(facet_field.key), "#", :"data-no-turbolink" => true %>
   </div>
-  <div id="<%= facet_field_id(facet_field) %>" class="panel-collapse facet-content <%= should_collapse_facet?(facet_field) ? 'collapse' : 'in' %>">
-    <div class="panel-body">
+
+  <div id="<%= facet_field_id(facet_field) %>" class="panel-collapse facet-content <%= should_collapse_facet?(facet_field) ? 'collapse' : 'show' %>">
+    <div class="card card-body">
       <%= yield %>
     </div>
   </div>

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -1,10 +1,10 @@
 <% # main container for facets/limits menu -%>
 <% if has_facet_values?  %>
-<div id="facets" class="facets sidenav">
+<div id="facets" class="facets sidenav facets-toggleable">
 
   <div class="top-panel-heading panel-heading">
-    <button type="button" class="facets-toggle" data-toggle="collapse" data-target="#facet-panel-collapse">
-      <span class="sr-only">Toggle facets</span>
+    <button type="button" class="navbar-toggler navbar-toggler-right" data-toggle="collapse" data-target="#facet-panel-collapse">
+      <span class="d-none">Toggle facets</span>
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>
       <span class="icon-bar"></span>
@@ -15,7 +15,7 @@
     </h2>
   </div>
 
-  <div id="facet-panel-collapse" class="collapse panel-group">
+  <div id="facet-panel-collapse" class="facets-collapse collapse">
     <%= has_search_parameters? ? render_facet_partials : render_home_facets %>
   </div>
 </div>

--- a/app/views/catalog/_facets.html.erb
+++ b/app/views/catalog/_facets.html.erb
@@ -1,18 +1,15 @@
 <% # main container for facets/limits menu -%>
 <% if has_facet_values?  %>
-<div id="facets" class="facets sidenav facets-toggleable">
+<div id="facets" class="facets sidenav facets-toggleable-sm">
 
-  <div class="top-panel-heading panel-heading">
-    <button type="button" class="navbar-toggler navbar-toggler-right" data-toggle="collapse" data-target="#facet-panel-collapse">
-      <span class="d-none">Toggle facets</span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-      <span class="icon-bar"></span>
-    </button>
-
+  <div class="navbar">
     <h2 class='facets-heading'>
       <%= t('blacklight.search.facets.title') %>
     </h2>
+    <button type="button" class="navbar-toggler" data-toggle="collapse" data-target="#facet-panel-collapse">
+      <span class="d-none">Toggle facets</span>
+      <span class="navbar-toggler-icon"></span>
+    </button>
   </div>
 
   <div id="facet-panel-collapse" class="facets-collapse collapse">

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,11 +1,11 @@
 <%= render 'constraints' %>
 <%= render 'did_you_mean' %>
 
-<div id="sidebar" class="col-md-4 col-sm-5">
+<div id="sidebar" class="col-12 col-md-5 col-lg-4">
   <%= render 'search_sidebar' %>
 </div>
 
-<div id="content" class="col-md-8 col-sm-7">
+<div id="content" class="col-12 col-md-7 col-lg-8">
   <% unless has_search_parameters? %>
     <%# if there are no input/search related params, display the "home" partial -%>
     <%= render 'home' %>


### PR DESCRIPTION
closes #1725 
   -cards instead of panels
   -updates layout to be compatible with BS4
   -fixes toggle button for xs sm screens
   -in the index view button moves up one level the grid: for example md-4 becomes lg-4 to be compatible with BS4
   -updates the space between the facet cards