### PR TITLE
1741 bl7 bookmarks show

### DIFF
--- a/app/assets/stylesheets/components/bookmark-all.scss
+++ b/app/assets/stylesheets/components/bookmark-all.scss
@@ -52,6 +52,7 @@
   label {
     padding: 0;
     display: inline-block;
+    margin: 10px 0;
   }
 
   input {

--- a/app/views/blacklight/nav/_bookmark.html.erb
+++ b/app/views/blacklight/nav/_bookmark.html.erb
@@ -1,4 +1,4 @@
 <%= link_to bookmarks_path, id:'bookmarks_nav', class: 'nav-link' do %>
   <%= t('blacklight.header_links.bookmarks') %>
-<span class="bookmarks-count" data-role='bookmark-counter'>(<%= current_or_guest_user.bookmarks.count %>)</span>
+(<span class="bookmarks-count" data-role='bookmark-counter'><%= current_or_guest_user.bookmarks.count %></span>)
 <% end %>

--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -48,6 +48,9 @@
             </li>
           </ul>
         </li>
+        <li>
+          <%= render(:partial => 'catalog/bookmark_control', :locals => {:document=> @document}) %>
+        </li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Closes #1741 
 - Restores the bookmark tool on the show page. We overrided the Blacklight show tools partial so configuring it in the catalog controller doesn't do anything.
 - Aligned the bookmark tool with the other tools.
 - Fixes an issue where toggling bookmarks removes the parentheses surrounding the bookmark count in the nav bar