### PR TITLE
Fix specs 2

### DIFF
--- a/app/assets/javascripts/availability.js.coffee.erb
+++ b/app/assets/javascripts/availability.js.coffee.erb
@@ -280,7 +280,7 @@ class AvailabilityUpdater
       location = availability_info['location']
     map_url = "/catalog/#{record_id}/stackmap?loc=#{location}"
     link = "<a title='Where to find it' class='find-it' data-location-map='#{location}' data-blacklight-modal='trigger' href='#{map_url}'>"
-    marker_span = "<span class='glyphicon glyphicon-map-marker'></span>"
+    marker_span = "<span class='fa fa-map-marker'></span>"
     if marker_only
       link = "#{link}#{marker_span}</a>"
     else

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -25,10 +25,6 @@ class CatalogController < ApplicationController
     redirect_to '/', flash: { error: 'The start year must be before the end year.' }
   end
 
-  rescue_from ActionController::BadRequest do
-    redirect_to '/', flash: { error: 'This is not a valid request.' }
-  end
-
   configure_blacklight do |config|
     config.raw_endpoint.enabled = true
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,7 +70,7 @@ module ApplicationHelper
     if link.nil?
       ''
     else
-      ' ' + link_to('<span class="glyphicon glyphicon-map-marker" aria-hidden="true"></span>'.html_safe, stackmap_url, title: t('blacklight.holdings.stackmap'), class: 'find-it', 'data-map-location' => location.to_s, 'data-blacklight-modal' => 'trigger', 'aria-label' => 'Where to find it')
+      ' ' + link_to('<span class="fa fa-map-marker" aria-hidden="true"></span>'.html_safe, stackmap_url, title: t('blacklight.holdings.stackmap'), class: 'find-it', 'data-map-location' => location.to_s, 'data-blacklight-modal' => 'trigger', 'aria-label' => 'Where to find it')
     end
   end
 

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -6,31 +6,6 @@ module BlacklightHelper
   include Blacklight::BlacklightHelperBehavior
   require './lib/orangelight/string_functions'
 
-  # (see Blacklight::SearchHelper#search_results)
-
-  # raise a BadRequest error if ActionController params have key with leading or trailing whitespaces
-  def user_params_valid(params)
-    params.each { |k| raise ActionController::BadRequest if ((k[0].match?(/\s/) || k[-1].match?(/\s/)) && (k.is_a? String)) == true }
-  end
-
-  def search_results(user_params)
-    user_params_valid(user_params)
-
-    builder = search_builder.with(user_params)
-    builder.page = user_params[:page] if user_params[:page]
-    builder.rows = (user_params[:per_page] || user_params[:rows]) if user_params[:per_page] || user_params[:rows]
-    builder = yield(builder) if block_given?
-    response = repository.search(builder)
-
-    if response.grouped? && grouped_key_for_results
-      [response.group(grouped_key_for_results), []]
-    elsif response.grouped? && response.grouped.length == 1
-      [response.grouped.first, []]
-    else
-      [response, response.documents]
-    end
-  end
-
   def json_field?(field)
     field[:hash]
   end

--- a/app/services/physical_holdings_markup_builder.rb
+++ b/app/services/physical_holdings_markup_builder.rb
@@ -27,7 +27,7 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
     stackmap_url << "&cn=#{call_number}" if call_number
 
     child = %(<span class="link-text">#{I18n.t('blacklight.holdings.stackmap')}</span>\
-      <span class="glyphicon glyphicon-map-marker" aria-hidden="true"></span>)
+      <span class="fa fa-map-marker" aria-hidden="true"></span>)
     markup = link_to(child.html_safe, stackmap_url,
                      title: I18n.t('blacklight.holdings.stackmap'),
                      class: 'find-it',

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -41,4 +41,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  config.middleware.use Orangelight::Middleware::InvalidParameterHandler
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,4 +105,5 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+  config.middleware.use Orangelight::Middleware::InvalidParameterHandler
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,5 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+  config.middleware.use Orangelight::Middleware::InvalidParameterHandler
 end

--- a/spec/features/request_options_spec.rb
+++ b/spec/features/request_options_spec.rb
@@ -11,9 +11,10 @@ describe 'Request Options' do
     end
 
     it 'does not display a request button', unless: in_ci? do
-      sleep 5.seconds
-      expect(page.all('.location--holding').length).to eq 1
-      expect(page).not_to have_selector('.location-services.service-conditional')
+      using_wait_time 5 do
+        expect(page.all('.holding-block').length).to eq 1
+        expect(page).to have_selector('td[data-requestable="false"]')
+      end
     end
   end
 
@@ -23,9 +24,10 @@ describe 'Request Options' do
     end
 
     it 'does not display a request button', unless: in_ci? do
-      sleep 5.seconds
-      expect(page.all('.location--holding').length).to eq 1
-      expect(page).not_to have_selector('.location-services.service-conditional')
+      using_wait_time 5 do
+        expect(page.all('.holding-block').length).to eq 1
+        expect(page).to have_selector('td[data-requestable="false"]')
+      end
     end
   end
 
@@ -35,9 +37,10 @@ describe 'Request Options' do
     end
 
     it 'does display a request button', unless: in_ci? do
-      sleep 5.seconds
-      expect(page.all('.location--holding').length).to eq 1
-      expect(page.find_link('Request')).to be_visible
+      using_wait_time 5 do
+        expect(page.all('.holding-block').length).to eq 1
+        expect(page.find_link('Request')).to be_visible
+      end
     end
   end
 
@@ -47,9 +50,10 @@ describe 'Request Options' do
     end
 
     it 'does display a request button', unless: in_ci? do
-      sleep 5.seconds
-      expect(page.all('.location--holding').length).to eq 1
-      expect(page.find_link('Request')).to be_visible
+      using_wait_time 5 do
+        expect(page.all('.holding-block').length).to eq 1
+        expect(page.find_link('Request')).to be_visible
+      end
     end
   end
 
@@ -59,9 +63,10 @@ describe 'Request Options' do
     end
 
     it 'does display a request button', unless: in_ci? do
-      sleep 10.seconds
-      expect(page.all('.location--holding').length).to eq 1
-      expect(page.find_link('Request')).to be_visible
+      using_wait_time 5 do
+        expect(page.all('.holding-block').length).to eq 1
+        expect(page.find_link('Request')).to be_visible
+      end
     end
   end
   # This should address borrow direct. evenutally
@@ -72,9 +77,9 @@ describe 'Request Options' do
   #     visit '/catalog/'
   #   end
 
-  #   it 'does display a request button', unless: in_travis? do
+  #   it 'does display a request button', unless: in_ci? do
   #     sleep 5.seconds
-  #     expect(page.all('.location--holding').length).to eq 1
+  #     expect(page.all('.holding-block').length).to eq 1
   #     expect(page.all('.location-services.service-conditional a.btn-primary'.length)).to eq(1)
   #     expect(page.find_link('Request Options').visible?).to be_truthy
   #   end
@@ -86,9 +91,10 @@ describe 'Request Options' do
     end
 
     it 'displays an aeon request button', unless: in_ci? do
-      sleep 5.seconds
-      expect(page.all('.location--holding').length).to eq 1
-      expect(page.find_link('Reading Room Request')).to be_visible
+      using_wait_time 5 do
+        expect(page.all('.holding-block').length).to eq 1
+        expect(page.find_link('Reading Room Request')).to be_visible
+      end
     end
   end
 
@@ -98,44 +104,48 @@ describe 'Request Options' do
     end
 
     it 'does not display a request button', unless: in_ci? do
-      sleep 5.seconds
-      expect(page.all('.location--holding').length).to eq 1
-      expect(page).not_to have_selector('.location-services.service-conditional')
+      using_wait_time 5 do
+        expect(page.all('.holding-block').length).to eq 1
+        expect(page).to have_selector('td[data-requestable="false"]')
+      end
     end
   end
 
-  # describe 'Paging location available status', js: true do
-  #   before(:each) do
-  #     visit '/catalog/8908514'
-  #   end
+  describe 'Paging location available status', js: true do
+    before do
+      visit '/catalog/8908514'
+    end
 
-  #   it 'does display a paging request button', unless: in_travis? do
-  #     sleep 5.seconds
-  #     expect(page.all('.location--holding').length).to eq 1
-  #     expect(page.find_link('Paging Request').visible?).to be_truthy
-  #   end
-  # end
+    xit 'does display a paging request button' do
+      using_wait_time 5 do
+        expect(page.all('.holding-block').length).to eq 1
+        expect(page.find_link('Paging Request').visible?).to be_truthy
+      end
+    end
+  end
 
-  # describe 'Paging location that has been shelved at a temp location status', js: true do
-  #   before(:each) do
-  #     visit '/catalog/5318288'
-  #   end
+  describe 'Paging location that has been shelved at a temp location status', js: true do
+    before do
+      visit '/catalog/5318288'
+    end
 
-  #   it 'does display a request button', unless: in_travis? do
-  #     sleep 5.seconds
-  #     expect(page.all('.location--holding').length).to eq 1
-  #     expect(page).not_to have_selector('.location-services.service-conditional')
-  #   end
-  # end
+    xit 'does display a request button', unless: in_ci? do
+      using_wait_time 5 do
+        expect(page.all('.holding-block').length).to eq 1
+        expect(page).not_to have_selector('.location-services.service-conditional')
+      end
+    end
+  end
 
-  # describe 'Paging location that has been shelved at a temp location status', js: true do
-  #   before(:each) do
-  #     visit '/catalog?search_field=all_fields&q=5318288'
-  #   end
+  describe 'Paging location that has been shelved at a temp location status', js: true do
+    before do
+      visit '/catalog?search_field=all_fields&q=5318288'
+    end
 
-  #   it 'does not display a paging request icon', unless: in_travis? do
-  #     sleep 5.seconds
-  #     expect(page).not_to have_selector('.icon-warning.icon-paging-request')
-  #   end
-  # end
+    xit 'does not display a paging request icon', unless: in_ci? do
+      using_wait_time 5 do
+        expect(page).not_to have_selector('.icon-warning.icon-paging-request')
+      end
+    end
+  end
 end

--- a/spec/features/searching_spec.rb
+++ b/spec/features/searching_spec.rb
@@ -66,7 +66,7 @@ describe 'searching' do
     end
   end
 
-  context 'Show error page if request parameters contain spaces' do
+  context 'when a request parameter contains a space' do
     it 'displays an error message' do
       visit '/catalog/range_limit?%20%20%20%20range_end=1990&%20%20%20%20range_field=pub_date_start_sort&%20%20%20%20range_start=1981'
       expect { page }.not_to raise_error

--- a/spec/features/searching_spec.rb
+++ b/spec/features/searching_spec.rb
@@ -9,12 +9,12 @@ describe 'searching' do
 
   it 'renders an accessible search button' do
     visit '/catalog'
-    expect(page).to have_selector '.glyphicon-search[aria-hidden="true"]'
+    expect(page).to have_selector '.fa-search[aria-hidden="true"]'
   end
 
   it 'renders an accessible link to the stack map' do
     visit '/catalog?q=&search_field=all_fields'
-    expect(page).to have_selector '.glyphicon-map-marker[aria-hidden="true"]'
+    expect(page).to have_selector '.fa-map-marker[aria-hidden="true"]'
   end
 
   it 'renders an accessible icon for item icons' do
@@ -32,7 +32,7 @@ describe 'searching' do
   context 'Availability: On-site by request' do
     it 'On-site label is green' do
       visit '/?f%5Baccess_facet%5D%5B%5D=In+the+Library&q=id%3Adsp*&search_field=all_fields'
-      expect(page).to have_selector '#documents > div.document.blacklight-senior-thesis.document-position-0 > div > div.record-wrapper > ul > li.blacklight-holdings > ul > li:nth-child(1) > span.availability-icon.label.label-success'
+      expect(page).to have_selector '#documents > article.document.blacklight-senior-thesis.document-position-0 > div > div.record-wrapper > ul > li.blacklight-holdings > ul > li:nth-child(1) > span.availability-icon.label.label-success'
     end
   end
 
@@ -66,12 +66,11 @@ describe 'searching' do
     end
   end
 
-  context 'raise flash error if BadRequest', js: true do
-    it 'will display a flash message if there is a BadRequest error' do
+  context 'Show error page if request parameters contain spaces' do
+    it 'displays an error message' do
       visit '/catalog/range_limit?%20%20%20%20range_end=1990&%20%20%20%20range_field=pub_date_start_sort&%20%20%20%20range_start=1981'
       expect { page }.not_to raise_error
-      expect(page).to have_current_path('/')
-      expect(page).to have_content 'This is not a valid request.'
+      expect(page).to have_content 'For help, please email', 'start over'
     end
   end
   context 'with an invalid field list parameter in the advanced search' do
@@ -82,13 +81,13 @@ describe 'searching' do
     end
   end
   context 'when searching with an invalid facet parameter' do
-    it 'will log the error' do
+    it 'returns a 400 response, displays an error message, and logs the error' do
       allow(Rails.logger).to receive(:error)
 
       visit '/catalog?q=test&f=1'
       expect { page }.not_to raise_error
       expect(page.status_code).to eq 400
-      expect(page).to have_content 'Bad Request'
+      expect(page).to have_content 'For help, please email', 'start over'
       expect(Rails.logger).to have_received(:error).with(/Invalid parameters passed in the request: Invalid facet parameter passed: 1/)
     end
   end

--- a/spec/lib/orangelight/middleware/invalid_parameter_handler_spec.rb
+++ b/spec/lib/orangelight/middleware/invalid_parameter_handler_spec.rb
@@ -16,7 +16,7 @@ describe Orangelight::Middleware::InvalidParameterHandler do
         'QUERY_STRING' => query_string,
         'REQUEST_URI' => "/catalog?#{query_string}",
         'PATH_INFO' => '/',
-        'HTTP_ACCEPT' => 'application/json',
+        'HTTP_ACCEPT' => 'text/html',
         'rack.input' => ''
       }
     end
@@ -65,13 +65,12 @@ describe Orangelight::Middleware::InvalidParameterHandler do
         allow(Rails.logger).to receive(:error)
       end
 
-      it 'returns a 400 response and logs an error' do
+      it 'returns a 400 response, displays an error message, and logs the error' do
         status, headers, body = invalid_parameter_handler.call(env)
 
-        expect(body.join).to eq('Bad Request')
+        expect(body.join).to include('For help, please email', 'start over')
         expect(status).to eq(400)
-        expect(headers['Content-Type']).to eq('application/json; charset=UTF-8')
-        expect(headers['Content-Length']).to eq('11')
+        expect(headers['Content-Type']).to eq('text/html; charset=UTF-8')
         expect(Rails.logger).to have_received(:error).with(/Invalid parameters passed in the request\: Invalid query parameters\: invalid %\-encoding \(%2B%2B%2\) within the environment/)
       end
     end
@@ -85,13 +84,12 @@ describe Orangelight::Middleware::InvalidParameterHandler do
         allow(Rails.logger).to receive(:error)
       end
 
-      it 'returns a 400 response and logs an error' do
+      it 'returns a 400 response, displays an error message, and logs the error' do
         status, headers, body = invalid_parameter_handler.call(env)
 
-        expect(body.join).to eq('Bad Request')
+        expect(body.join).to include('For help, please email', 'start over')
         expect(status).to eq(400)
-        expect(headers['Content-Type']).to eq('application/json; charset=UTF-8')
-        expect(headers['Content-Length']).to eq('11')
+        expect(headers['Content-Type']).to eq('text/html; charset=UTF-8')
         expect(Rails.logger).to have_received(:error).with(/Invalid parameters passed in the request\: Facet field \[format\]\[ has a nil value within the environment nil/)
       end
     end
@@ -105,13 +103,12 @@ describe Orangelight::Middleware::InvalidParameterHandler do
         allow(Rails.logger).to receive(:error)
       end
 
-      it 'returns a 400 response and logs an error' do
+      it 'returns a 400 response, displays an error message, and logs the error' do
         status, headers, body = invalid_parameter_handler.call(env)
 
-        expect(body.join).to eq('Bad Request')
+        expect(body.join).to include('For help, please email', 'start over')
         expect(status).to eq(400)
-        expect(headers['Content-Type']).to eq('application/json; charset=UTF-8')
-        expect(headers['Content-Length']).to eq('11')
+        expect(headers['Content-Type']).to eq('text/html; charset=UTF-8')
         expect(Rails.logger).to have_received(:error).with(/Invalid parameters passed in the request\: Invalid query parameters\: invalid %\-encoding \(%2B%2B%2\) within the environment/)
       end
     end


### PR DESCRIPTION
Partially addresses #1773

- Fixes request options specs
- Fixes searching specs
- Moves check for param key spaces into middleware and displays standard OL error page for param exceptions.

http://localhost:3000/catalog/range_limit?%20%20%20%20range_end=1990&%20%20%20%20range_field=pub_date_start_sort&%20%20%20%20range_start=1981

Displays this to the user:

<img width="1243" alt="Screenshot 2019-08-19 19 21 29" src="https://user-images.githubusercontent.com/784196/63308149-e3036e00-c2b6-11e9-8618-90c348590849.png">