### PR TITLE
Temporarily disable guest account cleanup

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -94,6 +94,8 @@ every :tuesday, at: '2:00am', roles: [:sitemap] do
   logging_rake 'sitemap:refresh', output: { error: '/tmp/ol_sitemap.log', standard: '/tmp/ol_sitemap.log' }
 end
 
-every 1.day, at: '11pm', roles: [:cron_db] do
-  logging_rake 'orangelight:clean:guest_users', output: { error: '/tmp/clean_guest_users.log', standard: '/tmp/clean_guest_users.log' }
-end
+# Temporarily disable this while the job catches up so it doesn't start running
+# double or triple
+# every 1.day, at: '11pm', roles: [:cron_db] do
+#   logging_rake 'orangelight:clean:guest_users', output: { error: '/tmp/clean_guest_users.log', standard: '/tmp/clean_guest_users.log' }
+# end


### PR DESCRIPTION
It will probably take a few days for the job to run so I'm disabling it
on the worker. Don't want a deploy to schedule it again and make it run
double or triple.
