### PR TITLE
Bl7 show page errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -52,6 +52,7 @@ Metrics/ClassLength:
     - 'app/controllers/catalog_controller.rb'
     - 'app/controllers/orangelight/browsables_controller.rb'
     - 'app/controllers/account_controller.rb'
+    - 'app/services/holding_requests_adapter.rb'
     - 'app/services/physical_holdings_markup_builder.rb'
     - 'lib/orangelight/voyager_patron_client.rb'
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -126,7 +126,7 @@ module ApplicationHelper
       else
         args[:document][args[:field]]
       end
-    args[:document][args[:field]] = series_display.join(', ')
+    series_display.join(', ')
   end
 
   # Retrieve the same series for that one being displayed
@@ -341,7 +341,7 @@ module ApplicationHelper
       all_links = all_links.map.with_index { |l, i| content_tag(:li, l, dir: dirtags[i]) }
       all_links = content_tag(:ul, all_links.join.html_safe)
     end
-    args[:document][args[:field]] = all_links
+    all_links
   end
 
   def format_icon(args)

--- a/app/views/catalog/librarian_view.html.erb
+++ b/app/views/catalog/librarian_view.html.erb
@@ -1,3 +1,4 @@
+<% @document = SolrDocument.new(id: params[:id]) %>
 <div class="pagination-search-widgets">
     <div class="col-md-12">
     <%= link_to "Back to item", solr_document_path(@document), :class => "btn btn-default" %>

--- a/spec/services/holding_requests_adapter_spec.rb
+++ b/spec/services/holding_requests_adapter_spec.rb
@@ -82,9 +82,9 @@ RSpec.describe HoldingRequestsAdapter do
           '671798' => { 'items' => [{ 'holding_id' => '671798', 'enumeration' => 'Oct., 1977- Mar., 1978', 'id' => '1118538', 'use_statement' => 'In Library Use', 'status_at_load' => 'Available', 'barcode' => '33433004579631', 'copy_number' => '1', 'cgc' => 'Open', 'collection_code' => 'NA' }] }
         }
       end
+      let(:document) { { 'holdings_1display' => holdings_hash.to_json } }
 
       it 'returns an empty array' do
-        allow(holdings).to receive(:doc_holdings).and_return(holdings_hash)
         expect(holdings.doc_holdings_elf).to be_empty
       end
     end
@@ -98,9 +98,9 @@ RSpec.describe HoldingRequestsAdapter do
           '671798' => { 'items' => [{ 'holding_id' => '671798', 'enumeration' => 'Oct., 1977- Mar., 1978', 'id' => '1118538', 'use_statement' => 'In Library Use', 'status_at_load' => 'Available', 'barcode' => '33433004579631', 'copy_number' => '1', 'cgc' => 'Open', 'collection_code' => 'NA' }] }
         }
       end
+      let(:document) { { 'holdings_1display' => holdings_hash.to_json } }
 
       it 'returns an empty array' do
-        allow(holdings).to receive(:doc_holdings).and_return(holdings_hash)
         expect(holdings.doc_holdings_physical).to be_empty
       end
     end


### PR DESCRIPTION
 - Restores name-title hierarchical search links in show page. Closes #1752.
 - Allows Staff view to render without erroring.
 - Allows series searches to perform without erroring.