### PR TITLE
Include rake task to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ To install run
   ```
   bundle install
   yarn install
+  rake pulsearch:solr:update
   ```
 
 ### Database Configuration


### PR DESCRIPTION
 We don't have an explicit "Install" section. Is throwing this command here sufficient?

Closes #2309.