### PR TITLE
Update icon to support fontawesome family with new unicode

### DIFF
--- a/app/assets/stylesheets/components/record.scss
+++ b/app/assets/stylesheets/components/record.scss
@@ -164,7 +164,7 @@
   }
 
   &:before {
-    content: "\e096";
+    content: "\f065";
     position: absolute;
     z-index: 2;
     width: 3rem;
@@ -176,7 +176,7 @@
     bottom: -25px;
     right: -25px;
     transform: translate(-50%, -50%);
-    font-family: "Glyphicons Halflings";
+    font-family: FontAwesome;
     speak: none;
     font-style: normal;
     font-weight: normal;


### PR DESCRIPTION
closes #1846 

![Screen Shot 2019-09-09 at 5 09 27 PM](https://user-images.githubusercontent.com/9905193/64566769-aca09800-d324-11e9-90c5-fee7e637cd68.png)
