### PR TITLE
Configure solr before starting it

### DIFF
--- a/lib/tasks/server.rake
+++ b/lib/tasks/server.rake
@@ -40,6 +40,7 @@ namespace :servers do
 
   desc "Start the Apache Solr and PostgreSQL container services using Lando."
   task start: :environment do
+    Rake::Task["pulsearch:solr:update"].invoke
     system("lando start")
     system("rake servers:initialize")
     system("rake servers:initialize RAILS_ENV=test")


### PR DESCRIPTION
Unless we run pulsearch:solr:update before starting lando, solr does not
have the config files it needs and errors out with a message about not
being able to find solrconfig.xml.

Fixes https://github.com/pulibrary/orangelight/issues/2419