### PR TITLE
Update webpacker to address security issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,7 @@ gem 'sitemap_generator', '~> 6.0'
 
 gem 'voight_kampff', '~> 1.1'
 
-gem 'webpacker', '~> 4.0'
+gem 'webpacker'
 
 gem 'lograge'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -449,6 +449,7 @@ GEM
     selenium-webdriver (3.142.4)
       childprocess (>= 0.5, < 3.0)
       rubyzip (~> 1.2, >= 1.2.2)
+    semantic_range (3.0.0)
     serverengine (2.0.7)
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
@@ -539,10 +540,11 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webpacker (4.0.7)
-      activesupport (>= 4.2)
+    webpacker (5.2.1)
+      activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
-      railties (>= 4.2)
+      railties (>= 5.2)
+      semantic_range (>= 2.3.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -622,10 +624,10 @@ DEPENDENCIES
   voight_kampff (~> 1.1)
   webdrivers
   webmock
-  webpacker (~> 4.0)
+  webpacker
   whenever (~> 0.11)
   yajl-ruby (>= 1.3.1)
   yard
 
 BUNDLED WITH
-   2.2.4
+   2.2.16


### PR DESCRIPTION
This should unblock several security upgrades that need to happen.
Webpacker 5.2.1 has been out since August 2020 so hopefully it's pretty
stable by now.