### PR TITLE
Updates the search results location display 

### DIFF
--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -92,10 +92,11 @@ export default class AvailabilityUpdater {
     return result;
   }
 
+  // search results
   process_result(record_id, holding_records) {
     for (let holding_id in holding_records) {
       const availability_info = holding_records[holding_id];
-      // a library name
+      // In Alma the label from the endpoint includes both the library name and the location.
       if (availability_info['label']) {
         const location = $(`*[data-location='true'][data-record-id='${record_id}'][data-holding-id='${holding_id}'] .results_location`);
         location.text(availability_info['label']);
@@ -114,6 +115,7 @@ export default class AvailabilityUpdater {
   }
 
   // show page
+  // In Alma the label from the endpoint includes both the library name and the location.
   process_single(holding_records) {
     return (() => {
       const result = [];

--- a/spec/fixtures/bibdata/holding_locations.json
+++ b/spec/fixtures/bibdata/holding_locations.json
@@ -1,1 +1,6596 @@
-[{"label":"African American Studies Reading Room (AAS). B-7-B","code":"aas","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/aas.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"","code":"anxa","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/anxa.json","library":{"label":"Forrestal Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null},{"label":"Documents Off-Site Storage","code":"anxadoc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/anxadoc.json","library":{"label":"Forrestal Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null},{"label":"Temporary","code":"anxafst","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/anxafst.json","library":{"label":"Forrestal Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null},{"label":"","code":"anxb","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/anxb.json","library":{"label":"Fine Annex","code":"annexb","order":3},"holding_library":null,"hours_location":null},{"label":"Locked","code":"anxbl","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/anxbl.json","library":{"label":"Fine Annex","code":"annexb","order":3},"holding_library":null,"hours_location":null},{"label":"Non Circulating","code":"anxbnc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/anxbnc.json","library":{"label":"Fine Annex","code":"annexb","order":3},"holding_library":null,"hours_location":null},{"label":"","code":"ast","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/ast.json","library":{"label":"Engineering Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering Library","code":"engineering"}},{"label":"Media Collection","code":"astrf","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/astrf.json","library":{"label":"Engineering Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering Library","code":"engineering"}},{"label":"Sylvia Beach Collection","code":"beac","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/beac.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"","code":"c","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/c.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Classics Collection (Clas)","code":"clas","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/clas.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Classics Collection (Clas): Non Circulating","code":"clasnc","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/clasnc.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Eugene B. Cook Chess Collection","code":"cook","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/cook.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Rare Books","code":"crare","aeon_location":true,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/crare.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Reference","code":"cref","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/cref.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Cotsen Children's Library","code":"ctsn","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/ctsn.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Cotsen Children's Library - Research Collection","code":"cotsenresearch"}},{"label":"Cotsen Children's Library: Reference","code":"ctsnrf","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/ctsnrf.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Cotsen Children's Library - Research Collection","code":"cotsenresearch"}},{"label":"Cataloging and Metadata Services","code":"dc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/dc.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Dixon Books","code":"dixn","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/dixn.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Government Documents Collection (DOCS)","code":"docs","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/docs.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Government Documents Collection (DOCS): Microforms","code":"docsm","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/docsm.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Trustee Reading Room Reference (DR)","code":"dr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/dr.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Trustee Reading Room Reference (DR): Atlases","code":"dra","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/dra.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Trustee Reading Room Reference (DR): Ready Reference","code":"drrr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/drrr.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Data and Statistical Services (DSS)","code":"dss","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/dss.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Edwards Collection","code":"ed","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/ed.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"English Graduate Study Room","code":"egsr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/egsr.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Online Resources","code":"elf","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/elf.json","library":{"label":"Online","code":"online","order":4},"holding_library":null,"hours_location":null},{"label":"*ONLINE*","code":"elf1","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/elf1.json","library":{"label":"Online","code":"online","order":4},"holding_library":null,"hours_location":null},{"label":"Accessible from Library Web Computers","code":"elf2","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/elf2.json","library":{"label":"Online","code":"online","order":4},"holding_library":null,"hours_location":null},{"label":"Online Resources","code":"elf3","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/elf3.json","library":{"label":"Online","code":"online","order":4},"holding_library":null,"hours_location":null},{"label":"Dixon eBooks","code":"elf4","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/elf4.json","library":{"label":"Online","code":"online","order":4},"holding_library":null,"hours_location":null},{"label":"Rare Books","code":"ex","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/ex.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Reference Collection in Dulles Reading Room","code":"exb","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/exb.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"J. Harlin O'Connell Collection","code":"exc","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/exc.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Laurance Roberts Carton Hunting Collection","code":"exca","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/exca.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Kenneth McKenzie Fable Collection","code":"exf","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/exf.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Miriam Y. Holden Collection","code":"exho","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/exho.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Incunabula Collection","code":"exi","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/exi.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Kane Collection","code":"exka","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/exka.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Otto von Kienbusch Angling Collection","code":"exki","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/exki.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Charles Scribner Collection of Charles Lamb","code":"exl","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/exl.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Robert Metzdorf Collection","code":"exme","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/exme.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Oversize ","code":"exov","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/exov.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Morris L. Parrish Collection","code":"expa","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/expa.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Kenneth H. Rockey Angling Collection","code":"exrc","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/exrc.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Leonard Milberg Coll. of American Poetry","code":"exrl","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/exrl.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Rare Books","code":"extr","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/extr.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Technical Services Reference","code":"extsf","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/extsf.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Harry B. Vandeventer Poetry Collection","code":"exv","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/exv.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Orlando F. Weber Coll. of Economic History","code":"exw","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/exw.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"","code":"f","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/f.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"French & Italian Graduate Study Room (FIS)","code":"fis","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/fis.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Microforms Services (Film)","code":"flm","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/flm.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Microforms Service","code":"microforms"}},{"label":"Microforms Services (FilmB)","code":"flmb","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/flmb.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Microforms Service","code":"microforms"}},{"label":"Microforms Services (FilmM)","code":"flmm","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/flmm.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Microforms Service","code":"microforms"}},{"label":"Microforms Services (FilmP)","code":"flmp","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/flmp.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Microforms Service","code":"microforms"}},{"label":"Non Circulating","code":"fnc","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/fnc.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Graphic Arts Collection","code":"ga","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/ga.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Graphic Arts: Reference Collection","code":"garf","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/garf.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Graphic Arts Collection","code":"gax","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/gax.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Western","code":"gest","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/gest.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Microforms Services: East Asian","code":"gestf","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/gestf.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Western Periodicals","code":"gestpe","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/gestpe.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Permanent Reserve","code":"gestpr","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/gestpr.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Rare Books","code":"gestrare","aeon_location":true,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/gestrare.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Reference","code":"gestrf","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/gestrf.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Reserve","code":"gstr","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/gstr.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Reference","code":"gstrf","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/gstrf.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Miriam Y. Holden Collection","code":"hldn","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/hldn.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"South East (CTSN)","code":"hsvc","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/hsvc.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"South East (East Asian)","code":"hsve","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/hsve.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"South East (GA)","code":"hsvg","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/hsvg.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"South East (MSS)","code":"hsvm","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/hsvm.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"South East (Num)","code":"hsvn","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/hsvn.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"South East (HM)","code":"hsvp","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/hsvp.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"South East (RB)","code":"hsvr","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/hsvr.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Rare Books: South East (Western Americana)","code":"hsvw","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/hsvw.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":null},{"label":"Laurence Hutton Collection","code":"htn","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/htn.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"","code":"hyc","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/hyc.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Periodicals","code":"hycpe","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/hycpe.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Rare Books","code":"hycrare","aeon_location":true,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/hycrare.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Reference","code":"hycrf","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/hycrf.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"","code":"hyg","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/hyg.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Microforms Services: East Asian","code":"hygf","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/hygf.json","library":{"label":"Forrestal Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null},{"label":"","code":"hyj","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/hyj.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"","code":"hyjpe","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/hyjpe.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Rare Books","code":"hyjrare","aeon_location":true,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/hyjrare.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Reference","code":"hyjrf","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/hyjrf.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"","code":"hyk","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/hyk.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Rare Books","code":"hykrare","aeon_location":true,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/hykrare.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Reference","code":"hykrf","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/hykrf.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"","code":"j","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/j.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Rare Books","code":"jrare","aeon_location":true,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/jrare.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Reference","code":"jref","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/jref.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"","code":"k","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/k.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Rare Books","code":"krare","aeon_location":true,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/krare.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Reference","code":"kref","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/kref.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"Locked Books","code":"l","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/l.json","library":{"label":"Forrestal Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null},{"label":"Law Cases and Statutes","code":"law","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/law.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Circulation Desk","code":"lrc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/lrc.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":null},{"label":"Permanent Reserve","code":"lrcpt","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/lrcpt.json","library":{"label":"Video Library","code":"hrc","order":2},"holding_library":null,"hours_location":null},{"label":"Reserve","code":"lrcr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/lrcr.json","library":{"label":"Video Library","code":"hrc","order":2},"holding_library":null,"hours_location":null},{"label":"Computer Media","code":"ltop","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/ltop.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Computer Media","code":"ltoppiapr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/ltoppiapr.json","library":{"label":"Stokes Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes Library","code":"stokes"}},{"label":"Computer Media","code":"ltopsa","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/ltopsa.json","library":{"label":"Marquand Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand Library of Art and Archaeology","code":"marquand"}},{"label":"Computer Media","code":"ltopsci","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/ltopsci.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"Computer Media","code":"ltopst","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/ltopst.json","library":{"label":"Engineering Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering Library","code":"engineering"}},{"label":"Historic Maps Collection","code":"map","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/map.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Audio Visual (Circulation Desk)","code":"mlis","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/mlis.json","library":{"label":"Mendel Music Library","code":"mendel","order":2},"holding_library":null,"hours_location":{"label":"Mendel Music Library","code":"music"}},{"label":"Manuscripts Collection","code":"mss","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/mss.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"","code":"mudd","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/mudd.json","library":{"label":"Mudd Manuscript Library","code":"mudd","order":2},"holding_library":null,"hours_location":{"label":"Mudd Manuscript Library and University Archives","code":"mudd"}},{"label":"Microforms","code":"mudf","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/mudf.json","library":{"label":"Mudd Manuscript Library","code":"mudd","order":2},"holding_library":null,"hours_location":{"label":"Mudd Manuscript Library and University Archives","code":"mudd"}},{"label":"","code":"mus","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/mus.json","library":{"label":"Mendel Music Library","code":"mendel","order":2},"holding_library":null,"hours_location":{"label":"Mendel Music Library","code":"music"}},{"label":"Graduate Reserve","code":"musg","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/musg.json","library":{"label":"Mendel Music Library","code":"mendel","order":2},"holding_library":null,"hours_location":{"label":"Mendel Music Library","code":"music"}},{"label":"New Book Shelf","code":"musnb","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/musnb.json","library":{"label":"Mendel Music Library","code":"mendel","order":2},"holding_library":null,"hours_location":{"label":"Mendel Music Library","code":"music"}},{"label":"Bound Periodicals","code":"muspe","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/muspe.json","library":{"label":"Mendel Music Library","code":"mendel","order":2},"holding_library":null,"hours_location":{"label":"Mendel Music Library","code":"music"}},{"label":"Reserve","code":"musr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/musr.json","library":{"label":"Mendel Music Library","code":"mendel","order":2},"holding_library":null,"hours_location":{"label":"Mendel Music Library","code":"music"}},{"label":"Reading Room (2nd Floor)","code":"musrg","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/musrg.json","library":{"label":"Mendel Music Library","code":"mendel","order":2},"holding_library":null,"hours_location":{"label":"Mendel Music Library","code":"music"}},{"label":"Near East Collections (NEC)","code":"nec","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/nec.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Near East Collections (NECnc): Non-Circulating","code":"necnc","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/necnc.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Near East Department Collection (NED). Jones Hall","code":"ned","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/ned.json","library":{"label":"East Asian Library","code":"eastasian","order":2},"holding_library":null,"hours_location":{"label":"East Asian Library","code":"eastasian"}},{"label":"New Order Request","code":"new","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/new.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Special Collections","code":"njpg","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/njpg.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Newspaper Collection (NR): Recent Issues","code":"nr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/nr.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Numismatics Collection","code":"num","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/num.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Numismatics Collection: Reference","code":"numrf","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/numrf.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"","code":"other","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/other.json","library":{"label":"Other Location","code":"other","order":4},"holding_library":null,"hours_location":null},{"label":"Princeton Collection","code":"p","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/p.json","library":{"label":"Forrestal Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null},{"label":"Princeton Borough Collection","code":"pb","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/pb.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"","code":"piapr","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/piapr.json","library":{"label":"Stokes Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes Library","code":"stokes"}},{"label":"Reserve","code":"piaprr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/piaprr.json","library":{"label":"Stokes Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes Library","code":"stokes"}},{"label":"","code":"ppl","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/ppl.json","library":{"label":"Harold P. Furth Plasma Physics Library","code":"plasma","order":2},"holding_library":null,"hours_location":{"label":"Plasma Physics Library","code":"plasma"}},{"label":"Indexes","code":"pplia","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/pplia.json","library":{"label":"Harold P. Furth Plasma Physics Library","code":"plasma","order":2},"holding_library":null,"hours_location":{"label":"Plasma Physics Library","code":"plasma"}},{"label":"Seminar Room","code":"pplla","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/pplla.json","library":{"label":"Harold P. Furth Plasma Physics Library","code":"plasma","order":2},"holding_library":null,"hours_location":{"label":"Plasma Physics Library","code":"plasma"}},{"label":"Office","code":"pplli","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/pplli.json","library":{"label":"Harold P. Furth Plasma Physics Library","code":"plasma","order":2},"holding_library":null,"hours_location":{"label":"Plasma Physics Library","code":"plasma"}},{"label":"New Book Shelf","code":"pplnb","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/pplnb.json","library":{"label":"Harold P. Furth Plasma Physics Library","code":"plasma","order":2},"holding_library":null,"hours_location":{"label":"Plasma Physics Library","code":"plasma"}},{"label":"Periodicals","code":"pplps","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/pplps.json","library":{"label":"Harold P. Furth Plasma Physics Library","code":"plasma","order":2},"holding_library":null,"hours_location":{"label":"Plasma Physics Library","code":"plasma"}},{"label":"Reserve","code":"pplr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/pplr.json","library":{"label":"Harold P. Furth Plasma Physics Library","code":"plasma","order":2},"holding_library":null,"hours_location":{"label":"Plasma Physics Library","code":"plasma"}},{"label":"Technical Reports","code":"pplrdr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/pplrdr.json","library":{"label":"Harold P. Furth Plasma Physics Library","code":"plasma","order":2},"holding_library":null,"hours_location":{"label":"Plasma Physics Library","code":"plasma"}},{"label":"Reference","code":"pplrf","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/pplrf.json","library":{"label":"Harold P. Furth Plasma Physics Library","code":"plasma","order":2},"holding_library":null,"hours_location":{"label":"Plasma Physics Library","code":"plasma"}},{"label":"Ready Reference","code":"pplrr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/pplrr.json","library":{"label":"Harold P. Furth Plasma Physics Library","code":"plasma","order":2},"holding_library":null,"hours_location":{"label":"Plasma Physics Library","code":"plasma"}},{"label":"Theses","code":"pplt","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/pplt.json","library":{"label":"Harold P. Furth Plasma Physics Library","code":"plasma","order":2},"holding_library":null,"hours_location":{"label":"Plasma Physics Library","code":"plasma"}},{"label":"Periodicals Collection (PR)","code":"pr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/pr.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Preservation Office","code":"pres","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/pres.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Princetoniana Collection","code":"prnc","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/prnc.json","library":{"label":"Mudd Manuscript Library","code":"mudd","order":2},"holding_library":null,"hours_location":{"label":"Mudd Manuscript Library and University Archives","code":"mudd"}},{"label":"Near East Periodicals Collection","code":"prne","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/prne.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Robert Patterson Collection","code":"ptt","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/ptt.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"African American Studies Reading Room (AAS): Reserve. B-7-B","code":"raas","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/raas.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Gov Docs","code":"rcpgp","aeon_location":false,"recap_electronic_delivery_location":true,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcpgp.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Firestone Library","code":"firestone","order":1},"hours_location":null},{"label":"JSTOR Restricted","code":"rcpjq","aeon_location":false,"recap_electronic_delivery_location":true,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcpjq.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":null,"hours_location":null},{"label":"","code":"rcppa","aeon_location":false,"recap_electronic_delivery_location":true,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcppa.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":null,"hours_location":null},{"label":"Supervised use in Firestone ","code":"rcppb","aeon_location":false,"recap_electronic_delivery_location":true,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcppb.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Firestone Library","code":"firestone","order":1},"hours_location":null},{"label":"Restricted Backup Copies","code":"rcppe","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcppe.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":null,"hours_location":null},{"label":"Use in Firestone Microforms only","code":"rcppf","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcppf.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Firestone Library","code":"firestone","order":1},"hours_location":null},{"label":"RBSC Off-Site Storage","code":"rcppg","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcppg.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"hours_location":null},{"label":"Mudd Off-Site Storage","code":"rcpph","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcpph.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Mudd Manuscript Library","code":"mudd","order":2},"hours_location":null},{"label":"Marquand Library use only","code":"rcppj","aeon_location":false,"recap_electronic_delivery_location":true,"open":false,"requestable":true,"always_requestable":true,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcppj.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Marquand Library","code":"marquand","order":2},"hours_location":null},{"label":"Mendel Music Library use only","code":"rcppk","aeon_location":false,"recap_electronic_delivery_location":true,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcppk.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Mendel Music Library","code":"mendel","order":2},"hours_location":null},{"label":"East Asian Library use only","code":"rcppl","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcppl.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"East Asian Library","code":"eastasian","order":2},"hours_location":null},{"label":"Donald E. Stokes Library use only","code":"rcppm","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcppm.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Stokes Library","code":"stokes","order":2},"hours_location":null},{"label":"Lewis Library use only","code":"rcppn","aeon_location":false,"recap_electronic_delivery_location":true,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcppn.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Lewis Library","code":"lewis","order":2},"hours_location":null},{"label":"Plasma Physics use only","code":"rcppq","aeon_location":false,"recap_electronic_delivery_location":true,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcppq.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Harold P. Furth Plasma Physics Library","code":"plasma","order":2},"hours_location":null},{"label":"Lewis Library (Rare) use only","code":"rcpps","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcpps.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Lewis Library","code":"lewis","order":2},"hours_location":null},{"label":"Technical Reports Offsite. Contact techrpts@princeton.edu","code":"rcppt","aeon_location":false,"recap_electronic_delivery_location":true,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcppt.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Engineering Library","code":"engineering","order":2},"hours_location":null},{"label":"Architecture Library use only","code":"rcppw","aeon_location":false,"recap_electronic_delivery_location":true,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcppw.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Architecture Library","code":"architecture","order":2},"hours_location":null},{"label":"Marquand Library (Rare) use only","code":"rcppz","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcppz.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Marquand Library","code":"marquand","order":2},"hours_location":null},{"label":"Reading Room use only","code":"rcpqb","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcpqb.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":null,"hours_location":null},{"label":"Mendel Music Library use only","code":"rcpqk","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcpqk.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Mendel Music Library","code":"mendel","order":2},"hours_location":null},{"label":"Firestone Microforms or East Asian Library use only","code":"rcpql","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcpql.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"East Asian Library","code":"eastasian","order":2},"hours_location":null},{"label":"Video Collection","code":"rcpqv","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcpqv.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Firestone Library","code":"firestone","order":1},"hours_location":null},{"label":"Broadcast Center use only","code":"rcpqx","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcpqx.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":null,"hours_location":null},{"label":"Cotsen Library Off-Site Storage","code":"rcpxc","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcpxc.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"hours_location":null},{"label":"Graphic Arts Off-Site Storage","code":"rcpxg","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcpxg.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"hours_location":null},{"label":"Manuscripts Off-Site Storage","code":"rcpxm","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcpxm.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"hours_location":null},{"label":"Numismatics Off-Site Storage","code":"rcpxn","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcpxn.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"hours_location":null},{"label":"Historic Maps Off-Site Storage","code":"rcpxp","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcpxp.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"hours_location":null},{"label":"Rare Books Off-Site Storage","code":"rcpxr","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcpxr.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"hours_location":null},{"label":"Western Amercian Off-Site Storage","code":"rcpxw","aeon_location":true,"recap_electronic_delivery_location":true,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcpxw.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"hours_location":null},{"label":"Special Items Off-Site Storage","code":"rcpxx","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/rcpxx.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"hours_location":null},{"label":"Reserve","code":"res","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/res.json","library":{"label":"Forrestal Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null},{"label":"Circulation Desk (3 Hour Reserve)","code":"resc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/resc.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Circulation Desk (24 Hour Reserve)","code":"reso","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/reso.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Robert H. Taylor Collection","code":"rht","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/rht.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Religion Graduate Study Room (SREL): Reserve","code":"rrel","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rrel.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Classics Graduate Study (SC): Reserve","code":"rsc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rsc.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Germanic Languages Graduate Study Room (SD): Reserve","code":"rsd","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rsd.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"English Graduate Study Room (EGSR): Reserve","code":"rse","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rse.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"History Reference (SH): Reserve","code":"rsh","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/rsh.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Politics Graduate Study Room: Reserve","code":"rshp","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rshp.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Russian Studies Reading Room (SLV): Reserve","code":"rslv","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rslv.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Near East Graduate Study Room (SNE): Reserve","code":"rsne","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rsne.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Anthropology Graduate Study Room: Reserve","code":"rsnst","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rsnst.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Philosophy Graduate Study Room: Reserve","code":"rsp","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rsp.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Comparative Literature Graduate Study Room (SPC): Reserve","code":"rspc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rspc.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Sociology Graduate Study Room (SSA): Reserve","code":"rssa","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rssa.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Economics Graduate Study Room: Reserve","code":"rsx","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/rsx.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"","code":"sa","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/sa.json","library":{"label":"Marquand Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand Library of Art and Archaeology","code":"marquand"}},{"label":"Barr Ferree Collection","code":"saf","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/saf.json","library":{"label":"Marquand Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand Library of Art and Archaeology","code":"marquand"}},{"label":"Tang Reading Room","code":"safesrf","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/safesrf.json","library":{"label":"Marquand Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand Library of Art and Archaeology","code":"marquand"}},{"label":"Microforms","code":"safi","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/safi.json","library":{"label":"Marquand Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand Library of Art and Archaeology","code":"marquand"}},{"label":"Manuscripts","code":"sams","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sams.json","library":{"label":"Marquand Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand Library of Art and Archaeology","code":"marquand"}},{"label":"Manuscripts: Reference","code":"samsrf","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/samsrf.json","library":{"label":"Marquand Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand Library of Art and Archaeology","code":"marquand"}},{"label":"Photography","code":"saph","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/saph.json","library":{"label":"Marquand Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand Library of Art and Archaeology","code":"marquand"}},{"label":"Photography Reference","code":"saphrf","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/saphrf.json","library":{"label":"Marquand Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand Library of Art and Archaeology","code":"marquand"}},{"label":"Reserve","code":"sar","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sar.json","library":{"label":"Marquand Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand Library of Art and Archaeology","code":"marquand"}},{"label":"Reference","code":"sarf","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/sarf.json","library":{"label":"Marquand Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand Library of Art and Archaeology","code":"marquand"}},{"label":"Storage","code":"sarp","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sarp.json","library":{"label":"Marquand Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand Library of Art and Archaeology","code":"marquand"}},{"label":"Rare Books: Miscellanea","code":"sat","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/sat.json","library":{"label":"Marquand Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand Library of Art and Archaeology","code":"marquand"}},{"label":"Workroom","code":"sawr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sawr.json","library":{"label":"Marquand Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand Library of Art and Archaeology","code":"marquand"}},{"label":"Rare Books","code":"sax","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/sax.json","library":{"label":"Marquand Library","code":"marquand","order":2},"holding_library":null,"hours_location":{"label":"Marquand Library of Art and Archaeology","code":"marquand"}},{"label":"Classics Graduate Study (SC)","code":"sc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/sc.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Friend Center Archive","code":"scc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scc.json","library":{"label":"Engineering Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering Library","code":"engineering"}},{"label":"","code":"sci","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sci.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"Documents","code":"scidoc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scidoc.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"E/F Oversize and Atlases","code":"sciefa","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sciefa.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"GIS and Digital Map Center","code":"scigis","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scigis.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"Graduate Reading","code":"scigr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scigr.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"Limited Access (Fine Hall Wing A-Floor)","code":"scilaf","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scilaf.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"Limited Access","code":"scilal","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scilal.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"Map Collection","code":"scimap","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scimap.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Map and Geospatial Information Center","code":"geoscimap"}},{"label":"Map Collection. Map Case","code":"scimc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scimc.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Map and Geospatial Information Center","code":"geoscimap"}},{"label":"Map Collection. Map Case Max","code":"scimcm","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scimcm.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Map and Geospatial Information Center","code":"geoscimap"}},{"label":"Microforms","code":"scimic","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scimic.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"Map Collection. Lateral File","code":"sciml","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sciml.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Map and Geospatial Information Center","code":"geoscimap"}},{"label":"Map Collection. Reference Maps","code":"scimlrf","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/scimlrf.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Map and Geospatial Information Center","code":"geoscimap"}},{"label":"Multimedia","code":"scimm","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scimm.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"New Book Shelf","code":"scinb","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scinb.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"Pamphlet","code":"scipam","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scipam.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"Peyton Hall Observing Room","code":"sciph","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sciph.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"Reference (Fine Hall Wing)","code":"sciref","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/sciref.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"Reference (Information Desk)","code":"scirefl","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/scirefl.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"Course Reserve","code":"scires","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scires.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"Term Loan Reserves","code":"sciresp","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sciresp.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"SuDoc Collection","code":"scisd","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scisd.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"Serials (shelved by serial title)","code":"sciss","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sciss.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"Theses","code":"scith","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scith.json","library":{"label":"Lewis Library","code":"lewis","order":2},"holding_library":null,"hours_location":{"label":"Lewis Library","code":"lewis"}},{"label":"","code":"scsbcul","aeon_location":false,"recap_electronic_delivery_location":true,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scsbcul.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":null,"hours_location":null},{"label":"","code":"scsbnypl","aeon_location":false,"recap_electronic_delivery_location":true,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/scsbnypl.json","library":{"label":"ReCAP","code":"recap","order":3},"holding_library":null,"hours_location":null},{"label":"Classics Theses","code":"sct","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sct.json","library":{"label":"Forrestal Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null},{"label":"Germanic Languages Graduate Study Room (SD)","code":"sd","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/sd.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"German Languages Theses","code":"sdt","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sdt.json","library":{"label":"Forrestal Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null},{"label":"Scribner Room (SE)","code":"se","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/se.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Scribner Room (SEREF): Reference","code":"seref","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/seref.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"English Theses","code":"set","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/set.json","library":{"label":"Forrestal Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null},{"label":"History Reference (SH)","code":"sh","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/sh.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Politics Graduate Study Room","code":"shp","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/shp.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Hellenic Studies Reading Room (SHS)","code":"shs","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/shs.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"History Theses","code":"sht","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sht.json","library":{"label":"Forrestal Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null},{"label":"Slavic Graduate Study Room (SLAV)","code":"slav","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/slav.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Near East Graduate Study Room (SNE)","code":"sne","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/sne.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Philosophy Graduate Study Room","code":"sp","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/sp.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Comparative Literature Graduate Study Room (SPC)","code":"spc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/spc.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"SPIA","code":"spia","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/spia.json","library":{"label":"Stokes Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes Library","code":"stokes"}},{"label":"Atlases","code":"spiaa","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/spiaa.json","library":{"label":"Stokes Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes Library","code":"stokes"}},{"label":"Indexes","code":"spiai","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/spiai.json","library":{"label":"Stokes Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes Library","code":"stokes"}},{"label":"Periodicals","code":"spiaps","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/spiaps.json","library":{"label":"Stokes Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes Library","code":"stokes"}},{"label":"Reference","code":"spiarf","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/spiarf.json","library":{"label":"Stokes Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes Library","code":"stokes"}},{"label":"Writing Shelf","code":"spiaws","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/spiaws.json","library":{"label":"Stokes Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes Library","code":"stokes"}},{"label":"Reserve","code":"spir","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/spir.json","library":{"label":"Stokes Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes Library","code":"stokes"}},{"label":"Comparative Literature Graduate Study Room","code":"spl","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/spl.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"SPR","code":"spr","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/spr.json","library":{"label":"Stokes Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes Library","code":"stokes"}},{"label":"Microforms","code":"sprf","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sprf.json","library":{"label":"Stokes Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes Library","code":"stokes"}},{"label":"Periodicals","code":"sprps","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sprps.json","library":{"label":"Stokes Library","code":"stokes","order":2},"holding_library":null,"hours_location":{"label":"Stokes Library","code":"stokes"}},{"label":"Spanish & Portuguese Graduate Study Room (SPS)","code":"sps","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/sps.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Philosophy Theses","code":"spt","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/spt.json","library":{"label":"Forrestal Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null},{"label":"Religion Graduate Study (SREL)","code":"srel","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/srel.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Romance Theses","code":"srt","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/srt.json","library":{"label":"Forrestal Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null},{"label":"Sociology Graduate Study Room","code":"ssa","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/ssa.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Social Science Reference Center","code":"ssrc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/ssrc.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Government Documents Collection (DOCS): Census","code":"ssrcdc","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/ssrcdc.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Data and Statistical Services (DSS): Stat Abstracts","code":"ssrcfo","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/ssrcfo.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Social Science Reference Center: Ready Reference","code":"ssrcrr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/ssrcrr.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"History Graduate Study (SSS)","code":"sss","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/sss.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"","code":"st","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/st.json","library":{"label":"Engineering Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering Library","code":"engineering"}},{"label":"Microforms","code":"stf","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/stf.json","library":{"label":"Fine Annex","code":"annexb","order":3},"holding_library":null,"hours_location":null},{"label":"Indexes and Abstracts","code":"stia","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/stia.json","library":{"label":"Engineering Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering Library","code":"engineering"}},{"label":"Engineering","code":"stlo","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/stlo.json","library":{"label":"Forrestal Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null},{"label":"New Book Shelf","code":"stnb","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/stnb.json","library":{"label":"Engineering Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering Library","code":"engineering"}},{"label":"","code":"str","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/str.json","library":{"label":"Engineering Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering Library","code":"engineering"}},{"label":"Reference","code":"strf","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/strf.json","library":{"label":"Engineering Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering Library","code":"engineering"}},{"label":"Term Loan Reserve","code":"strp","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/strp.json","library":{"label":"Engineering Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering Library","code":"engineering"}},{"label":"Reserve","code":"strr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/strr.json","library":{"label":"Engineering Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering Library","code":"engineering"}},{"label":"Serials","code":"stss","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/stss.json","library":{"label":"Engineering Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering Library","code":"engineering"}},{"label":"Theses","code":"stt","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/stt.json","library":{"label":"Engineering Library","code":"engineering","order":2},"holding_library":null,"hours_location":{"label":"Engineering Library","code":"engineering"}},{"label":"Reference","code":"sv","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/sv.json","library":{"label":"Mendel Music Library","code":"mendel","order":2},"holding_library":null,"hours_location":{"label":"Mendel Music Library","code":"music"}},{"label":"Facsimiles","code":"svf","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/svf.json","library":{"label":"Mendel Music Library","code":"mendel","order":2},"holding_library":null,"hours_location":{"label":"Mendel Music Library","code":"music"}},{"label":"Locked","code":"svl","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/svl.json","library":{"label":"Mendel Music Library","code":"mendel","order":2},"holding_library":null,"hours_location":{"label":"Mendel Music Library","code":"music"}},{"label":"Economics Graduate Study Room","code":"sx","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sx.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Social Science Reference Center: Index Tables","code":"sxfa","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/sxfa.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Pliny Fisk Library: Financial Serv.","code":"sxffi","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sxffi.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Pliny Fisk Library: Federal Reserve","code":"sxffr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sxffr.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Pliny Fisk Library: Index Tables","code":"sxfit","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/sxfit.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Pliny Fisk Library: Ready Reference","code":"sxfrr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/sxfrr.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Theses Collection","code":"t","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":true,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/t.json","library":{"label":"Forrestal Annex","code":"annexa","order":3},"holding_library":null,"hours_location":null},{"label":"Theatre Collection","code":"thx","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/thx.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Theatre Collection: Reference","code":"thxr","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/thxr.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Travel Guides (TRV)","code":"trv","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/trv.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"","code":"ues","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/ues.json","library":{"label":"Architecture Library","code":"architecture","order":2},"holding_library":null,"hours_location":{"label":"Architecture Library","code":"architecture"}},{"label":"Indexes","code":"uesia","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/uesia.json","library":{"label":"Architecture Library","code":"architecture","order":2},"holding_library":null,"hours_location":{"label":"Architecture Library","code":"architecture"}},{"label":"Librarian's Office","code":"uesla","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/uesla.json","library":{"label":"Architecture Library","code":"architecture","order":2},"holding_library":null,"hours_location":{"label":"Architecture Library","code":"architecture"}},{"label":"New Book Shelf","code":"uesnb","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/uesnb.json","library":{"label":"Architecture Library","code":"architecture","order":2},"holding_library":null,"hours_location":{"label":"Architecture Library","code":"architecture"}},{"label":"Reserve 3 Hour","code":"ueso","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/ueso.json","library":{"label":"Architecture Library","code":"architecture","order":2},"holding_library":null,"hours_location":{"label":"Architecture Library","code":"architecture"}},{"label":"Reserve Closed","code":"uesr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/uesr.json","library":{"label":"Architecture Library","code":"architecture","order":2},"holding_library":null,"hours_location":{"label":"Architecture Library","code":"architecture"}},{"label":"Reference","code":"uesrf","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/uesrf.json","library":{"label":"Architecture Library","code":"architecture","order":2},"holding_library":null,"hours_location":{"label":"Architecture Library","code":"architecture"}},{"label":"United Nations Collection","code":"un","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/un.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Circulation Desk","code":"vidl","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/vidl.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":null},{"label":"Reserve: Firestone (B-15-H)","code":"vidlr","aeon_location":false,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/vidlr.json","library":{"label":"Video Library","code":"hrc","order":2},"holding_library":null,"hours_location":null},{"label":"Junius Morgan Collection","code":"vrg","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/vrg.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"John Shaw Pierson Civil War Collection","code":"w","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/w.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Western Americana Collection","code":"wa","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/wa.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Western Americana: Reference Collection (WARF)","code":"warf","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/warf.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"William H. Scheide Library","code":"whs","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/whs.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"John Witherspoon Library","code":"wit","aeon_location":true,"recap_electronic_delivery_location":false,"open":false,"requestable":false,"always_requestable":true,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/wit.json","library":{"label":"Rare Books and Special Collections","code":"rare","order":2},"holding_library":null,"hours_location":{"label":"Firestone Library - Rare Books and Special Collections","code":"rbsc"}},{"label":"Very large books (XL)","code":"xl","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/xl.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Very large books (XLnc): Non-Circulating","code":"xlnc","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":false,"url":"https://bibdata.princeton.edu/locations/holding_locations/xlnc.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}},{"label":"Zeiss Wildlife Collection","code":"zeis","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":false,"always_requestable":false,"circulates":true,"url":"https://bibdata.princeton.edu/locations/holding_locations/zeis.json","library":{"label":"Firestone Library","code":"firestone","order":1},"holding_library":null,"hours_location":{"label":"Firestone Library - Building and Circulation/Reserves Hours","code":"firestone"}}]
+[
+    {
+      "label": "African American Studies Reading Room (AAS). B-7-B",
+      "code": "aas",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/aas.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "",
+      "code": "anxa",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/anxa.json",
+      "library": {
+        "label": "Forrestal Annex",
+        "code": "annexa",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Documents Off-Site Storage",
+      "code": "anxadoc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/anxadoc.json",
+      "library": {
+        "label": "Forrestal Annex",
+        "code": "annexa",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Temporary",
+      "code": "anxafst",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/anxafst.json",
+      "library": {
+        "label": "Forrestal Annex",
+        "code": "annexa",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "",
+      "code": "anxb",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/anxb.json",
+      "library": {
+        "label": "Fine Annex",
+        "code": "annexb",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Locked",
+      "code": "anxbl",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/anxbl.json",
+      "library": {
+        "label": "Fine Annex",
+        "code": "annexb",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Non Circulating",
+      "code": "anxbnc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/anxbnc.json",
+      "library": {
+        "label": "Fine Annex",
+        "code": "annexb",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "",
+      "code": "ast",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ast.json",
+      "library": {
+        "label": "Engineering Library",
+        "code": "engineering",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Engineering Library",
+        "code": "engineering"
+      }
+    },
+    {
+      "label": "Media Collection",
+      "code": "astrf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/astrf.json",
+      "library": {
+        "label": "Engineering Library",
+        "code": "engineering",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Engineering Library",
+        "code": "engineering"
+      }
+    },
+    {
+      "label": "Sylvia Beach Collection",
+      "code": "beac",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/beac.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "",
+      "code": "c",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/c.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Classics Collection (Clas)",
+      "code": "clas",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/clas.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Classics Collection (Clas): Non Circulating",
+      "code": "clasnc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/clasnc.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Eugene B. Cook Chess Collection",
+      "code": "cook",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/cook.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Rare Books",
+      "code": "crare",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/crare.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Reference",
+      "code": "cref",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/cref.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Cotsen Children's Library",
+      "code": "ctsn",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ctsn.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Cotsen Children's Library - Research Collection",
+        "code": "cotsenresearch"
+      }
+    },
+    {
+      "label": "Cotsen Children's Library: Reference",
+      "code": "ctsnrf",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ctsnrf.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Cotsen Children's Library - Research Collection",
+        "code": "cotsenresearch"
+      }
+    },
+    {
+      "label": "Cataloging and Metadata Services",
+      "code": "dc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/dc.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Dixon Books",
+      "code": "dixn",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/dixn.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Government Documents Collection (DOCS)",
+      "code": "docs",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/docs.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Government Documents Collection (DOCS): Microforms",
+      "code": "docsm",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/docsm.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Trustee Reading Room Reference (DR)",
+      "code": "dr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/dr.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Trustee Reading Room Reference (DR): Atlases",
+      "code": "dra",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/dra.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Trustee Reading Room Reference (DR): Ready Reference",
+      "code": "drrr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/drrr.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Data and Statistical Services (DSS)",
+      "code": "dss",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/dss.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Edwards Collection",
+      "code": "ed",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ed.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "English Graduate Study Room",
+      "code": "egsr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/egsr.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Online Resources",
+      "code": "elf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/elf.json",
+      "library": {
+        "label": "Online",
+        "code": "online",
+        "order": 4
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "*ONLINE*",
+      "code": "elf1",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/elf1.json",
+      "library": {
+        "label": "Online",
+        "code": "online",
+        "order": 4
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Accessible from Library Web Computers",
+      "code": "elf2",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/elf2.json",
+      "library": {
+        "label": "Online",
+        "code": "online",
+        "order": 4
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Online Resources",
+      "code": "elf3",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/elf3.json",
+      "library": {
+        "label": "Online",
+        "code": "online",
+        "order": 4
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Dixon eBooks",
+      "code": "elf4",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/elf4.json",
+      "library": {
+        "label": "Online",
+        "code": "online",
+        "order": 4
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Rare Books",
+      "code": "ex",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ex.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Reference Collection in Dulles Reading Room",
+      "code": "exb",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/exb.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "J. Harlin O'Connell Collection",
+      "code": "exc",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/exc.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Laurance Roberts Carton Hunting Collection",
+      "code": "exca",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/exca.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Kenneth McKenzie Fable Collection",
+      "code": "exf",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/exf.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Miriam Y. Holden Collection",
+      "code": "exho",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/exho.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Incunabula Collection",
+      "code": "exi",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/exi.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Kane Collection",
+      "code": "exka",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/exka.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Otto von Kienbusch Angling Collection",
+      "code": "exki",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/exki.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Charles Scribner Collection of Charles Lamb",
+      "code": "exl",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/exl.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Robert Metzdorf Collection",
+      "code": "exme",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/exme.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Oversize ",
+      "code": "exov",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/exov.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Morris L. Parrish Collection",
+      "code": "expa",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/expa.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Kenneth H. Rockey Angling Collection",
+      "code": "exrc",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/exrc.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Leonard Milberg Coll. of American Poetry",
+      "code": "exrl",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/exrl.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Rare Books",
+      "code": "extr",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/extr.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Technical Services Reference",
+      "code": "extsf",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/extsf.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Harry B. Vandeventer Poetry Collection",
+      "code": "exv",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/exv.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Orlando F. Weber Coll. of Economic History",
+      "code": "exw",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/exw.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "",
+      "code": "f",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/f.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "French & Italian Graduate Study Room (FIS)",
+      "code": "fis",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/fis.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Microforms Services (Film)",
+      "code": "flm",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/flm.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Microforms Service",
+        "code": "microforms"
+      }
+    },
+    {
+      "label": "Microforms Services (FilmB)",
+      "code": "flmb",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/flmb.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Microforms Service",
+        "code": "microforms"
+      }
+    },
+    {
+      "label": "Microforms Services (FilmM)",
+      "code": "flmm",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/flmm.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Microforms Service",
+        "code": "microforms"
+      }
+    },
+    {
+      "label": "Microforms Services (FilmP)",
+      "code": "flmp",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/flmp.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Microforms Service",
+        "code": "microforms"
+      }
+    },
+    {
+      "label": "Non Circulating",
+      "code": "fnc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/fnc.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Graphic Arts Collection",
+      "code": "ga",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ga.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Graphic Arts: Reference Collection",
+      "code": "garf",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/garf.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Graphic Arts Collection",
+      "code": "gax",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/gax.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Western",
+      "code": "gest",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/gest.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Microforms Services: East Asian",
+      "code": "gestf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/gestf.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Western Periodicals",
+      "code": "gestpe",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/gestpe.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Permanent Reserve",
+      "code": "gestpr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/gestpr.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Rare Books",
+      "code": "gestrare",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/gestrare.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Reference",
+      "code": "gestrf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/gestrf.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Reserve",
+      "code": "gstr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/gstr.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Reference",
+      "code": "gstrf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/gstrf.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Miriam Y. Holden Collection",
+      "code": "hldn",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hldn.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "South East (CTSN)",
+      "code": "hsvc",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hsvc.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "South East (East Asian)",
+      "code": "hsve",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hsve.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "South East (GA)",
+      "code": "hsvg",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hsvg.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "South East (MSS)",
+      "code": "hsvm",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hsvm.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "South East (Num)",
+      "code": "hsvn",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hsvn.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "South East (HM)",
+      "code": "hsvp",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hsvp.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "South East (RB)",
+      "code": "hsvr",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hsvr.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Rare Books: South East (Western Americana)",
+      "code": "hsvw",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hsvw.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Laurence Hutton Collection",
+      "code": "htn",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/htn.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "",
+      "code": "hyc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hyc.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Periodicals",
+      "code": "hycpe",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hycpe.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Rare Books",
+      "code": "hycrare",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hycrare.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Reference",
+      "code": "hycrf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hycrf.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "",
+      "code": "hyg",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hyg.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Microforms Services: East Asian",
+      "code": "hygf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hygf.json",
+      "library": {
+        "label": "Forrestal Annex",
+        "code": "annexa",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "",
+      "code": "hyj",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hyj.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "",
+      "code": "hyjpe",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hyjpe.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Rare Books",
+      "code": "hyjrare",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hyjrare.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Reference",
+      "code": "hyjrf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hyjrf.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "",
+      "code": "hyk",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hyk.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Rare Books",
+      "code": "hykrare",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hykrare.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Reference",
+      "code": "hykrf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/hykrf.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "",
+      "code": "j",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/j.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Rare Books",
+      "code": "jrare",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/jrare.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Reference",
+      "code": "jref",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/jref.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "",
+      "code": "k",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/k.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Rare Books",
+      "code": "krare",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/krare.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Reference",
+      "code": "kref",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/kref.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "Locked Books",
+      "code": "l",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/l.json",
+      "library": {
+        "label": "Forrestal Annex",
+        "code": "annexa",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Law Cases and Statutes",
+      "code": "law",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/law.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Circulation Desk",
+      "code": "lrc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/lrc.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Permanent Reserve",
+      "code": "lrcpt",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/lrcpt.json",
+      "library": {
+        "label": "Video Library",
+        "code": "hrc",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Reserve",
+      "code": "lrcr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/lrcr.json",
+      "library": {
+        "label": "Video Library",
+        "code": "hrc",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Computer Media",
+      "code": "ltop",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ltop.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Computer Media",
+      "code": "ltoppiapr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ltoppiapr.json",
+      "library": {
+        "label": "Stokes Library",
+        "code": "stokes",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Stokes Library",
+        "code": "stokes"
+      }
+    },
+    {
+      "label": "Computer Media",
+      "code": "ltopsa",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ltopsa.json",
+      "library": {
+        "label": "Marquand Library",
+        "code": "marquand",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Marquand Library of Art and Archaeology",
+        "code": "marquand"
+      }
+    },
+    {
+      "label": "Computer Media",
+      "code": "ltopsci",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ltopsci.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "Computer Media",
+      "code": "ltopst",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ltopst.json",
+      "library": {
+        "label": "Engineering Library",
+        "code": "engineering",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Engineering Library",
+        "code": "engineering"
+      }
+    },
+    {
+      "label": "Historic Maps Collection",
+      "code": "map",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/map.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Audio Visual (Circulation Desk)",
+      "code": "mlis",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/mlis.json",
+      "library": {
+        "label": "Mendel Music Library",
+        "code": "mendel",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Mendel Music Library",
+        "code": "music"
+      }
+    },
+    {
+      "label": "Manuscripts Collection",
+      "code": "mss",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/mss.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "",
+      "code": "mudd",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/mudd.json",
+      "library": {
+        "label": "Mudd Manuscript Library",
+        "code": "mudd",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Mudd Manuscript Library and University Archives",
+        "code": "mudd"
+      }
+    },
+    {
+      "label": "Microforms",
+      "code": "mudf",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/mudf.json",
+      "library": {
+        "label": "Mudd Manuscript Library",
+        "code": "mudd",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Mudd Manuscript Library and University Archives",
+        "code": "mudd"
+      }
+    },
+    {
+      "label": "",
+      "code": "mus",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/mus.json",
+      "library": {
+        "label": "Mendel Music Library",
+        "code": "mendel",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Mendel Music Library",
+        "code": "music"
+      }
+    },
+    {
+      "label": "Graduate Reserve",
+      "code": "musg",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/musg.json",
+      "library": {
+        "label": "Mendel Music Library",
+        "code": "mendel",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Mendel Music Library",
+        "code": "music"
+      }
+    },
+    {
+      "label": "New Book Shelf",
+      "code": "musnb",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/musnb.json",
+      "library": {
+        "label": "Mendel Music Library",
+        "code": "mendel",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Mendel Music Library",
+        "code": "music"
+      }
+    },
+    {
+      "label": "Bound Periodicals",
+      "code": "muspe",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/muspe.json",
+      "library": {
+        "label": "Mendel Music Library",
+        "code": "mendel",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Mendel Music Library",
+        "code": "music"
+      }
+    },
+    {
+      "label": "Reserve",
+      "code": "musr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/musr.json",
+      "library": {
+        "label": "Mendel Music Library",
+        "code": "mendel",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Mendel Music Library",
+        "code": "music"
+      }
+    },
+    {
+      "label": "Reading Room (2nd Floor)",
+      "code": "musrg",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/musrg.json",
+      "library": {
+        "label": "Mendel Music Library",
+        "code": "mendel",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Mendel Music Library",
+        "code": "music"
+      }
+    },
+    {
+      "label": "Near East Collections (NEC)",
+      "code": "nec",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/nec.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Near East Collections (NECnc): Non-Circulating",
+      "code": "necnc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/necnc.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Near East Department Collection (NED). Jones Hall",
+      "code": "ned",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ned.json",
+      "library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "East Asian Library",
+        "code": "eastasian"
+      }
+    },
+    {
+      "label": "New Order Request",
+      "code": "new",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/new.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Special Collections",
+      "code": "njpg",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/njpg.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Newspaper Collection (NR): Recent Issues",
+      "code": "nr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/nr.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Numismatics Collection",
+      "code": "num",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/num.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Numismatics Collection: Reference",
+      "code": "numrf",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/numrf.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "",
+      "code": "other",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/other.json",
+      "library": {
+        "label": "Other Location",
+        "code": "other",
+        "order": 4
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Princeton Collection",
+      "code": "p",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/p.json",
+      "library": {
+        "label": "Forrestal Annex",
+        "code": "annexa",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Princeton Borough Collection",
+      "code": "pb",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/pb.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "",
+      "code": "piapr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/piapr.json",
+      "library": {
+        "label": "Stokes Library",
+        "code": "stokes",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Stokes Library",
+        "code": "stokes"
+      }
+    },
+    {
+      "label": "Reserve",
+      "code": "piaprr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/piaprr.json",
+      "library": {
+        "label": "Stokes Library",
+        "code": "stokes",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Stokes Library",
+        "code": "stokes"
+      }
+    },
+    {
+      "label": "",
+      "code": "ppl",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ppl.json",
+      "library": {
+        "label": "Harold P. Furth Plasma Physics Library",
+        "code": "plasma",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Plasma Physics Library",
+        "code": "plasma"
+      }
+    },
+    {
+      "label": "Indexes",
+      "code": "pplia",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplia.json",
+      "library": {
+        "label": "Harold P. Furth Plasma Physics Library",
+        "code": "plasma",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Plasma Physics Library",
+        "code": "plasma"
+      }
+    },
+    {
+      "label": "Seminar Room",
+      "code": "pplla",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplla.json",
+      "library": {
+        "label": "Harold P. Furth Plasma Physics Library",
+        "code": "plasma",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Plasma Physics Library",
+        "code": "plasma"
+      }
+    },
+    {
+      "label": "Office",
+      "code": "pplli",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplli.json",
+      "library": {
+        "label": "Harold P. Furth Plasma Physics Library",
+        "code": "plasma",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Plasma Physics Library",
+        "code": "plasma"
+      }
+    },
+    {
+      "label": "New Book Shelf",
+      "code": "pplnb",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplnb.json",
+      "library": {
+        "label": "Harold P. Furth Plasma Physics Library",
+        "code": "plasma",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Plasma Physics Library",
+        "code": "plasma"
+      }
+    },
+    {
+      "label": "Periodicals",
+      "code": "pplps",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplps.json",
+      "library": {
+        "label": "Harold P. Furth Plasma Physics Library",
+        "code": "plasma",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Plasma Physics Library",
+        "code": "plasma"
+      }
+    },
+    {
+      "label": "Reserve",
+      "code": "pplr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplr.json",
+      "library": {
+        "label": "Harold P. Furth Plasma Physics Library",
+        "code": "plasma",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Plasma Physics Library",
+        "code": "plasma"
+      }
+    },
+    {
+      "label": "Technical Reports",
+      "code": "pplrdr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplrdr.json",
+      "library": {
+        "label": "Harold P. Furth Plasma Physics Library",
+        "code": "plasma",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Plasma Physics Library",
+        "code": "plasma"
+      }
+    },
+    {
+      "label": "Reference",
+      "code": "pplrf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplrf.json",
+      "library": {
+        "label": "Harold P. Furth Plasma Physics Library",
+        "code": "plasma",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Plasma Physics Library",
+        "code": "plasma"
+      }
+    },
+    {
+      "label": "Ready Reference",
+      "code": "pplrr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplrr.json",
+      "library": {
+        "label": "Harold P. Furth Plasma Physics Library",
+        "code": "plasma",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Plasma Physics Library",
+        "code": "plasma"
+      }
+    },
+    {
+      "label": "Theses",
+      "code": "pplt",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplt.json",
+      "library": {
+        "label": "Harold P. Furth Plasma Physics Library",
+        "code": "plasma",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Plasma Physics Library",
+        "code": "plasma"
+      }
+    },
+    {
+      "label": "Periodicals Collection (PR)",
+      "code": "pr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/pr.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Preservation Office",
+      "code": "pres",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/pres.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Princetoniana Collection",
+      "code": "prnc",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/prnc.json",
+      "library": {
+        "label": "Mudd Manuscript Library",
+        "code": "mudd",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Mudd Manuscript Library and University Archives",
+        "code": "mudd"
+      }
+    },
+    {
+      "label": "Near East Periodicals Collection",
+      "code": "prne",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/prne.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Robert Patterson Collection",
+      "code": "ptt",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ptt.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "African American Studies Reading Room (AAS): Reserve. B-7-B",
+      "code": "raas",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/raas.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Gov Docs",
+      "code": "rcpgp",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": true,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpgp.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "hours_location": null
+    },
+    {
+      "label": "JSTOR Restricted",
+      "code": "rcpjq",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": true,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpjq.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "",
+      "code": "rcppa",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": true,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppa.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Supervised use in Firestone ",
+      "code": "rcppb",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": true,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppb.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Restricted Backup Copies",
+      "code": "rcppe",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppe.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Use in Firestone Microforms only",
+      "code": "rcppf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppf.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "hours_location": null
+    },
+    {
+      "label": "RBSC Off-Site Storage",
+      "code": "rcppg",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppg.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Mudd Off-Site Storage",
+      "code": "rcpph",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpph.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Mudd Manuscript Library",
+        "code": "mudd",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Marquand Library use only",
+      "code": "rcppj",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": true,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppj.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Marquand Library",
+        "code": "marquand",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Mendel Music Library use only",
+      "code": "rcppk",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": true,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppk.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Mendel Music Library",
+        "code": "mendel",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "East Asian Library use only",
+      "code": "rcppl",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppl.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Donald E. Stokes Library use only",
+      "code": "rcppm",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppm.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Stokes Library",
+        "code": "stokes",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Lewis Library use only",
+      "code": "rcppn",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": true,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppn.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Plasma Physics use only",
+      "code": "rcppq",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": true,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppq.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Harold P. Furth Plasma Physics Library",
+        "code": "plasma",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Lewis Library (Rare) use only",
+      "code": "rcpps",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpps.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Technical Reports Offsite. Contact techrpts@princeton.edu",
+      "code": "rcppt",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": true,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppt.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Engineering Library",
+        "code": "engineering",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Architecture Library use only",
+      "code": "rcppw",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": true,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppw.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Architecture Library",
+        "code": "architecture",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Marquand Library (Rare) use only",
+      "code": "rcppz",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppz.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Marquand Library",
+        "code": "marquand",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Reading Room use only",
+      "code": "rcpqb",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpqb.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Mendel Music Library use only",
+      "code": "rcpqk",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpqk.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Mendel Music Library",
+        "code": "mendel",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Firestone Microforms or East Asian Library use only",
+      "code": "rcpql",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpql.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "East Asian Library",
+        "code": "eastasian",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Video Collection",
+      "code": "rcpqv",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpqv.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Broadcast Center use only",
+      "code": "rcpqx",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpqx.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Cotsen Library Off-Site Storage",
+      "code": "rcpxc",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpxc.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Graphic Arts Off-Site Storage",
+      "code": "rcpxg",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpxg.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Manuscripts Off-Site Storage",
+      "code": "rcpxm",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpxm.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Numismatics Off-Site Storage",
+      "code": "rcpxn",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpxn.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Historic Maps Off-Site Storage",
+      "code": "rcpxp",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpxp.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Rare Books Off-Site Storage",
+      "code": "rcpxr",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpxr.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Western Amercian Off-Site Storage",
+      "code": "rcpxw",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": true,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpxw.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Special Items Off-Site Storage",
+      "code": "rcpxx",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpxx.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "hours_location": null
+    },
+    {
+      "label": "Reserve",
+      "code": "res",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/res.json",
+      "library": {
+        "label": "Forrestal Annex",
+        "code": "annexa",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Circulation Desk (3 Hour Reserve)",
+      "code": "resc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/resc.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Circulation Desk (24 Hour Reserve)",
+      "code": "reso",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/reso.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Robert H. Taylor Collection",
+      "code": "rht",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rht.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Religion Graduate Study Room (SREL): Reserve",
+      "code": "rrel",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rrel.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Classics Graduate Study (SC): Reserve",
+      "code": "rsc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rsc.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Germanic Languages Graduate Study Room (SD): Reserve",
+      "code": "rsd",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rsd.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "English Graduate Study Room (EGSR): Reserve",
+      "code": "rse",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rse.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "History Reference (SH): Reserve",
+      "code": "rsh",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rsh.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Politics Graduate Study Room: Reserve",
+      "code": "rshp",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rshp.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Russian Studies Reading Room (SLV): Reserve",
+      "code": "rslv",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rslv.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Near East Graduate Study Room (SNE): Reserve",
+      "code": "rsne",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rsne.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Anthropology Graduate Study Room: Reserve",
+      "code": "rsnst",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rsnst.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Philosophy Graduate Study Room: Reserve",
+      "code": "rsp",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rsp.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Comparative Literature Graduate Study Room (SPC): Reserve",
+      "code": "rspc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rspc.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Sociology Graduate Study Room (SSA): Reserve",
+      "code": "rssa",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rssa.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Economics Graduate Study Room: Reserve",
+      "code": "rsx",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/rsx.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "",
+      "code": "sa",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sa.json",
+      "library": {
+        "label": "Marquand Library",
+        "code": "marquand",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Marquand Library of Art and Archaeology",
+        "code": "marquand"
+      }
+    },
+    {
+      "label": "Barr Ferree Collection",
+      "code": "saf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/saf.json",
+      "library": {
+        "label": "Marquand Library",
+        "code": "marquand",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Marquand Library of Art and Archaeology",
+        "code": "marquand"
+      }
+    },
+    {
+      "label": "Tang Reading Room",
+      "code": "safesrf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/safesrf.json",
+      "library": {
+        "label": "Marquand Library",
+        "code": "marquand",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Marquand Library of Art and Archaeology",
+        "code": "marquand"
+      }
+    },
+    {
+      "label": "Microforms",
+      "code": "safi",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/safi.json",
+      "library": {
+        "label": "Marquand Library",
+        "code": "marquand",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Marquand Library of Art and Archaeology",
+        "code": "marquand"
+      }
+    },
+    {
+      "label": "Manuscripts",
+      "code": "sams",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sams.json",
+      "library": {
+        "label": "Marquand Library",
+        "code": "marquand",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Marquand Library of Art and Archaeology",
+        "code": "marquand"
+      }
+    },
+    {
+      "label": "Manuscripts: Reference",
+      "code": "samsrf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/samsrf.json",
+      "library": {
+        "label": "Marquand Library",
+        "code": "marquand",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Marquand Library of Art and Archaeology",
+        "code": "marquand"
+      }
+    },
+    {
+      "label": "Photography",
+      "code": "saph",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/saph.json",
+      "library": {
+        "label": "Marquand Library",
+        "code": "marquand",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Marquand Library of Art and Archaeology",
+        "code": "marquand"
+      }
+    },
+    {
+      "label": "Photography Reference",
+      "code": "saphrf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/saphrf.json",
+      "library": {
+        "label": "Marquand Library",
+        "code": "marquand",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Marquand Library of Art and Archaeology",
+        "code": "marquand"
+      }
+    },
+    {
+      "label": "Reserve",
+      "code": "sar",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sar.json",
+      "library": {
+        "label": "Marquand Library",
+        "code": "marquand",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Marquand Library of Art and Archaeology",
+        "code": "marquand"
+      }
+    },
+    {
+      "label": "Reference",
+      "code": "sarf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sarf.json",
+      "library": {
+        "label": "Marquand Library",
+        "code": "marquand",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Marquand Library of Art and Archaeology",
+        "code": "marquand"
+      }
+    },
+    {
+      "label": "Storage",
+      "code": "sarp",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sarp.json",
+      "library": {
+        "label": "Marquand Library",
+        "code": "marquand",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Marquand Library of Art and Archaeology",
+        "code": "marquand"
+      }
+    },
+    {
+      "label": "Rare Books: Miscellanea",
+      "code": "sat",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sat.json",
+      "library": {
+        "label": "Marquand Library",
+        "code": "marquand",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Marquand Library of Art and Archaeology",
+        "code": "marquand"
+      }
+    },
+    {
+      "label": "Workroom",
+      "code": "sawr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sawr.json",
+      "library": {
+        "label": "Marquand Library",
+        "code": "marquand",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Marquand Library of Art and Archaeology",
+        "code": "marquand"
+      }
+    },
+    {
+      "label": "Rare Books",
+      "code": "sax",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sax.json",
+      "library": {
+        "label": "Marquand Library",
+        "code": "marquand",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Marquand Library of Art and Archaeology",
+        "code": "marquand"
+      }
+    },
+    {
+      "label": "Classics Graduate Study (SC)",
+      "code": "sc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sc.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Friend Center Archive",
+      "code": "scc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scc.json",
+      "library": {
+        "label": "Engineering Library",
+        "code": "engineering",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Engineering Library",
+        "code": "engineering"
+      }
+    },
+    {
+      "label": "",
+      "code": "sci",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sci.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "Documents",
+      "code": "scidoc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scidoc.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "E/F Oversize and Atlases",
+      "code": "sciefa",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sciefa.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "GIS and Digital Map Center",
+      "code": "scigis",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scigis.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "Graduate Reading",
+      "code": "scigr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scigr.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "Limited Access (Fine Hall Wing A-Floor)",
+      "code": "scilaf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scilaf.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "Limited Access",
+      "code": "scilal",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scilal.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "Map Collection",
+      "code": "scimap",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scimap.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Map and Geospatial Information Center",
+        "code": "geoscimap"
+      }
+    },
+    {
+      "label": "Map Collection. Map Case",
+      "code": "scimc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scimc.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Map and Geospatial Information Center",
+        "code": "geoscimap"
+      }
+    },
+    {
+      "label": "Map Collection. Map Case Max",
+      "code": "scimcm",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scimcm.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Map and Geospatial Information Center",
+        "code": "geoscimap"
+      }
+    },
+    {
+      "label": "Microforms",
+      "code": "scimic",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scimic.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "Map Collection. Lateral File",
+      "code": "sciml",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sciml.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Map and Geospatial Information Center",
+        "code": "geoscimap"
+      }
+    },
+    {
+      "label": "Map Collection. Reference Maps",
+      "code": "scimlrf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scimlrf.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Map and Geospatial Information Center",
+        "code": "geoscimap"
+      }
+    },
+    {
+      "label": "Multimedia",
+      "code": "scimm",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scimm.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "New Book Shelf",
+      "code": "scinb",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scinb.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "Pamphlet",
+      "code": "scipam",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scipam.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "Peyton Hall Observing Room",
+      "code": "sciph",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sciph.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "Reference (Fine Hall Wing)",
+      "code": "sciref",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sciref.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "Reference (Information Desk)",
+      "code": "scirefl",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scirefl.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "Course Reserve",
+      "code": "scires",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scires.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "Term Loan Reserves",
+      "code": "sciresp",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sciresp.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "SuDoc Collection",
+      "code": "scisd",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scisd.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "Serials (shelved by serial title)",
+      "code": "sciss",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sciss.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "Theses",
+      "code": "scith",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scith.json",
+      "library": {
+        "label": "Lewis Library",
+        "code": "lewis",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Lewis Library",
+        "code": "lewis"
+      }
+    },
+    {
+      "label": "",
+      "code": "scsbcul",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": true,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scsbcul.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "",
+      "code": "scsbnypl",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": true,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/scsbnypl.json",
+      "library": {
+        "label": "ReCAP",
+        "code": "recap",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Classics Theses",
+      "code": "sct",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sct.json",
+      "library": {
+        "label": "Forrestal Annex",
+        "code": "annexa",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Germanic Languages Graduate Study Room (SD)",
+      "code": "sd",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sd.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "German Languages Theses",
+      "code": "sdt",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sdt.json",
+      "library": {
+        "label": "Forrestal Annex",
+        "code": "annexa",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Scribner Room (SE)",
+      "code": "se",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/se.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Scribner Room (SEREF): Reference",
+      "code": "seref",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/seref.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "English Theses",
+      "code": "set",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/set.json",
+      "library": {
+        "label": "Forrestal Annex",
+        "code": "annexa",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "History Reference (SH)",
+      "code": "sh",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sh.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Politics Graduate Study Room",
+      "code": "shp",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/shp.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Hellenic Studies Reading Room (SHS)",
+      "code": "shs",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/shs.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "History Theses",
+      "code": "sht",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sht.json",
+      "library": {
+        "label": "Forrestal Annex",
+        "code": "annexa",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Slavic Graduate Study Room (SLAV)",
+      "code": "slav",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/slav.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Near East Graduate Study Room (SNE)",
+      "code": "sne",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sne.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Philosophy Graduate Study Room",
+      "code": "sp",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sp.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Comparative Literature Graduate Study Room (SPC)",
+      "code": "spc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/spc.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "SPIA",
+      "code": "spia",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/spia.json",
+      "library": {
+        "label": "Stokes Library",
+        "code": "stokes",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Stokes Library",
+        "code": "stokes"
+      }
+    },
+    {
+      "label": "Atlases",
+      "code": "spiaa",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/spiaa.json",
+      "library": {
+        "label": "Stokes Library",
+        "code": "stokes",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Stokes Library",
+        "code": "stokes"
+      }
+    },
+    {
+      "label": "Indexes",
+      "code": "spiai",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/spiai.json",
+      "library": {
+        "label": "Stokes Library",
+        "code": "stokes",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Stokes Library",
+        "code": "stokes"
+      }
+    },
+    {
+      "label": "Periodicals",
+      "code": "spiaps",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/spiaps.json",
+      "library": {
+        "label": "Stokes Library",
+        "code": "stokes",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Stokes Library",
+        "code": "stokes"
+      }
+    },
+    {
+      "label": "Reference",
+      "code": "spiarf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/spiarf.json",
+      "library": {
+        "label": "Stokes Library",
+        "code": "stokes",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Stokes Library",
+        "code": "stokes"
+      }
+    },
+    {
+      "label": "Writing Shelf",
+      "code": "spiaws",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/spiaws.json",
+      "library": {
+        "label": "Stokes Library",
+        "code": "stokes",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Stokes Library",
+        "code": "stokes"
+      }
+    },
+    {
+      "label": "Reserve",
+      "code": "spir",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/spir.json",
+      "library": {
+        "label": "Stokes Library",
+        "code": "stokes",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Stokes Library",
+        "code": "stokes"
+      }
+    },
+    {
+      "label": "Comparative Literature Graduate Study Room",
+      "code": "spl",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/spl.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "SPR",
+      "code": "spr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/spr.json",
+      "library": {
+        "label": "Stokes Library",
+        "code": "stokes",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Stokes Library",
+        "code": "stokes"
+      }
+    },
+    {
+      "label": "Microforms",
+      "code": "sprf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sprf.json",
+      "library": {
+        "label": "Stokes Library",
+        "code": "stokes",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Stokes Library",
+        "code": "stokes"
+      }
+    },
+    {
+      "label": "Periodicals",
+      "code": "sprps",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sprps.json",
+      "library": {
+        "label": "Stokes Library",
+        "code": "stokes",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Stokes Library",
+        "code": "stokes"
+      }
+    },
+    {
+      "label": "Spanish & Portuguese Graduate Study Room (SPS)",
+      "code": "sps",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sps.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Philosophy Theses",
+      "code": "spt",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/spt.json",
+      "library": {
+        "label": "Forrestal Annex",
+        "code": "annexa",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Religion Graduate Study (SREL)",
+      "code": "srel",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/srel.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Romance Theses",
+      "code": "srt",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/srt.json",
+      "library": {
+        "label": "Forrestal Annex",
+        "code": "annexa",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Sociology Graduate Study Room",
+      "code": "ssa",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ssa.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Social Science Reference Center",
+      "code": "ssrc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ssrc.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Government Documents Collection (DOCS): Census",
+      "code": "ssrcdc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ssrcdc.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Data and Statistical Services (DSS): Stat Abstracts",
+      "code": "ssrcfo",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ssrcfo.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Social Science Reference Center: Ready Reference",
+      "code": "ssrcrr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ssrcrr.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "History Graduate Study (SSS)",
+      "code": "sss",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sss.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "",
+      "code": "st",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/st.json",
+      "library": {
+        "label": "Engineering Library",
+        "code": "engineering",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Engineering Library",
+        "code": "engineering"
+      }
+    },
+    {
+      "label": "Microforms",
+      "code": "stf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/stf.json",
+      "library": {
+        "label": "Fine Annex",
+        "code": "annexb",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Indexes and Abstracts",
+      "code": "stia",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/stia.json",
+      "library": {
+        "label": "Engineering Library",
+        "code": "engineering",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Engineering Library",
+        "code": "engineering"
+      }
+    },
+    {
+      "label": "Engineering",
+      "code": "stlo",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/stlo.json",
+      "library": {
+        "label": "Forrestal Annex",
+        "code": "annexa",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "New Book Shelf",
+      "code": "stnb",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/stnb.json",
+      "library": {
+        "label": "Engineering Library",
+        "code": "engineering",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Engineering Library",
+        "code": "engineering"
+      }
+    },
+    {
+      "label": "",
+      "code": "str",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/str.json",
+      "library": {
+        "label": "Engineering Library",
+        "code": "engineering",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Engineering Library",
+        "code": "engineering"
+      }
+    },
+    {
+      "label": "Reference",
+      "code": "strf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/strf.json",
+      "library": {
+        "label": "Engineering Library",
+        "code": "engineering",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Engineering Library",
+        "code": "engineering"
+      }
+    },
+    {
+      "label": "Term Loan Reserve",
+      "code": "strp",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/strp.json",
+      "library": {
+        "label": "Engineering Library",
+        "code": "engineering",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Engineering Library",
+        "code": "engineering"
+      }
+    },
+    {
+      "label": "Reserve",
+      "code": "strr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/strr.json",
+      "library": {
+        "label": "Engineering Library",
+        "code": "engineering",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Engineering Library",
+        "code": "engineering"
+      }
+    },
+    {
+      "label": "Serials",
+      "code": "stss",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/stss.json",
+      "library": {
+        "label": "Engineering Library",
+        "code": "engineering",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Engineering Library",
+        "code": "engineering"
+      }
+    },
+    {
+      "label": "Theses",
+      "code": "stt",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/stt.json",
+      "library": {
+        "label": "Engineering Library",
+        "code": "engineering",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Engineering Library",
+        "code": "engineering"
+      }
+    },
+    {
+      "label": "Reference",
+      "code": "sv",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sv.json",
+      "library": {
+        "label": "Mendel Music Library",
+        "code": "mendel",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Mendel Music Library",
+        "code": "music"
+      }
+    },
+    {
+      "label": "Facsimiles",
+      "code": "svf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/svf.json",
+      "library": {
+        "label": "Mendel Music Library",
+        "code": "mendel",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Mendel Music Library",
+        "code": "music"
+      }
+    },
+    {
+      "label": "Locked",
+      "code": "svl",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/svl.json",
+      "library": {
+        "label": "Mendel Music Library",
+        "code": "mendel",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Mendel Music Library",
+        "code": "music"
+      }
+    },
+    {
+      "label": "Economics Graduate Study Room",
+      "code": "sx",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sx.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Social Science Reference Center: Index Tables",
+      "code": "sxfa",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sxfa.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Pliny Fisk Library: Financial Serv.",
+      "code": "sxffi",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sxffi.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Pliny Fisk Library: Federal Reserve",
+      "code": "sxffr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sxffr.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Pliny Fisk Library: Index Tables",
+      "code": "sxfit",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sxfit.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Pliny Fisk Library: Ready Reference",
+      "code": "sxfrr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/sxfrr.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Theses Collection",
+      "code": "t",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/t.json",
+      "library": {
+        "label": "Forrestal Annex",
+        "code": "annexa",
+        "order": 3
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Theatre Collection",
+      "code": "thx",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/thx.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Theatre Collection: Reference",
+      "code": "thxr",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/thxr.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Travel Guides (TRV)",
+      "code": "trv",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/trv.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "",
+      "code": "ues",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ues.json",
+      "library": {
+        "label": "Architecture Library",
+        "code": "architecture",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Architecture Library",
+        "code": "architecture"
+      }
+    },
+    {
+      "label": "Indexes",
+      "code": "uesia",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/uesia.json",
+      "library": {
+        "label": "Architecture Library",
+        "code": "architecture",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Architecture Library",
+        "code": "architecture"
+      }
+    },
+    {
+      "label": "Librarian's Office",
+      "code": "uesla",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/uesla.json",
+      "library": {
+        "label": "Architecture Library",
+        "code": "architecture",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Architecture Library",
+        "code": "architecture"
+      }
+    },
+    {
+      "label": "New Book Shelf",
+      "code": "uesnb",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/uesnb.json",
+      "library": {
+        "label": "Architecture Library",
+        "code": "architecture",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Architecture Library",
+        "code": "architecture"
+      }
+    },
+    {
+      "label": "Reserve 3 Hour",
+      "code": "ueso",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/ueso.json",
+      "library": {
+        "label": "Architecture Library",
+        "code": "architecture",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Architecture Library",
+        "code": "architecture"
+      }
+    },
+    {
+      "label": "Reserve Closed",
+      "code": "uesr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/uesr.json",
+      "library": {
+        "label": "Architecture Library",
+        "code": "architecture",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Architecture Library",
+        "code": "architecture"
+      }
+    },
+    {
+      "label": "Reference",
+      "code": "uesrf",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/uesrf.json",
+      "library": {
+        "label": "Architecture Library",
+        "code": "architecture",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Architecture Library",
+        "code": "architecture"
+      }
+    },
+    {
+      "label": "United Nations Collection",
+      "code": "un",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/un.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Circulation Desk",
+      "code": "vidl",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/vidl.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Reserve: Firestone (B-15-H)",
+      "code": "vidlr",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/vidlr.json",
+      "library": {
+        "label": "Video Library",
+        "code": "hrc",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "Junius Morgan Collection",
+      "code": "vrg",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/vrg.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "John Shaw Pierson Civil War Collection",
+      "code": "w",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/w.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Western Americana Collection",
+      "code": "wa",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/wa.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Western Americana: Reference Collection (WARF)",
+      "code": "warf",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/warf.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "William H. Scheide Library",
+      "code": "whs",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/whs.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "John Witherspoon Library",
+      "code": "wit",
+      "aeon_location": true,
+      "recap_electronic_delivery_location": false,
+      "open": false,
+      "requestable": false,
+      "always_requestable": true,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/wit.json",
+      "library": {
+        "label": "Rare Books and Special Collections",
+        "code": "rare",
+        "order": 2
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Rare Books and Special Collections",
+        "code": "rbsc"
+      }
+    },
+    {
+      "label": "Very large books (XL)",
+      "code": "xl",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/xl.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Very large books (XLnc): Non-Circulating",
+      "code": "xlnc",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": false,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/xlnc.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    },
+    {
+      "label": "Zeiss Wildlife Collection",
+      "code": "zeis",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": false,
+      "always_requestable": false,
+      "circulates": true,
+      "url": "https://bibdata.princeton.edu/locations/holding_locations/zeis.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 1
+      },
+      "holding_library": null,
+      "hours_location": {
+        "label": "Firestone Library - Building and Circulation/Reserves Hours",
+        "code": "firestone"
+      }
+    }
+  ]

--- a/spec/helpers/locations_spec.rb
+++ b/spec/helpers/locations_spec.rb
@@ -74,6 +74,45 @@ RSpec.describe ApplicationHelper do
     end
   end
 
+  context 'when using Alma' do
+    before do
+      allow(Rails.configuration).to receive(:use_alma).and_return(true)
+    end
+
+    let(:fallback) { 'Fallback' }
+    let(:without_code) { { 'library' => 'Library Name', 'location' => fallback } }
+    let(:invalid_code) { { 'library' => 'Library Name', 'location' => fallback, 'location_code' => 'invalid' } }
+    let(:valid_code) { { 'library' => 'Library Name', 'location' => fallback, 'location_code' => 'aas' } }
+
+    it 'returns holding location label when location code lookup successful' do
+      stub_holding_locations
+      expect(holding_location_label(valid_code)).to eq('Firestone Library - African American Studies Reading Room (AAS). B-7-B')
+    end
+    it 'returns holding location value when location code lookup fails' do
+      stub_request(:get, "#{Requests.config['bibdata_base']}/locations/holding_locations.json")
+        .to_return(status: 500,
+                   body: '')
+      expect(holding_location_label(invalid_code)).to eq('Library Name - Fallback')
+    end
+    it 'returns holding location value when no location code' do
+      expect(holding_location_label(without_code)).to eq('Library Name - Fallback')
+    end
+    it 'returns nil when no location code or holding location value' do
+      expect(holding_location_label({})).to be_nil # -
+    end
+  end
+
+  describe '#aeon_location?' do
+    let(:loc) { { aeon_location: true } }
+
+    it 'returns the location aeon_location attribute value' do
+      expect(aeon_location?(loc)).to eq true
+    end
+    it 'returns false when nil location is passed to function' do
+      expect(aeon_location?(nil)).to eq false
+    end
+  end
+
   describe '#aeon_location?' do
     let(:loc) { { aeon_location: true } }
 


### PR DESCRIPTION
to include the library name and to be consistent when js runs.
Updates the record page location display that comes from js to include the library name. https://github.com/pulibrary/orangelight/issues/2467