### PR TITLE
Adding a Capistrano command to run rake cache:clear

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -105,5 +105,18 @@ namespace :sneakers do
   end
 end
 
+namespace :cache do
+  desc 'Run rake cache:clear'
+  task :clear do
+    on roles(:web) do
+      within current_path do
+        with :rails_env => fetch(:rails_env) do
+          execute :rake, 'cache:clear'
+        end
+      end
+    end
+  end
+end
+
 after 'deploy:reverted', 'sneakers:restart'
 after 'deploy:published', 'sneakers:restart'


### PR DESCRIPTION
Clears the Rails cache on all servers.  

This is needed to get changes to Bibdata (marc_liberation) to show up in Orangelight more immediately.

fixes #1969 