### PR TITLE
Adding handling for cases where bibdata env. variables are nil within the CourseReserveRepository

### DIFF
--- a/app/repositories/course_reserve_repository.rb
+++ b/app/repositories/course_reserve_repository.rb
@@ -8,11 +8,18 @@ class CourseReserveRepository
 
     private
 
+      def bibdata_url
+        ENV['bibdata_base']
+      end
+
       def courses_response
-        Faraday.get("#{ENV['bibdata_base']}/courses")
+        courses_url = "#{bibdata_url}/courses"
+        Faraday.get(courses_url)
       end
 
       def courses
+        return {} unless bibdata_url
+
         values = courses_response.body
         JSON.parse(values)
       rescue Faraday::ClientError => client_error

--- a/spec/requests/course_reserve_spec.rb
+++ b/spec/requests/course_reserve_spec.rb
@@ -9,6 +9,27 @@ describe 'course reserves' do
     conn.delete_by_query('type_s:ReserveListing')
     conn.commit
   end
+
+  context 'when the URL is not provided' do
+    let(:env_bibdata) { ENV['bibdata'] }
+
+    before do
+      env_bibdata
+      ENV['bibdata_base'] = nil
+    end
+
+    after do
+      ENV['bibdata_base'] = env_bibdata
+    end
+
+    it 'quietly does not retrieve the data' do
+      get '/catalog.json?search_field=all_fields&f[instructor][]=Test, Jane&f[filter][]=Course Reserves'
+      r = JSON.parse(response.body)
+      r['data'].length
+      expect(r['data']).to be_empty
+    end
+  end
+
   describe 'searching with an instructor name given' do
     it 'returns matching reserve ids' do
       stub_all_query


### PR DESCRIPTION
This may resolve #1660, although I am not certain why these values wouldn't be passed (or, if they are not, whether or not it would be best to let HoneyBadger log these errors).