### PR TITLE
Updating requests to remove appointment link for ETAS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GIT
 
 GIT
   remote: https://github.com/pulibrary/requests.git
-  revision: 2b11eb8a6f1e7e1438b87d612aadcaf0f77304e2
+  revision: 8079657b654a0b40a83339a7b43335d5fc4cc88f
   specs:
     requests (0.0.2)
       bootstrap


### PR DESCRIPTION
Link is still present as it should be
https://catalog-staging.princeton.edu/requests/5636487?mfhd=5744248&source=pulsearch

Link is no longer present
https://catalog-staging.princeton.edu/requests/1000059

Like it is in prod:
https://catalog.princeton.edu/requests/1000059