### PR TITLE
Display availability as Online in the search results and Unavailable in the record page for CDL records

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -248,8 +248,11 @@ module ApplicationHelper
         info << content_tag(:div, search_location_display(holding, document), class: 'library-location', data: { location: true, record_id: document['id'], holding_id: id })
       end
       block << content_tag(:li, info.html_safe, data: { availability_record: check_availability, record_id: document['id'], holding_id: id, aeon: aeon_location?(location) })
-      cdl_placeholder = content_tag(:span, '', class: 'badge badge-primary', 'data-availability-cdl' => true)
-      block << content_tag(:li, cdl_placeholder.html_safe)
+
+      if Rails.configuration.use_alma
+        cdl_placeholder = content_tag(:span, '', class: 'badge badge-primary', 'data-availability-cdl' => true)
+        block << content_tag(:li, cdl_placeholder.html_safe)
+      end
     end
 
     if scsb_multiple == true

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -247,8 +247,9 @@ module ApplicationHelper
         end
         info << content_tag(:div, search_location_display(holding, document), class: 'library-location', data: { location: true, record_id: document['id'], holding_id: id })
       end
-      info << content_tag(:span, "Online", class: 'badge badge-primary hidden', 'data-availability-cdl' => true)
       block << content_tag(:li, info.html_safe, data: { availability_record: check_availability, record_id: document['id'], holding_id: id, aeon: aeon_location?(location) })
+      cdl_placeholder = content_tag(:span, '', class: 'badge badge-primary', 'data-availability-cdl' => true)
+      block << content_tag(:li, cdl_placeholder.html_safe)
     end
 
     if scsb_multiple == true

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -247,6 +247,7 @@ module ApplicationHelper
         end
         info << content_tag(:div, search_location_display(holding, document), class: 'library-location', data: { location: true, record_id: document['id'], holding_id: id })
       end
+      info << content_tag(:span, "Online", class: 'badge badge-primary hidden', 'data-availability-cdl' => true)
       block << content_tag(:li, info.html_safe, data: { availability_record: check_availability, record_id: document['id'], holding_id: id, aeon: aeon_location?(location) })
     end
 

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -110,7 +110,7 @@ export default class AvailabilityUpdater {
         const temp_map_link = this.stackmap_link(record_id, availability_info, true);
         current_map_link.replaceWith(temp_map_link);
       }
-      this.apply_availability_label(availability_element, availability_info);
+      this.apply_availability_label(availability_element, availability_info, true);
     }
     return true;
   }
@@ -153,7 +153,7 @@ export default class AvailabilityUpdater {
           const location = $(`*[data-location='true'][data-holding-id='${holding_id}']`);
           location.text(availability_info['label']);
         }
-        this.apply_availability_label(availability_element, availability_info);
+        this.apply_availability_label(availability_element, availability_info, false);
         if (availability_info["cdl"]) {
           insert_online_link();
         }
@@ -281,20 +281,18 @@ export default class AvailabilityUpdater {
     return true;
   }
 
-  apply_availability_label(availability_element, availability_info) {
+  apply_availability_label(availability_element, availability_info, addCdlBadge) {
     availability_element.addClass("badge");
     let status_label = availability_info['status_label'];
     let isCdl = availability_info['cdl'];
     status_label = `${status_label}${this.due_date(availability_info["due_date"])}`;
     if (status_label.toLowerCase() === 'unavailable') {
-      if (isCdl) {
-        // If the item is on CDL we display "Online" as the availability
-        // rather than "Unavailable"
-        status_label = "Online";
-        availability_element.attr("title", "Available online. Physical copy might not be available.");
-        availability_element.addClass("badge-secondary");
-      } else {
-        availability_element.addClass("badge-danger");
+      availability_element.addClass("badge-danger");
+      if (isCdl && addCdlBadge) {
+        // In this case althought the _physical_ copy is not available we
+        // display an extra badge to indicate that it is available _online_.
+        availability_element.attr("title", "Physical copy is not available.");
+        availability_element.parent().find(`*[data-availability-cdl='true']`).removeClass('hidden');
       }
     } else if (status_label.toLowerCase() === 'available') {
       availability_element.addClass("badge-success");

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -284,15 +284,24 @@ export default class AvailabilityUpdater {
   apply_availability_label(availability_element, availability_info) {
     availability_element.addClass("badge");
     let status_label = availability_info['status_label'];
+    let isCdl = availability_info['cdl'];
     status_label = `${status_label}${this.due_date(availability_info["due_date"])}`;
-    availability_element.text(status_label);
     if (status_label.toLowerCase() === 'unavailable') {
-      availability_element.addClass("badge-danger");
+      if (isCdl) {
+        // If the item is on CDL we display "Online" as the availability
+        // rather than "Unavailable"
+        status_label = "Online";
+        availability_element.attr("title", "Available online. Physical copy might not be available.");
+        availability_element.addClass("badge-secondary");
+      } else {
+        availability_element.addClass("badge-danger");
+      }
     } else if (status_label.toLowerCase() === 'available') {
       availability_element.addClass("badge-success");
     } else {
       availability_element.addClass("badge-secondary");
     }
+    availability_element.text(status_label);
   }
 
   title_case(str) {

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -286,20 +286,22 @@ export default class AvailabilityUpdater {
     let status_label = availability_info['status_label'];
     let isCdl = availability_info['cdl'];
     status_label = `${status_label}${this.due_date(availability_info["due_date"])}`;
+    availability_element.text(status_label);
     if (status_label.toLowerCase() === 'unavailable') {
       availability_element.addClass("badge-danger");
       if (isCdl && addCdlBadge) {
-        // In this case althought the _physical_ copy is not available we
-        // display an extra badge to indicate that it is available _online_.
-        availability_element.attr("title", "Physical copy is not available.");
-        availability_element.parent().find(`*[data-availability-cdl='true']`).removeClass('hidden');
+        // The _physical_ copy is not available but we highlight that the _online_ copy is.
+        availability_element.attr('title', 'Physical copy is not available.');
+        let cdlPlaceholder = availability_element.parent().next().find("*[data-availability-cdl='true']");
+        cdlPlaceholder.text('Online');
+        cdlPlaceholder.attr('title', 'Online copy available via Controlled Digital Lending');
+        cdlPlaceholder.addClass('badge badge-primary');
       }
     } else if (status_label.toLowerCase() === 'available') {
       availability_element.addClass("badge-success");
     } else {
       availability_element.addClass("badge-secondary");
     }
-    availability_element.text(status_label);
   }
 
   title_case(str) {

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -220,6 +220,55 @@ describe('AvailabilityUpdater', function() {
     spy.mockRestore()
   })
 
+  test('extra Online availability added for CDL records that are reported as unavailable', () => {
+    document.body.innerHTML = '<ul>'+
+      '  <li data-availability-record="true" data-record-id="9965126093506421" data-holding-id="22202918790006421" data-aeon="false">' +
+      '    <span class="availability-icon"></span>' +
+      '    <div class="library-location" data-location="true" data-record-id="9965126093506421" data-holding-id="22202918790006421">' +
+      '      <span class="results_location">Firestone Library - Stacks</span> » ' +
+      '      <span class="call-number">PS3558.A62424 B43 2010 ' +
+      '        <a title="Where to find it" class="find-it" data-map-location="firestone$stacks" data-blacklight-modal="trigger" ' +
+      '           aria-label="Where to find it" href="/catalog/9965126093506421/stackmap?loc=firestone$stacks&amp;cn=PS3558.A62424 B43 2010">' +
+      '          <span class="fa fa-map-marker" aria-hidden="true"></span>' +
+      '        </a>' +
+      '      </span>' +
+      '    </div>' +
+      '  </li>' +
+      '  <li>' +
+      '    <span class="badge badge-primary" data-availability-cdl="true"></span>' +
+      '  </li>' +
+      '  <li class="empty" data-record-id="9965126093506421">' +
+      '    <a class="availability-icon more-info" title="Click on the record for full availability info" data-toggle="tooltip" href="/catalog/9965126093506421"></a>' +
+      '  </li>' +
+      '</ul>';
+
+    const availability_response = {
+      "9965126093506421" : {
+        "22202918790006421" : {
+          "on_reserve": "N",
+          "location": "firestone$stacks",
+          "label": "Firestone Library - Stacks",
+          "status_label": "Unavailable",
+          "copy_number": null,
+          "cdl": true,
+          "temp_location": false,
+          "id": "22202918790006421"
+        }
+      }
+    };
+    const holding_data = availability_response["9965126093506421"]["22202918790006421"];
+
+    const cdl_element = $("*[data-availability-cdl='true']")[0];
+    const av_element = $(`*[data-availability-record='true'][data-record-id='9965126093506421'][data-holding-id='22202918790006421'] .availability-icon`);
+
+    let u = new updater;
+    u.id = '9965126093506421';
+
+    expect(cdl_element.textContent).not.toContain('Online');
+    u.apply_availability_label(av_element, holding_data, true);
+    expect(cdl_element.textContent).toContain('Online');
+  })
+
   // TODO: This method isn't covered by the feature tests
   test('scsb_barcodes() on a search results page', () => {
     // This is only used on search results page


### PR DESCRIPTION
First pass at addressing display of status for CDL items (https://github.com/pulibrary/bibdata/issues/1291). With this change instead of displaying an off-putting "Unavailable" status for the records available via CDL we display "Online" as the status. Notice that new logic only kicks in if the Status is Unavailable and the item is on CDL.

Below is a screenshot of how a record like this would be displayed in the Show page

![show_page](https://user-images.githubusercontent.com/568286/119677262-92666080-be0c-11eb-9fc4-245ce10c2f99.png)

The Online status has a tooltip (not shown) that says "Available online. Physical copy might not be available."

### This change also handles the display on the Search results. 
![search_page](https://user-images.githubusercontent.com/568286/119677325-9eeab900-be0c-11eb-8945-612be96eca8f.png)

### A note on facet counts
Notice that the "Access" facet counts might not be accurate when these CDL records are on the search results since we calculating this new "Online" status on the fly. This might not be obvious when there are many records in the search results (like on the above screenshot) but it is obvious when this record is the only one on the result set

![search_page_single](https://user-images.githubusercontent.com/568286/119677693-eec98000-be0c-11eb-9f7b-62a04fd8cc88.png)
