### PR TITLE
update update schedule for call numbers, name titles

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -24,7 +24,7 @@ set :job_template, "bash -l -c 'export PATH=\"/usr/local/bin/:$PATH\" && :job'"
 
 job_type :browse_facet_update, 'cd :path && :environment_variable=:environment SOLR_URL=:solr_url :bundle_command rake :task --silent :output'
 
-every 1.day, at: '1:15am', roles: [:cron_prod1] do
+every [:sunday, :wednesday, :friday], at: '1:15am', roles: [:cron_prod1] do
   browse_facet_update(
     'browse:call_numbers',
     solr_url: 'http://lib-solr3.princeton.edu:8983/solr/catalog-production',
@@ -32,7 +32,7 @@ every 1.day, at: '1:15am', roles: [:cron_prod1] do
   )
 end
 
-every 1.day, at: '6:20am', roles: [:cron_prod1] do
+every [:sunday, :wednesday, :friday], at: '6:20am', roles: [:cron_prod1] do
   browse_facet_update(
     'browse:load_call_numbers',
     solr_url: ENV['SOLR_URL'],
@@ -40,7 +40,7 @@ every 1.day, at: '6:20am', roles: [:cron_prod1] do
   )
 end
 
-every 1.day, at: '2:00am', roles: [:cron_prod1] do
+every [:tuesday, :thursday, :saturday], at: '2:00am', roles: [:cron_prod1] do
   browse_facet_update(
     'browse:name_titles',
     solr_url: ENV['SOLR_URL'],
@@ -48,7 +48,7 @@ every 1.day, at: '2:00am', roles: [:cron_prod1] do
   )
 end
 
-every 1.day, at: '6:00am', roles: [:cron_prod1] do
+every [:tuesday, :thursday, :saturday], at: '6:00am', roles: [:cron_prod1] do
   browse_facet_update(
     'browse:load_name_titles',
     solr_url: ENV['SOLR_URL'],


### PR DESCRIPTION
Have the name titles and call number browse updates run every other day to lessen the load on the worker machines and solr.