### PR TITLE
Always show a CDL link even if there is already another link

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,13 @@ Start the Bibdata server, and then set the ```bidata_base``` value in OrangeLigh
 `$ yarn install`
 `$ yarn test`
 
-Debugging instructions: https://facebook.github.io/jest/docs/en/troubleshooting.html
+### Debugging jest tests
+
+1. Place a `debugger;` line in your javascript
+1. Open up Chrome and type in the address bar: chrome://inspect
+1. Click on "Open dedicated DevTools for Node"
+1. Back in terminal run `yarn test:debug [path_to_test]` (This has been added to
+   package.json)
 
 ## Development Mailcatcher
 

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -320,13 +320,20 @@ export default class AvailabilityUpdater {
     }
   }
 
-  insert_online_link() {
-    let online_div = $(".availability--online:visible");
+  insert_online_header() {
+    const online_div = $("div[class^='availability--online']");
     if (online_div.length < 1) {
       const physical_div = $(".availability--physical");
-      online_div = '<div class="availability--online"><h3>Available Online</h3><ul><li>Princeton users: <a href="#view">View digital content</a></li></ul></div>';
+      const online_div = '<div class="availability--online:visible"><h3>Available Online</h3><ul></ul></div>';
       return $(online_div).insertBefore(physical_div);
     }
+  }
+
+  insert_online_link() {
+    this.insert_online_header()
+    const online_list = $("div[class^='availability--online'] ul");
+    const online_link = '<li>Princeton users: <a href="#view">View digital content</a></li></div>';
+    return $(online_list).append(online_link);
   }
 
   apply_record(record_id, holding_records) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "webpack-dev-server": "^3.1.14"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "test:debug": "node --inspect node_modules/.bin/jest --runInBand"
   },
   "jest": {
     "verbose": true,

--- a/spec/javascript/availability.spec.js
+++ b/spec/javascript/availability.spec.js
@@ -5,6 +5,38 @@ describe('AvailabilityUpdater', function() {
     expect(updater).not.toBe(undefined)
   })
 
+  test('insert_online_header() when there was no header', () => {
+    document.body.innerHTML =
+      '<div class="wrapper"><div class="availability--physical"></div></div>'
+    let u = new updater
+    u.insert_online_header()
+
+    const onlineDiv = document.getElementsByClassName('availability--online:visible')
+    expect(onlineDiv.length).toEqual(1)
+  })
+
+  test("insert_online_header() doesn't add a new one when there was already a header", () => {
+    document.body.innerHTML =
+      '<div class="wrapper"><div class="availability--online:visible"></div><div class="availability--physical"></div></div>'
+    let u = new updater
+    u.insert_online_header()
+
+    const onlineDiv = document.getElementsByClassName('availability--online:visible')
+    expect(onlineDiv.length).toEqual(1)
+  })
+
+  test("insert_online_link() adds a new link to the list", () => {
+    document.body.innerHTML =
+      '<div class="wrapper"><div class="availability--online:visible"><ul></ul></div><div class="availability--physical"></div></div>'
+    let u = new updater
+    u.insert_online_link()
+
+    const link = document.getElementsByTagName('li')
+    expect(link.length).toEqual(1)
+    let link_item = link.item(0)
+    expect(link.item(0).textContent).toEqual("Princeton users: View digital content")
+  })
+
   // TODO: This method isn't covered by the feature tests
   test('scsb_barcodes() on a search results page', () => {
     // This is only used on search results page


### PR DESCRIPTION
Fixes #2201
Advances #2185 by splitting out the header from the link