### PR TITLE
restores search results layout

### DIFF
--- a/app/assets/javascripts/availability.js.coffee.erb
+++ b/app/assets/javascripts/availability.js.coffee.erb
@@ -94,34 +94,34 @@ class AvailabilityUpdater
     for barcode, availability_info of item_records
       availability_element = $("*[data-availability-record='true'][data-record-id='#{id}'][data-scsb-barcode='#{barcode}'] .availability-icon")
       aeon = $("*[data-availability-record='true'][data-record-id='#{id}'][data-scsb-barcode='#{barcode}']").attr('data-aeon')
-      availability_element.addClass("label")
+      availability_element.addClass("badge")
       if aeon == 'true'
-        availability_element.addClass("label-success")
+        availability_element.addClass("badge-success")
         availability_element.text("On-Site Access")
         availability_element.attr("title", "Availability: On-site access by request")
       else if multi_items
         if status_message
-          availability_element.addClass("label-default")
+          availability_element.addClass("badge-secondary")
           availability_element.text(status_message)
           availability_element.attr("title", "Availability: Some items not available")
         else
-          availability_element.addClass("label-success")
+          availability_element.addClass("badge-success")
           availability_element.text('All Items Available')
           availability_element.attr("title", "Availability: All items available")
       else
         if availability_info['itemAvailabilityStatus'] == 'Available'
-          availability_element.addClass("label-success")
+          availability_element.addClass("badge-success")
           availability_element.text(availability_info['itemAvailabilityStatus'])
           availability_element.attr("title", "Availability: On shelf")
         else
-          availability_element.addClass("label-danger")
+          availability_element.addClass("badge-danger")
           availability_element.text(availability_info['itemAvailabilityStatus'])
           availability_element.attr("title", "Availability: Checked out")
   update_location_services: (holding_id, availability_info) ->
     status = availability_info['status']
     temp_status = availability_info['temp_loc']
     location_services_element = $(".location-services[data-holding-id='#{holding_id}'] a")
-    availability_label = $(".holding-status[data-holding-id='#{holding_id}'] .availability-icon.label")
+    availability_label = $(".holding-status[data-holding-id='#{holding_id}'] .availability-icon.badge")
     if availability_label.text()
       availability_label_text = title_case(availability_label.text())
     display_request = location_services_element.attr('data-requestable')
@@ -152,11 +152,11 @@ class AvailabilityUpdater
   apply_scsb_record: (barcode, item_data) ->
     availability_element = $("*[data-scsb-availability='true'][data-scsb-barcode='#{barcode}']")
     if item_data['itemAvailabilityStatus'] == 'Available'
-      availability_element.addClass("label-success")
+      availability_element.addClass("badge-success")
       availability_element.text(item_data['itemAvailabilityStatus'])
       availability_element.attr("title", "Availability: On Shelf")
     else
-      availability_element.addClass("label-danger")
+      availability_element.addClass("badge-danger")
       availability_element.text('Checked Out')
       availability_element.attr("title", "Availability: Checked Out")
     true
@@ -190,8 +190,8 @@ class AvailabilityUpdater
           span.attr("title", "Availability: " + txt)
           span.attr("data-original-title", "Availability: " + txt)
           if !status.match(on_site_unavailable)
-            span.removeClass("label-success")
-            span.addClass("label-default")
+            span.removeClass("badge-success")
+            span.addClass("badge-secondary")
             location_services_element = $(".location-services[data-holding-id='#{holding_id}']")
             location_services_element.show()
       if ul != ""
@@ -215,28 +215,28 @@ class AvailabilityUpdater
         element.append(li)
   record_needs_more_info: (record_id) ->
     element = $("*[data-record-id='#{record_id}'] .more-info")
-    element.addClass("label label-default")
+    element.addClass("badge badge-secondary")
     element.text("View record for full availability")
     element.attr('title', "Click on the record for full availability info")
     empty = $("*[data-record-id='#{record_id}'].empty")
     empty.removeClass("empty")
   apply_record_icon: (availability_element, status, aeon, availability_info) ->
     status = title_case(status)
-    availability_element.addClass("label")
+    availability_element.addClass("badge")
     label = status_label(status)
     availability_element.text("#{label}#{due_date(availability_info["due_date"])}")
     if label in unavailable_labels
-      availability_element.addClass("label-danger")
+      availability_element.addClass("badge-danger")
     else if label in available_labels
-      availability_element.addClass("label-success")
+      availability_element.addClass("badge-success")
     else if label == 'On-site access'
-      availability_element.addClass("label-warning")
+      availability_element.addClass("badge-warning")
     else if label == circ_desk
-      availability_element.addClass("label-warning")
+      availability_element.addClass("badge-warning")
     else if label == 'Online'
-      availability_element.addClass("label-primary")
+      availability_element.addClass("badge-primary")
     else
-      availability_element.addClass("label-default")
+      availability_element.addClass("badge-secondary")
     if aeon == 'true'
       status = "On-site access by request"
     availability_element.attr('title', "Availability: #{title_case(status)}")

--- a/app/assets/javascripts/bookmark_all.js.coffee
+++ b/app/assets/javascripts/bookmark_all.js.coffee
@@ -6,11 +6,11 @@ class BookmarkAllManager
     this.prepopulate_value()
     this.bind_element()
   prepopulate_value: ->
-    if $("input.toggle_bookmark:checked").length == $("input.toggle_bookmark").length
+    if $("input.toggle-bookmark:checked").length == $("input.toggle-bookmark").length
       @element.prop('checked', true)
   bind_element: ->
     parent = this
-    $("input.toggle_bookmark").click ->
+    $("input.toggle-bookmark").click ->
       unless this.checked
         parent.element.prop('checked', false)
       else
@@ -21,6 +21,6 @@ class BookmarkAllManager
       else
         parent.unbookmark_all()
   bookmark_all: ->
-    $("input.toggle_bookmark:not(:checked)").click()
+    $("input.toggle-bookmark:not(:checked)").click()
   unbookmark_all: ->
-    $("input.toggle_bookmark:checked").click()
+    $("input.toggle-bookmark:checked").click()

--- a/app/assets/javascripts/introjs/tutorial.js
+++ b/app/assets/javascripts/introjs/tutorial.js
@@ -56,7 +56,7 @@ function resultsPage(){
           position: 'bottom'
         },
         {
-          element: 'form.bookmark_toggle',
+          element: 'form.bookmark-toggle',
           intro: 'Items may also be bookmarked individually.',
           position: 'bottom'
         },

--- a/app/assets/stylesheets/components/availability.scss
+++ b/app/assets/stylesheets/components/availability.scss
@@ -16,19 +16,19 @@
     margin-right: 0;
     white-space: normal;
 
-    &.label-default {
+    &.badge-secondary {
       color: $gray-light;
     }
 
-    &.label-warning {
+    &.badge-warning {
       color: $dark-orange;
     }
 
-    &.label-danger {
+    &.badge-danger {
       color: $brand-danger;
     }
 
-    &.label-success {
+    &.badge-success {
       color: $brand-success;
     }
   }
@@ -131,7 +131,7 @@
   }
 }
 
-.blacklight-holdings .availability-icon.label:hover {
+.blacklight-holdings .availability-icon.badge:hover {
   color: white;
   text-decoration: none;
 }
@@ -391,7 +391,7 @@
       float: left;
       padding: 6px 5px;
 
-      &.label-warning {
+      &.badge-warning {
         color: $black;
       }
     }

--- a/app/assets/stylesheets/components/bookmark-all.scss
+++ b/app/assets/stylesheets/components/bookmark-all.scss
@@ -21,22 +21,22 @@
   }
 }
 
-.checkbox.toggle_bookmark {
+.checkbox.toggle-bookmark {
   margin-bottom: 5px;
   padding: 0;
   text-align: center;
 
   label {
-    padding: 6px 12px;
+    cursor: pointer;
   }
 }
 
-.search-widgets label.toggle_bookmark {
+.search-widgets label.toggle-bookmark {
   min-width: initial;
 }
 
 @media (max-width: $bp-small) {
-  .search-widgets .checkbox.toggle_bookmark {
+  .search-widgets .checkbox.toggle-bookmark {
     padding: 0;
   }
 }
@@ -46,7 +46,7 @@
 }
 
 .checkbox.bookmark_all,
-.search-widgets .checkbox.toggle_bookmark {
+.search-widgets .checkbox.toggle-bookmark {
   float: right;
 
   label {

--- a/app/assets/stylesheets/components/buttons.scss
+++ b/app/assets/stylesheets/components/buttons.scss
@@ -66,7 +66,7 @@ a.clear-bookmarks {
 .pagination-search-widgets .previous,
 .pagination-search-widgets .next,
 .checkbox.bookmark_all span,
-.search-widgets .checkbox.toggle_bookmark span,
+.search-widgets .checkbox.toggle-bookmark span,
 .bookmarksTools.nav #emailLink,
 .bookmarksTools.nav #citationLink,
 .bookmarksTools.nav > li > a,
@@ -101,11 +101,11 @@ a.clear-bookmarks {
 }
 
 .checkbox.bookmark_all span,
-.search-widgets .checkbox.toggle_bookmark span {
+.search-widgets .checkbox.toggle-bookmark span {
   display: inline-block;
 }
 
-.pagination-search-widgets .checkbox.toggle_bookmark {
+.pagination-search-widgets .checkbox.toggle-bookmark {
   margin-bottom: 0;
 }
 
@@ -192,7 +192,7 @@ header .navbar-nav > li > a {
 #per_page-dropdown,
 #per_page-dropdown .dropdown-toggle,
 .checkbox.bookmark_all span,
-// .search-widgets .checkbox.toggle_bookmark span,
+// .search-widgets .checkbox.toggle-bookmark span,
 .bookmark_all,
 .bookmark_all label,
 .bookmark_all span {
@@ -205,9 +205,8 @@ header .navbar-nav > li > a {
 }
 
 .checkbox.bookmark_all,
-.search-widgets .checkbox.toggle_bookmark {
+.search-widgets .checkbox.toggle-bookmark {
   @media (max-width: 500px) {
-    // float: left;
     margin-left: 0;
   }
 }

--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -181,9 +181,9 @@
         width: 100%;
       }
 
-      .checkbox.toggle_bookmark,
-      .checkbox.toggle_bookmark label,
-      .checkbox.toggle_bookmark span {
+      .checkbox.toggle-bookmark,
+      .checkbox.toggle-bookmark label,
+      .checkbox.toggle-bookmark span {
         width: 100%;
         margin: 0;
       }

--- a/app/assets/stylesheets/components/record.scss
+++ b/app/assets/stylesheets/components/record.scss
@@ -66,7 +66,7 @@
       font-family: $font-sans-alt;
       font-size: 1rem;
 
-      .label {
+      .badge {
         font-size: 1rem;
         font-weight: 500;
         letter-spacing: initial;

--- a/app/assets/stylesheets/components/search-results.scss
+++ b/app/assets/stylesheets/components/search-results.scss
@@ -73,6 +73,13 @@ dd.blacklight-electronic_access_display {
 .thumbnail-wrapper {
   width: 120px;
   float: right;
+  padding-left: 10px;
+}
+
+// remove when https://github.com/projectblacklight/blacklight/pull/2125 is released
+.documents-list .document .document-thumbnail {
+    margin-bottom: ($spacer * 3);
+    padding-left: ($spacer * 3);
 }
 
 #spell {

--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -139,7 +139,7 @@ h1,
   font-size: 12pt;
 }
 
-.label {
+.badge {
   border: 0;
 }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -191,27 +191,27 @@ module ApplicationHelper
         if links.empty?
           check_availability = render_availability?
           info << content_tag(:span, 'Link Missing',
-                              class: 'availability-icon label label-default', title: 'Availability: Online',
+                              class: 'availability-icon badge badge-secondary', title: 'Availability: Online',
                               'data-toggle' => 'tooltip')
           info << content_tag(:div, 'Online access is not currently available.', class: 'library-location')
         else
-          info << content_tag(:span, 'Online', class: 'availability-icon label label-primary', title: 'Electronic access', 'data-toggle' => 'tooltip')
+          info << content_tag(:span, 'Online', class: 'availability-icon badge badge-primary', title: 'Electronic access', 'data-toggle' => 'tooltip')
           info << links.shift.html_safe
         end
       else
         if holding['dspace']
           check_availability = false
-          info << content_tag(:span, 'On-site access', class: 'availability-icon label label-success', title: 'Availability: On-site by request', 'data-toggle' => 'tooltip')
+          info << content_tag(:span, 'On-site access', class: 'availability-icon badge badge-success', title: 'Availability: On-site by request', 'data-toggle' => 'tooltip')
           info << content_tag(:span, '', class: 'icon-warning icon-request-reading-room', title: 'Items at this location Must be requested', 'data-toggle' => 'tooltip', 'aria-hidden' => 'true').html_safe if aeon_location?(location)
         elsif /^scsb.+/.match? location[:code]
           check_availability = false
           unless holding['items'].nil?
             scsb_multiple = true unless holding['items'].count == 1
             if scsb_supervised_items?(holding)
-              info << content_tag(:span, 'On-site access', class: 'availability-icon label label-success', title: 'Availability: On-site by request', 'data-toggle' => 'tooltip')
+              info << content_tag(:span, 'On-site access', class: 'availability-icon badge badge-success', title: 'Availability: On-site by request', 'data-toggle' => 'tooltip')
               info << content_tag(:span, '', class: 'icon-warning icon-request-reading-room', title: 'Items at this location must be requested', 'data-toggle' => 'tooltip', 'aria-hidden' => 'true').html_safe
             else
-              info << content_tag(:span, '', class: 'availability-icon label', title: '', 'data-scsb-availability' => 'true', 'data-toggle' => 'tooltip', 'data-scsb-barcode' => holding['items'].first['barcode'].to_s).html_safe
+              info << content_tag(:span, '', class: 'availability-icon badge', title: '', 'data-scsb-availability' => 'true', 'data-toggle' => 'tooltip', 'data-scsb-barcode' => holding['items'].first['barcode'].to_s).html_safe
             end
           end
         elsif holding['dspace'].nil?
@@ -219,7 +219,7 @@ module ApplicationHelper
           info << content_tag(:span, '', class: 'icon-warning icon-request-reading-room', title: 'Items at this location must be requested', 'data-toggle' => 'tooltip', 'aria-hidden' => 'true').html_safe if aeon_location?(location)
         else
           check_availability = false
-          info << content_tag(:span, 'Unavailable', class: 'availability-icon label label-danger', title: 'Availability: Material under embargo', 'data-toggle' => 'tooltip')
+          info << content_tag(:span, 'Unavailable', class: 'availability-icon badge badge-danger', title: 'Availability: Material under embargo', 'data-toggle' => 'tooltip')
         end
         info << content_tag(:div, search_location_display(holding, document), class: 'library-location', data: { location: true, record_id: document['id'], holding_id: id })
       end
@@ -227,10 +227,10 @@ module ApplicationHelper
     end
 
     if scsb_multiple == true
-      block << content_tag(:li, link_to('View Record for Full Availability', solr_document_path(document['id']), class: 'availability-icon label label-default more-info', title: 'Click on the record for full availability info', 'data-toggle' => 'tooltip').html_safe)
+      block << content_tag(:li, link_to('View Record for Full Availability', solr_document_path(document['id']), class: 'availability-icon badge badge-secondary more-info', title: 'Click on the record for full availability info', 'data-toggle' => 'tooltip').html_safe)
     elsif holdings_hash.length > 2
       block << content_tag(:li, link_to('View Record for Full Availability', solr_document_path(document['id']),
-                                        class: 'availability-icon label label-default more-info', title: 'Click on the record for full availability info',
+                                        class: 'availability-icon badge badge-secondary more-info', title: 'Click on the record for full availability info',
                                         'data-toggle' => 'tooltip').html_safe)
 
     elsif !holdings_hash.empty?

--- a/app/services/online_holdings_markup_builder.rb
+++ b/app/services/online_holdings_markup_builder.rb
@@ -8,7 +8,7 @@ class OnlineHoldingsMarkupBuilder < HoldingRequestsBuilder
   def self.online_link(bib_id, holding_id)
     children = content_tag(
       :span, 'Link Missing',
-      class: 'availability-icon label label-default',
+      class: 'availability-icon badge badge-secondary',
       title: 'Availability: Online',
       'data-toggle' => 'tooltip'
     )

--- a/app/services/physical_holdings_markup_builder.rb
+++ b/app/services/physical_holdings_markup_builder.rb
@@ -95,7 +95,7 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
   def self.holding_location_repository
     children = content_tag(:span,
                            'On-site access',
-                           class: 'availability-icon label label-success',
+                           class: 'availability-icon badge badge-success',
                            title: 'Availability: On-site by request',
                            'data-toggle' => 'tooltip')
     content_tag(:td, children.html_safe)
@@ -104,7 +104,7 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
   def self.holding_location_scsb_span
     markup = content_tag(:span, '',
                          title: '',
-                         class: 'availability-icon label',
+                         class: 'availability-icon badge',
                          data: { toggle: 'tooltip' })
     markup
   end
@@ -138,7 +138,7 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
   def self.holding_location_unavailable
     children = content_tag(:span,
                            'Unavailable',
-                           class: 'availability-icon label label-danger',
+                           class: 'availability-icon badge badge-danger',
                            title: 'Availability: Embargoed',
                            'data-toggle' => 'tooltip')
     content_tag(:td, children.html_safe, class: 'holding-status')

--- a/app/views/catalog/_index_header_default.html.erb
+++ b/app/views/catalog/_index_header_default.html.erb
@@ -22,10 +22,8 @@
               <%= truncated_link document, titlealt, :counter => counter, :dir => altdir %>
             <% end %>
             </h3>
-
-            
+            <h3 class="index_title">
         <% end %>
-        <h3 class="index_title">
         <%= truncated_link document, document_show_link_field(document), :counter => counter %>
         </h3>
       </div>

--- a/app/views/orangelight/browsables/index.html.erb
+++ b/app/views/orangelight/browsables/index.html.erb
@@ -83,11 +83,11 @@
           <td><%= link_to orangelight_name.label, "/catalog/#{orangelight_name.bibid}" %></td>
           <td class="availability-column" data-availability-record="<%= should_check_availability?(orangelight_name.bibid) %>" data-record-id="<%= bib_for_availability(orangelight_name.bibid) %>" data-holding-id="<%= orangelight_name.holding_id %>">
             <%= content_tag(:span, content_tag(:span, orangelight_name.location, class: 'results_location'), class: 'library-location', data: { location: true, record_id: orangelight_name.bibid, holding_id: orangelight_name.holding_id }) %>
-            </br><span class="availability-icon label label-default"></span>
+            </br><span class="availability-icon badge badge-secondary"></span>
             <%= content_tag(:span, '', class: 'more-info empty', data: { record_id: orangelight_name.bibid }) unless orangelight_name.location == 'Multiple locations' %>
             <% if scsb_id?(orangelight_name.bibid) %>
               </br>
-              <span class="more-info label label-default" data-record-id="<%= orangelight_name.bibid %>" title="Click on the record for full availability info">View record for full availability</span>
+              <span class="more-info badge badge-secondary" data-record-id="<%= orangelight_name.bibid %>" title="Click on the record for full availability info">View record for full availability</span>
             <% end %>
           </td>
 

--- a/spec/features/availability_spec.rb
+++ b/spec/features/availability_spec.rb
@@ -50,7 +50,7 @@ describe 'Availability' do
     it 'display availability as on-site and does not display individual items', unless: in_ci? do
       stub_holding_locations
       visit 'catalog/2238036'
-      expect(page).to have_selector '.availability-icon.label.label-success', text: 'On-site access', count: 1
+      expect(page).to have_selector '.availability-icon.badge.badge-success', text: 'On-site access', count: 1
     end
   end
 

--- a/spec/features/searching_spec.rb
+++ b/spec/features/searching_spec.rb
@@ -32,7 +32,7 @@ describe 'searching' do
   context 'Availability: On-site by request' do
     it 'On-site label is green' do
       visit '/?f%5Baccess_facet%5D%5B%5D=In+the+Library&q=id%3Adsp*&search_field=all_fields'
-      expect(page).to have_selector '#documents > article.document.blacklight-senior-thesis.document-position-0 > div > div.record-wrapper > ul > li.blacklight-holdings > ul > li:nth-child(1) > span.availability-icon.label.label-success'
+      expect(page).to have_selector '#documents > article.document.blacklight-senior-thesis.document-position-0 > div > div.record-wrapper > ul > li.blacklight-holdings > ul > li:nth-child(1) > span.availability-icon.badge.badge-success'
     end
   end
 

--- a/spec/javascript/availability.spec.js
+++ b/spec/javascript/availability.spec.js
@@ -9,7 +9,7 @@ describe('AvailabilityUpdater', function() {
     document.body.innerHTML =
       '<div>' +
       '<li data-availability-record="true" data-record-id="8938641" data-holding-id="8856502" data-aeon="false">' +
-      '  <span class="availability-icon label label-primary" title="" data-toggle="tooltip" data-original-title="Electronic access">Online</span>' +
+      '  <span class="availability-icon badge badge-primary" title="" data-toggle="tooltip" data-original-title="Electronic access">Online</span>' +
       '</li>' +
       '</div>'
     let u = new updater

--- a/spec/requests/request_spec.rb
+++ b/spec/requests/request_spec.rb
@@ -52,7 +52,7 @@ describe 'blacklight tests' do
       r = JSON.parse(response.body)
       expect(r['location'].length).to be > 2
       get '/catalog?&search_field=all_fields&q=857469'
-      expect(response.body).to include '<a class="availability-icon label label-default more-info" '\
+      expect(response.body).to include '<a class="availability-icon badge badge-secondary more-info" '\
                                        'title="Click on the record for full availability info" '\
                                        'data-toggle="tooltip" href="/catalog/857469">View Record '\
                                        'for Full Availability</a>'


### PR DESCRIPTION
Search results holding information/availability restored by replacing bootstrap 3 labels with version 4 badges.
Adjust bookmark checkbox spacing. The class names were changed in Blacklight 7 (ie toggle_bookmark class is now toggle-bookmark)