### PR TITLE
Replacing the #view ID attribute with #viewer-container for the conta…

### DIFF
--- a/app/assets/javascripts/orangelight.js
+++ b/app/assets/javascripts/orangelight.js
@@ -88,7 +88,7 @@ $(document).ready(function() {
     });
 
     $('.document-thumbnail').click(function(e){
-        var target = $('#view');
+        var target = $('#viewer-container');
         if( target.length ) {
             e.preventDefault();
             $('html, body').stop().animate({

--- a/app/javascript/orangelight/figgy_manifest_manager.js
+++ b/app/javascript/orangelight/figgy_manifest_manager.js
@@ -39,7 +39,7 @@ class FiggyViewer {
   }
 
   buildViewerId() {
-    return this.idx == 0 ? 'view' : `view_${this.idx}`
+    return this.idx == 0 ? 'viewer-container' : `viewer-container_${this.idx}`
   }
 
   updateArkLinkElement() {
@@ -241,7 +241,7 @@ class FiggyThumbnailSet {
       }
       $element.empty()
       $element.addClass('has-viewer-link')
-      $element.wrap('<a href="#view"></a>').append('<span class="sr-only">Go to viewer</span>')
+      $element.wrap('<a href="#viewer-container"></a>').append('<span class="sr-only">Go to viewer</span>')
       $element.append($thumbnailElement)
     })
   }

--- a/app/javascript/orangelight/insert_online_link.es6
+++ b/app/javascript/orangelight/insert_online_link.es6
@@ -11,7 +11,7 @@ export const online_link_content = (link, target) => {
   return `Princeton users: <a href="${link}" target="${target}">View digital content</a>`;
 }
 
-export const insert_online_link = (link = "#view", id = "cdl_link", content = online_link_content) => {
+export const insert_online_link = (link = "#viewer-container", id = "cdl_link", content = online_link_content) => {
   insert_online_header()
   const existing_online_link = $(`#${id}`)
   if (existing_online_link.length > 0)

--- a/app/views/catalog/_show_digital_content.html.erb
+++ b/app/views/catalog/_show_digital_content.html.erb
@@ -1,1 +1,1 @@
-<div class="document-viewers" data-bib-id="<%= @document.id %>"></div>
+<div id="view" class="document-viewers" data-bib-id="<%= @document.id %>"></div>

--- a/spec/javascript/orangelight/insert_online_link.spec.js
+++ b/spec/javascript/orangelight/insert_online_link.spec.js
@@ -30,7 +30,7 @@ describe('insert_online_link', function() {
     let list_item = li_elements.item(0)
     expect(list_item.textContent).toEqual("Princeton users: View digital content")
     const anchor = list_item.getElementsByTagName('a').item(0)
-    expect(anchor.getAttribute("href")).toEqual("#view")
+    expect(anchor.getAttribute("href")).toEqual("#viewer-container")
     expect(anchor.getAttribute("target")).toEqual("_self")
   })
 

--- a/spec/system/catalog_show_spec.rb
+++ b/spec/system/catalog_show_spec.rb
@@ -17,6 +17,24 @@ describe 'Viewing Catalog Documents', type: :system, js: true do
     let(:document_fixture_path) { Rails.root.join('spec', 'fixtures', 'alma', "#{document_id}.json") }
     let(:document_fixture_content) { File.read(document_fixture_path) }
     let(:document_fixture) { JSON.parse(document_fixture_content) }
+    let(:solr_url) do
+      Blacklight.connection_config[:url]
+    end
+    let(:solr) do
+      RSolr.connect(url: solr_url)
+    end
+    let(:document_id) do
+      '9946093213506421'
+    end
+    let(:document_fixture_path) do
+      Rails.root.join('spec', 'fixtures', 'alma', "#{document_id}.json")
+    end
+    let(:document_fixture_content) do
+      File.read(document_fixture_path)
+    end
+    let(:document_fixture) do
+      JSON.parse(document_fixture_content)
+    end
 
     before do
       solr.add(document_fixture)
@@ -42,6 +60,14 @@ describe 'Viewing Catalog Documents', type: :system, js: true do
         expect(node["data-bib-id"]).not_to be_empty
         expect(node["data-bib-id"]).to eq document_id
       end
+    end
+
+    it 'renders the IIIF Manifest viewer with #view as a container <div> element' do
+      visit "catalog/#{document_id}"
+      expect(page).to have_selector "div#view.document-viewers"
+      node = page.find("div#view")
+      expect(node["data-bib-id"]).not_to be_empty
+      expect(node["data-bib-id"]).to eq document_id
     end
   end
 end

--- a/spec/views/catalog/show.html.erb_spec.rb
+++ b/spec/views/catalog/show.html.erb_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe 'catalog/show' do
   context 'when entries describe resources published using multiple ARKs', js: true do
     it 'renders multiple viewers' do
       visit '/catalog/3943643'
-      expect(page).to have_selector('div#view')
-      expect(page).to have_selector('div#view_1')
+      expect(page).to have_selector('div#viewer-container')
+      expect(page).to have_selector('div#viewer-container_1')
     end
   end
 


### PR DESCRIPTION
Resolves #2485 and addresses the following:

- Introduces a selenium_headless configuration for Capybara (this was not headless in my local environment)
- Introduces system specs for in-browser testing (please see https://relishapp.com/rspec/rspec-rails/docs/system-specs/system-spec)