### PR TITLE
Prevents error when trying to render the back to catalog link

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -236,6 +236,6 @@ module BlacklightHelper
     # invalid back to catalog link. In that case, rather than blowing up on the user, we
     # render a valid link. This link does not preserve the user's previous setings and that is
     # OK because very likely their session is corrupted.
-    "/"
+    link_to "Back to search", root_url
   end
 end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -228,4 +228,14 @@ module BlacklightHelper
       url
     end
   end
+
+  def link_back_to_catalog_safe(opts = { label: nil })
+    link_back_to_catalog(opts)
+  rescue ActionController::UrlGenerationError
+    # This exception is triggered if the user's session has information that results in an
+    # invalid back to catalog link. In that case, rather than blowing up on the user, we
+    # render a valid link. This link does not preserve the user's previous setings and that is
+    # OK because very likely their session is corrupted.
+    "/"
+  end
 end

--- a/app/views/catalog/_previous_next_doc.html.erb
+++ b/app/views/catalog/_previous_next_doc.html.erb
@@ -7,7 +7,7 @@
       </div>
       <% if @search_context %>
         <% if @search_context[:prev] || @search_context[:next] %>
-          <%= link_back_to_catalog class: 'btn btn-default button--back-to-search', label:  t('blacklight.back_to_search').html_safe %>
+          <%= link_back_to_catalog_safe class: 'btn btn-default button--back-to-search', label:  t('blacklight.back_to_search').html_safe %>
           <div class="page_links">
             <%= link_to_previous_document @search_context[:prev] %>
             <%= link_to_next_document @search_context[:next] %>

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -5,12 +5,6 @@ require 'rails_helper'
 describe BlacklightHelper do
   let(:blacklight_params) { {} }
 
-  class FakeSearchState
-    def reset(search_session)
-      search_session
-    end
-  end
-
   before do
     allow(self).to receive(:blacklight_params).and_return(blacklight_params)
     allow(self).to receive(:current_or_guest_user).and_return(User.new)
@@ -140,10 +134,12 @@ describe BlacklightHelper do
   end
 
   describe "#link_back_to_catalog_safe" do
+    let(:blacklight_config) { CatalogController.new.blacklight_config }
+    let(:search_state) { Blacklight::SearchState.new({}, blacklight_config) }
+    let(:search_session) { {} }
+
     context "with valid parameters" do
-      let(:search_state) { FakeSearchState.new }
       let(:valid_session) { instance_double(Search) }
-      let(:search_session) { {} }
       it "produces a link" do
         allow(valid_session).to receive(:query_params).and_return(
           action: "show", controller: "catalog", id: "123"
@@ -154,10 +150,7 @@ describe BlacklightHelper do
     end
 
     context "invalid parameters" do
-      let(:search_state) { FakeSearchState.new }
       let(:invalid_session) { instance_double(Search) }
-      let(:search_session) { {} }
-
       it "produces a default link (i.e. does not crash)" do
         allow(invalid_session).to receive(:query_params).and_return(
           action: "index", controller: "advanced", id: "123"

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -11,18 +11,6 @@ describe BlacklightHelper do
     end
   end
 
-  class FakeValidCurrentSearchSession
-    def query_params
-      { action: "show", controller: "catalog", id: "123" }
-    end
-  end
-
-  class FakeInvalidCurrentSearchSession
-    def query_params
-      { action: "index", controller: "advanced", id: "123" }
-    end
-  end
-
   before do
     allow(self).to receive(:blacklight_params).and_return(blacklight_params)
     allow(self).to receive(:current_or_guest_user).and_return(User.new)
@@ -154,18 +142,27 @@ describe BlacklightHelper do
   describe "#link_back_to_catalog_safe" do
     context "with valid parameters" do
       let(:search_state) { FakeSearchState.new }
-      let(:current_search_session) { FakeValidCurrentSearchSession.new }
+      let(:valid_session) { instance_double(Search) }
       let(:search_session) { {} }
       it "produces a link" do
+        allow(valid_session).to receive(:query_params).and_return(
+          action: "show", controller: "catalog", id: "123"
+        )
+        allow(self).to receive(:current_search_session).and_return(valid_session)
         expect(link_back_to_catalog_safe).to include("/catalog/123")
       end
     end
 
     context "invalid parameters" do
       let(:search_state) { FakeSearchState.new }
-      let(:current_search_session) { FakeInvalidCurrentSearchSession.new }
+      let(:invalid_session) { instance_double(Search) }
       let(:search_session) { {} }
+
       it "produces a default link (i.e. does not crash)" do
+        allow(invalid_session).to receive(:query_params).and_return(
+          action: "index", controller: "advanced", id: "123"
+        )
+        allow(self).to receive(:current_search_session).and_return(invalid_session)
         expect(link_back_to_catalog_safe).to include("http://test.host/")
       end
     end

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -166,7 +166,7 @@ describe BlacklightHelper do
       let(:current_search_session) { FakeInvalidCurrentSearchSession.new }
       let(:search_session) { {} }
       it "produces a default link (i.e. does not crash)" do
-        expect(link_back_to_catalog_safe).to eq("/")
+        expect(link_back_to_catalog_safe).to include("http://test.host/")
       end
     end
   end

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -134,18 +134,16 @@ describe BlacklightHelper do
   end
 
   describe "#link_back_to_catalog_safe" do
-    let(:blacklight_config) { CatalogController.new.blacklight_config }
-    let(:search_state) { Blacklight::SearchState.new({}, blacklight_config) }
-    let(:search_session) { {} }
-
     context "with valid parameters" do
       let(:valid_session) { instance_double(Search) }
       it "produces a link" do
         allow(valid_session).to receive(:query_params).and_return(
           action: "show", controller: "catalog", id: "123"
         )
-        allow(self).to receive(:current_search_session).and_return(valid_session)
-        expect(link_back_to_catalog_safe).to include("/catalog/123")
+        allow(helper).to receive(:current_search_session).and_return(valid_session)
+        allow(helper).to receive(:blacklight_config).and_return(CatalogController.new.blacklight_config)
+        allow(helper).to receive(:search_session).and_return({})
+        expect(helper.link_back_to_catalog_safe).to include("/catalog/123")
       end
     end
 
@@ -155,8 +153,10 @@ describe BlacklightHelper do
         allow(invalid_session).to receive(:query_params).and_return(
           action: "index", controller: "advanced", id: "123"
         )
-        allow(self).to receive(:current_search_session).and_return(invalid_session)
-        expect(link_back_to_catalog_safe).to include("http://test.host/")
+        allow(helper).to receive(:current_search_session).and_return(invalid_session)
+        allow(helper).to receive(:blacklight_config).and_return(CatalogController.new.blacklight_config)
+        allow(helper).to receive(:search_session).and_return({})
+        expect(helper.link_back_to_catalog_safe).to include("http://test.host/")
       end
     end
   end


### PR DESCRIPTION
Prevents error when trying to render the back to catalog link and the user's session has information that results in an invalid link. This fix should probably be pushed eventually to Blacklight but for now a local fix would do.

Fixes https://github.com/pulibrary/orangelight/issues/1336

See also https://github.com/pulibrary/pulmap/pull/950