### PR TITLE
Mudd closure notice

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -202,7 +202,7 @@ module ApplicationHelper
         if holding['dspace']
           check_availability = false
           info << content_tag(:span, 'On-site access', class: 'availability-icon badge badge-success', title: 'Availability: On-site by request', 'data-toggle' => 'tooltip')
-          info << content_tag(:span, '', class: 'icon-warning icon-request-reading-room', title: 'Items at this location Must be requested', 'data-toggle' => 'tooltip', 'aria-hidden' => 'true').html_safe if aeon_location?(location)
+          info << content_tag(:span, '', class: 'icon-warning icon-request-reading-room', title: 'Items at this location must be requested', 'data-toggle' => 'tooltip', 'aria-hidden' => 'true').html_safe if aeon_location?(location)
         elsif /^scsb.+/.match? location[:code]
           check_availability = false
           unless holding['items'].nil?

--- a/app/services/holding_requests_adapter.rb
+++ b/app/services/holding_requests_adapter.rb
@@ -154,8 +154,13 @@ class HoldingRequestsAdapter
   # Duplicates PhysicalHoldingsMarkupBuilder.scsb_list
   # @param holding [Hash]
   def restrictions_for_holding(holding)
-    return [] unless holding.key? 'items'
-    holding['items'].map { |values| values['use_statement'] }.reject(&:blank?)
+    if holding.key? 'items'
+      holding['items'].map { |values| values['use_statement'] }.reject(&:blank?)
+    elsif holding['library'] == 'Mudd Manuscript Library'
+      ['Mudd']
+    else
+      []
+    end
   end
 
   # Determine whether or not the holding is explicitly marked as "Unavailable"

--- a/app/services/holding_requests_adapter.rb
+++ b/app/services/holding_requests_adapter.rb
@@ -154,6 +154,11 @@ class HoldingRequestsAdapter
   # Duplicates PhysicalHoldingsMarkupBuilder.scsb_list
   # @param holding [Hash]
   def restrictions_for_holding(holding)
+    # TODO: Uncomment these once Mudd has re-opened
+    # return [] unless holding.key? 'items'
+    # holding['items'].map { |values| values['use_statement'] }.reject(&:blank?)
+
+    # TODO: Remove this block once Mudd has re-opened
     if holding.key? 'items'
       holding['items'].map { |values| values['use_statement'] }.reject(&:blank?)
     elsif holding['library'] == 'Mudd Manuscript Library' || holding['location_code'] == 'rcpph'

--- a/app/services/holding_requests_adapter.rb
+++ b/app/services/holding_requests_adapter.rb
@@ -156,7 +156,7 @@ class HoldingRequestsAdapter
   def restrictions_for_holding(holding)
     if holding.key? 'items'
       holding['items'].map { |values| values['use_statement'] }.reject(&:blank?)
-    elsif holding['library'] == 'Mudd Manuscript Library'
+    elsif holding['library'] == 'Mudd Manuscript Library' || holding['location_code'] == 'rcpph'
       ['Mudd']
     else
       []

--- a/app/services/physical_holdings_markup_builder.rb
+++ b/app/services/physical_holdings_markup_builder.rb
@@ -200,11 +200,13 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
     end
   end
 
+  # TODO: Remove this method once Mudd has re-opened
   def self.mudd_closure_message
     "Mudd Library collections are unavailable until approximately June 3, 2020 due to
     a #{link_to('renovation.', mudd_url)}".html_safe
   end
 
+  # TODO: Remove this method once Mudd has re-opened
   def self.mudd_url
     "https://library.princeton.edu/special-collections/policies/access-mudd-library-during-renovation"
   end
@@ -213,7 +215,9 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
   # @param holding [Hash] the restrictions for all holdings
   # @return [String] the markup
   def self.restrictions_markup(restrictions)
+    # TODO: Remove this line once Mudd has re-opened
     return mudd_closure_message if restrictions.first == "Mudd"
+
     restricted_items = restrictions.map do |value|
       content_tag(:td, scsb_use_label(value),
                   class: 'icon-warning icon-request-reading-room',

--- a/app/services/physical_holdings_markup_builder.rb
+++ b/app/services/physical_holdings_markup_builder.rb
@@ -200,10 +200,20 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
     end
   end
 
+  def self.mudd_closure_message
+    "Mudd Library collections are unavailable until approximately June 3, 2020 due to
+    a #{link_to('renovation.', mudd_url)}".html_safe
+  end
+
+  def self.mudd_url
+    "https://library.princeton.edu/special-collections/policies/access-mudd-library-during-renovation"
+  end
+
   # Generate the markup for record restrictions
   # @param holding [Hash] the restrictions for all holdings
   # @return [String] the markup
   def self.restrictions_markup(restrictions)
+    return mudd_closure_message if restrictions.first == 'Mudd'
     restricted_items = restrictions.map do |value|
       content_tag(:td, scsb_use_label(value),
                   class: 'icon-warning icon-request-reading-room',

--- a/app/services/physical_holdings_markup_builder.rb
+++ b/app/services/physical_holdings_markup_builder.rb
@@ -213,7 +213,7 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
   # @param holding [Hash] the restrictions for all holdings
   # @return [String] the markup
   def self.restrictions_markup(restrictions)
-    return mudd_closure_message if restrictions.first == 'Mudd'
+    return mudd_closure_message if restrictions.first == "Mudd"
     restricted_items = restrictions.map do |value|
       content_tag(:td, scsb_use_label(value),
                   class: 'icon-warning icon-request-reading-room',

--- a/app/views/catalog/_show_availability.html.erb
+++ b/app/views/catalog/_show_availability.html.erb
@@ -14,6 +14,11 @@
 <% unless physical.empty? %>
   <div class="availability--physical">
     <h3><%= t('blacklight.holdings.print') %></h3>
+      <% if holding_requests_adapter.doc_holdings.any? {|_,h| h["library"] == "Mudd Manuscript Library"} %>
+      <div class="alert alert-warning mudd-closure">
+        <%= PhysicalHoldingsMarkupBuilder.mudd_closure_message %>
+      </div>
+      <% end %>
     <table class="availability-table">
       <thead>
         <tr>

--- a/app/views/catalog/_show_availability.html.erb
+++ b/app/views/catalog/_show_availability.html.erb
@@ -14,11 +14,6 @@
 <% unless physical.empty? %>
   <div class="availability--physical">
     <h3><%= t('blacklight.holdings.print') %></h3>
-      <% if holding_requests_adapter.doc_holdings.any? {|_,h| h["library"] == "Mudd Manuscript Library"} %>
-      <div class="alert alert-warning mudd-closure">
-        <%= PhysicalHoldingsMarkupBuilder.mudd_closure_message %>
-      </div>
-      <% end %>
     <table class="availability-table">
       <thead>
         <tr>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -2,6 +2,7 @@
 <div id="main-content" class="col-12 main-content">
   <div id="sidebar" class="<%= render_document_class %>">
     <%= render_document_sidebar_partial %>
+    <%= render partial: 'show_restrictions', locals: { document: @document } %>
   </div>
   <div id="content" class="content">
     <%= render_document_heading_partial %>
@@ -23,7 +24,6 @@
   </div>
   <div id="aside" class="<%= render_document_class %>">
     <h2 class="sr-only">Supplementary Information</h2>
-    <%= render partial: 'show_restrictions', locals: { document: @document } %>
     <%= render partial: 'show_other_versions', locals: { document: @document } %>
   </div>
 </div>


### PR DESCRIPTION
Display alert message for Mudd items (onsite and offsite) to reflect library closure.
Example record: https://catalog.princeton.edu/catalog/805699