### PR TITLE
Pointing to the new version of locator

### DIFF
--- a/app/services/stackmap_service.rb
+++ b/app/services/stackmap_service.rb
@@ -44,7 +44,7 @@ class StackmapService
     private
 
       def locator_url
-        "https://library.princeton.edu/locator/index.php?loc=#{@loc}&id=#{bibid}&embed=true"
+        "https://locator-prod.princeton.edu/index.php?loc=#{@loc}&id=#{bibid}&embed=true"
       end
 
       def stackmap_url

--- a/spec/services/stackmap_service_spec.rb
+++ b/spec/services/stackmap_service_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe StackmapService::Url do
       let(:call_number) { 'Q43.2' }
 
       it 'resolves to embeded firestone locator with loc and bibid' do
-        expect(url).to eq("https://library.princeton.edu/locator/index.php?loc=#{location}&id=#{properties[:id]}&embed=true")
+        expect(url).to eq("https://locator-prod.princeton.edu/index.php?loc=#{location}&id=#{properties[:id]}&embed=true")
       end
     end
     describe 'firestone, no call number provided' do
       let(:location) { 'f' }
 
       it 'resolves to embeded firestone locator with loc and bibid' do
-        expect(url).to eq("https://library.princeton.edu/locator/index.php?loc=#{location}&id=#{properties[:id]}&embed=true")
+        expect(url).to eq("https://locator-prod.princeton.edu/index.php?loc=#{location}&id=#{properties[:id]}&embed=true")
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe StackmapService::Url do
       let(:doc_cn) { nil }
 
       it 'resolves to embeded firestone locator with loc and bibid' do
-        expect(url).to eq("https://library.princeton.edu/locator/index.php?loc=#{location}&id=#{properties[:id]}&embed=true")
+        expect(url).to eq("https://locator-prod.princeton.edu/index.php?loc=#{location}&id=#{properties[:id]}&embed=true")
       end
 
       it 'preferred_callno returns nil' do


### PR DESCRIPTION
Since the new locator is available over the web no reason to proxy it through the library site.

I believe taking out the proxy will make things simpler to diagnose int he long run if something ever goes down.