### PR TITLE
Remove Mini Racer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,8 +24,6 @@ gem 'modernizr-rails'
 gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .js.coffee assets and views
 gem 'coffee-rails', '~> 4.2.0'
-# See https://github.com/sstephenson/execjs#readme for more supported runtimes
-gem 'mini_racer'
 
 # Use jquery as the JavaScript library
 # jest tests use yarn to get jquery; if upgrading here keep that version in sync

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,7 +277,6 @@ GEM
       addressable (~> 2.3)
     lcsort (0.9.1)
     library_stdnums (1.6.0)
-    libv8 (7.3.492.27.1)
     lograge (0.11.2)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -302,8 +301,6 @@ GEM
     method_source (0.9.2)
     mini_mime (1.1.0)
     mini_portile2 (2.5.0)
-    mini_racer (0.2.6)
-      libv8 (>= 6.9.411)
     minitest (5.14.4)
     modernizr-rails (2.7.1)
     msgpack (1.3.1)
@@ -597,7 +594,6 @@ DEPENDENCIES
   lograge
   logstash-event
   mail_form
-  mini_racer
   modernizr-rails
   omniauth-cas
   openurl (~> 1.0)


### PR DESCRIPTION
We have Node now. Closes #2188

We'll have to update NodeJS to get this in.

![Screen Shot 2020-09-28 at 9 52 30 AM](https://user-images.githubusercontent.com/2806645/94462550-8be5f300-0170-11eb-9163-2bf32196640b.png)
