### PR TITLE
[DO NOT MERGE] Use a new env var to configure reserves index

### DIFF
--- a/app/indexers/reserve_indexer.rb
+++ b/app/indexers/reserve_indexer.rb
@@ -11,17 +11,10 @@ class ReserveIndexer
     end
 
     def connection_url
-      (Blacklight.default_index.connection.uri.to_s.split('/')[0..-2] + [core]).join('/')
-    end
-
-    def core
-      ENV['RESERVES_CORE'] || default_core
-    end
-
-    def default_core
-      Blacklight.default_index.connection.uri.to_s.gsub(%r{^.*\/solr}, '').delete('/')
+      ENV['RESERVES_SOLR_URL'] || Blacklight.default_index.connection.uri.to_s.chomp('/')
     end
   end
+
   attr_reader :courses
   def initialize(courses)
     @courses = courses

--- a/spec/indexers/reserve_indexer_spec.rb
+++ b/spec/indexers/reserve_indexer_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReserveIndexer do
+  describe ".connection_url" do
+    context "when an env value is given" do
+      before do
+        allow(ENV).to receive(:[]).and_call_original
+        allow(ENV).to receive(:[]).with("RESERVES_CORE").and_return("reserves")
+        allow(ENV).to receive(:[]).with("RESERVES_SOLR_URL").and_return("http://example.com/remote_solr/reserves")
+      end
+      it "returns the configured value" do
+        expect(described_class.connection_url).to eq "http://example.com/remote_solr/reserves"
+      end
+    end
+
+    context "when no env value is given" do
+      it "returns the default catalog index location" do
+        expect(described_class.connection_url).to eq "http://127.0.0.1:8888/solr/orangelight-core-test"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Do not merge until https://github.com/pulibrary/princeton_ansible/pull/1291 has been run on OL staging boxes, this PR has been deployed to staging and verified, and productions have also been provisioned.

To enable it to be on a different solrcloud than the catalog index

closes #1933