### PR TITLE
Update account login page text

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -13,10 +13,6 @@
   </div>
 
   <div class='card card-barcode collapse' id="collapseBarcode">
-    <div class='card-header'>
-      <%= content_tag :h2, t('blacklight.login.barcode_header'), class: 'card-title' %>
-      <p><%=t('blacklight.login.barcode_subheader')%></p>
-    </div>
     <div class='card-body'>
       <%= simple_form_for(@user, url: user_barcode_omniauth_callback_path, class: 'form-horizontal', data: { toggle: 'validator' })  do |f| %>
           <div class='field form-group col-md-12 row'>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -76,9 +76,9 @@ en:
       redirect_text: 'You will be redirected to the secure Princeton University Central Authentication Service (CAS) login.'
       barcode_login_msg: 'Log in with a barcode (affiliates, family members, guest borrowers, etc)'
       barcode_netid: 'Please log in with netID.'
-      barcode_header: 'Other users'
-      barcode_subheader: 'For borrowers without a netID'
-      barcode_help: 'If you cannot login please stop at Firestone Circulation (609-258-3202) or email <a href="mailto:fstcirc@princeton.edu">fstcirc@princeton.edu</a>.'
+      barcode_header: ''
+      barcode_subheader: ''
+      barcode_help: 'If you cannot log in, please stop at Firestone Circulation (609-258-3202) or email <a href="mailto:fstcirc@princeton.edu">fstcirc@princeton.edu</a>.'
     email:
       form:
         title: 'Email the catalog record and (optional) message.'


### PR DESCRIPTION
As per the request of circulation staff, updates the login page text and removes the "For borrowers without a netID" text on the account sign-in page.

Staff approved layout in staging: https://catalog-staging.princeton.edu/users/sign_in