### PR TITLE
Revert `facet` method override in catalog controller

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -627,24 +627,4 @@ class CatalogController < ApplicationController
   rescue ActionController::BadRequest
     render file: Rails.public_path.join('x400.html'), layout: true, status: :bad_request
   end
-
-  # @see Blacklight::Catalog#facet
-  # @see https://github.com/projectblacklight/blacklight/blob/v6.13.0/app/controllers/concerns/blacklight/catalog.rb#L68
-  # displays values and pagination links for a single facet field
-  def facet
-    @facet = blacklight_config.facet_fields[params[:id]]
-    raise ActionController::RoutingError, 'Not Found' unless @facet
-    @response = get_facet_field_response(@facet.key, params)
-    @display_facet = @response.aggregations[@facet.field]
-    raise ActionController::RoutingError, 'Not Found' unless @display_facet
-    @pagination = facet_paginator(@facet, @display_facet)
-    respond_to do |format|
-      format.html do
-        # Draw the partial for the "more" facet modal window:
-        return render layout: false if request.xhr?
-        # Otherwise draw the facet selector for users who have javascript disabled.
-      end
-      format.json
-    end
-  end
 end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -75,14 +75,4 @@ RSpec.describe CatalogController do
       expect(response.status).to eq(400)
     end
   end
-
-  describe 'rendering facet values and links' do
-    context 'when the display information cannot be retrieved for the facet' do
-      it 'renders an error message' do
-        expect do
-          get :facet, params: { id: 'publication_place_facet_nonexistent', f: { 'format' => ['Audio'] }, '++++f' => { 'lc_1letter_facet' => ['M+-+Music'] } }
-        end.to raise_error(ActionController::RoutingError, 'Not Found')
-      end
-    end
-  end
 end


### PR DESCRIPTION
Revert "Linking to the GitHub line of code for release 6.13.0 within CatalogController#facet"
This reverts commit b9949d031475b3fb503a324e10c344c878d7cac2.

Revert "Overriding Blacklight::Catalog#facet and handling cases where display information for a faceted field cannot be retrieved"
This reverts commit 2d96e55e7f4616c242119d7ca7f6a5d4adae7215.

fixes #1871