### PR TITLE
Remove unused lines from application.css

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,11 +12,10 @@
  *
  *= require  'blacklight_range_limit'
  *= require 'blacklight_advanced_search'
+ *= require chosen
  *= require introjs
  *= require_self
  */
-
-@import 'chosen';
 
 @import 'variables/breaks';
 @import 'variables/colors';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,10 +16,6 @@
  *= require_self
  */
 
-// Temporary fix until the chosen gem 1.8.3 is fixed
-$chosen-sprite: image-url('chosen-sprite.png');
-$chosen-sprite-retina: image-url('chosen-sprite@2x.png');
-
 @import 'chosen';
 
 @import 'variables/breaks';


### PR DESCRIPTION
closes #1276 

With the chosen-rails upgrade to 1.8.7 we no longer need to upload image-url('chosen-sprite.png') and image-url('chosen-sprite@2x.png') before importing the chosen-rails gem.
for more info see: https://github.com/tsechingho/chosen-rails/pull/101/files and https://github.com/tsechingho/chosen-rails/issues/97