### PR TITLE
Removes deprecated libraryh3lp chat

### DIFF
--- a/app/assets/stylesheets/components/ask-a-librarian.scss
+++ b/app/assets/stylesheets/components/ask-a-librarian.scss
@@ -21,39 +21,3 @@
     }
   }
 }
-
-.libraryh3lp {
-  .button--libraryh3lp {
-    border: 0;
-    border-radius: 3px;
-    display: inline-block;
-    font-family: $font-serif;
-    font-size: 0.75rem;
-    font-style: italic;
-    font-weight: bold;
-    margin-left: 1em;
-    padding: 3px 7px;
-    position: relative;
-    text-decoration: none;
-    text-shadow: none;
-    top: -2px;
-  }
-}
-
-.button--libraryh3lp__online {
-  background-color: $yellow-light;
-  color: $black;
-
-  &:hover {
-    background: darken($yellow-light, 7%);
-  }
-}
-
-.button--libraryh3lp__offline {
-  background: $light-gray;
-  color: $gray-dark;
-
-  &:hover {
-    background: darken($light-gray, 7%);
-  }
-}

--- a/app/views/shared/_ask_librarian.html.erb
+++ b/app/views/shared/_ask_librarian.html.erb
@@ -6,16 +6,5 @@
     </li>
     <li class="help-link">
       <%= link_to "Ask a librarian", "https://library.princeton.edu/help/ask-a-librarian", class: "icon-chat" %>
-      <span class="needs-js" style="display: none;"></span>
-      <span class="libraryh3lp" jid="libchatpul-main@chat.libraryh3lp.com" style="display: none;"><a class="button--libraryh3lp button--libraryh3lp__online get-help-link" href="https://library.princeton.edu/help/ask-a-librarian"> Online now</a></span>
-      <span class="libraryh3lp" style=""><a class="button--libraryh3lp button--libraryh3lp__offline get-help-link" href="https://library.princeton.edu/help/ask-a-librarian"> Offline now</a></span>
     </li>
 </div>
-
-<script type="text/javascript">
-  (function() {
-    var x = document.createElement("script"); x.type = "text/javascript"; x.async = true;
-    x.src = (document.location.protocol === "https:" ? "https://" : "http://") + "libraryh3lp.com/js/libraryh3lp.js?multi,poll";
-    var y = document.getElementsByTagName("script")[0]; y.parentNode.insertBefore(x, y);
-  })();
-</script>


### PR DESCRIPTION
https://catalog.princeton.edu/help still has a link to the old chat tool we no longer use. This removes  the deprecated libraryh3lp chat.