### PR TITLE
Indicates babel-jest as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "jest": "^26.6.3",
+    "babel-jest": "26.6.3",
     "jquery": "3.5.1",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2294,7 +2294,7 @@ babel-helper-remap-async-to-generator@^6.24.1:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
-babel-jest@^26.6.3:
+babel-jest@26.6.3, babel-jest@^26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-26.6.3.tgz#d87d25cb0037577a0c89f82e5755c5d293c01056"
   integrity sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==


### PR DESCRIPTION
Indicates `babel-jest` as a dependency, otherwise it does not get installed and the tests won't run.

Thanks @hackartisan 