### PR TITLE
Pinning bundler to 2.2.14 to fix the libv8 install issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           name: Set Timezone to EST
           command: echo 'America/New_York' = /etc/timezone
       # Install Bundler
-      - run: gem install bundler -v '~> 2.0'
+      - run: gem install bundler -v '2.2.14'
       # Restore bundle cache
       - restore_cache:
           keys:


### PR DESCRIPTION
Without pinning bundler you start seeing the error, whenever an existing cache is not used.
```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/home/circleci/orangelight/vendor/bundle/ruby/2.6.0/gems/libv8-7.3.492.27.1/ext/libv8
/usr/local/bin/ruby -I /usr/local/lib/ruby/2.6.0 -r
./siteconf20210319-3474-1pkqj58.rb extconf.rb
creating Makefile
```