### PR TITLE
Retry call to bib data availability endpoint in the show page

### DIFF
--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -25,10 +25,11 @@ export default class AvailabilityUpdater {
     this.process_barcodes = this.process_barcodes.bind(this);
     this.process_single = this.process_single.bind(this);
     this.update_single = this.update_single.bind(this);
+    this.update_single_undetermined = this.update_single_undetermined.bind(this);
     this.process_scsb_single = this.process_scsb_single.bind(this);
   }
 
-  request_availability() {
+  request_availability(allowRetry) {
     let url;
     // a search results page or a call number browse page
     if ($(".documents-list").length > 0) {
@@ -54,6 +55,18 @@ export default class AvailabilityUpdater {
         url = `${this.bibdata_base_url}/bibliographic/${this.id}/availability.json`;
         return $.getJSON(url, this.process_single)
           .fail((jqXHR, textStatus, errorThrown) => {
+            if (jqXHR.status == 429) {
+              if (allowRetry) {
+                console.log(`Retrying availability for record ${this.id}`);
+                window.setTimeout(() => {
+                  this.request_availability(false);
+                }, 1500);
+              } else {
+                console.error(`Failed to retrieve availability data for the bib (retry). Record ${this.id}: ${errorThrown}`);
+                this.update_single_undetermined();
+              }
+              return;
+            }
             return console.error(`Failed to retrieve availability data for the bib. record ${this.id}: ${errorThrown}`);
           });
       }
@@ -174,6 +187,14 @@ export default class AvailabilityUpdater {
       }
       return result;
     })();
+  }
+
+  // This method is used to set the availability info to Undetermined when
+  // the call to the Availability endpoint fails.
+  update_single_undetermined() {
+    $(`*[data-availability-record='true'] span`).text("Undetermined");
+    $(`*[data-availability-record='true'] span`).attr("title", "Cannot determine real-time availability for this item at this time.");
+    $(`*[data-availability-record='true'] span`).addClass("badge badge-secondary");
   }
 
   process_scsb_single(item_records) {

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -193,7 +193,7 @@ export default class AvailabilityUpdater {
   // the call to the Availability endpoint fails.
   update_single_undetermined() {
     $(`*[data-availability-record='true'] span`).text("Undetermined");
-    $(`*[data-availability-record='true'] span`).attr("title", "Cannot determine real-time availability for this item at this time.");
+    $(`*[data-availability-record='true'] span`).attr("title", "Cannot determine real-time availability for item at this time.");
     $(`*[data-availability-record='true'] span`).addClass("badge badge-secondary");
   }
 

--- a/app/javascript/orangelight/orangelight_ui_loader.es6
+++ b/app/javascript/orangelight/orangelight_ui_loader.es6
@@ -23,7 +23,7 @@ export default class OrangelightUiLoader {
     } else {
       au2 = new VoyagerAvailabilityUpdater
     }
-    au2.request_availability();
+    au2.request_availability(true);
     au2.scsb_search_availability();
   }
 

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -151,6 +151,23 @@ describe('AvailabilityUpdater', function() {
     spy.mockRestore()
   })
 
+  // Make sure that the code to handle undetermined availability status updates
+  // the HTML correctly.
+  test('undetermined availability for show page', () => {
+    document.body.innerHTML =
+      '<table><tr>' +
+        '<td class="holding-status" data-availability-record="true" data-record-id="9965126093506421" data-holding-id="22202918790006421" data-aeon="false">' +
+          '<span class="availability-icon"></span>' +
+        '</td>' +
+      '</tr></table>';
+
+    let u = new updater
+    u.id = '9965126093506421'
+    u.update_single_undetermined();
+
+    expect(document.body.innerHTML).toContain("Undetermined");
+  })
+
   test('record has temporary locations and complete data', () => {
     const holding_records = {
       "9959958323506421": {


### PR DESCRIPTION
Retries call to bib data availability endpoint in the show page when the error returned was an HTTP 429 (too many calls per second). Notice that we wait a second and a half before retrying.

Part of #2413 

Below is a screenshot of how this will look for a user in the event that even the retry failed to fetch the availability. The tooltip (not shown) will say "Cannot determine real-time availability for item at this time."

![undetermined](https://user-images.githubusercontent.com/568286/121427202-6ede0280-c942-11eb-980b-1b1200a21b28.png)