### PR TITLE
Retry call to bib data availability endpoint in the SEARCH page

### DIFF
--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -25,7 +25,7 @@ export default class AvailabilityUpdater {
     this.process_barcodes = this.process_barcodes.bind(this);
     this.process_single = this.process_single.bind(this);
     this.update_single = this.update_single.bind(this);
-    this.update_single_undetermined = this.update_single_undetermined.bind(this);
+    this.update_av_undertermined = this.update_av_undertermined.bind(this);
     this.process_scsb_single = this.process_scsb_single.bind(this);
   }
 
@@ -38,7 +38,20 @@ export default class AvailabilityUpdater {
       url = `${this.bibdata_base_url}/bibliographic/availability.json?bib_ids=${bib_ids.join()}`;
       return $.getJSON(url, this.process_results_list)
         .fail((jqXHR, textStatus, errorThrown) => {
-          return console.error(`Failed to retrieve availability data for the bib. records ${bib_ids.join(", ")}: ${errorThrown}`);
+          if (jqXHR.status == 429) {
+            if (allowRetry) {
+              console.log(`Retrying availability for records ${bib_ids.join()}`);
+              window.setTimeout(() => {
+                this.update_av_retrying();
+                this.request_availability(false);
+              }, 1500);
+            } else {
+              console.error(`Failed to retrieve availability data for bibs (retry). Records ${bib_ids.join()}: ${errorThrown}`);
+              this.update_av_undertermined();
+            }
+            return;
+          }
+          return console.error(`Failed to retrieve availability data thes bib. records ${bib_ids.join(", ")}: ${errorThrown}`);
         });
 
     // a show page
@@ -59,11 +72,12 @@ export default class AvailabilityUpdater {
               if (allowRetry) {
                 console.log(`Retrying availability for record ${this.id}`);
                 window.setTimeout(() => {
+                  this.update_av_retrying();
                   this.request_availability(false);
                 }, 1500);
               } else {
                 console.error(`Failed to retrieve availability data for the bib (retry). Record ${this.id}: ${errorThrown}`);
-                this.update_single_undetermined();
+                this.update_av_undertermined();
               }
               return;
             }
@@ -189,12 +203,20 @@ export default class AvailabilityUpdater {
     })();
   }
 
-  // This method is used to set the availability info to Undetermined when
-  // the call to the Availability endpoint fails.
-  update_single_undetermined() {
-    $(`*[data-availability-record='true'] span`).text("Undetermined");
-    $(`*[data-availability-record='true'] span`).attr("title", "Cannot determine real-time availability for item at this time.");
-    $(`*[data-availability-record='true'] span`).addClass("badge badge-secondary");
+  // Sets the availability badge to indicate that we are retrying to fetch the information
+  update_av_retrying() {
+    var avBadges = $(`*[data-availability-record='true'] span.availability-icon`);
+    $(avBadges).text("Retrying...");
+    $(avBadges).attr("title", "Fetching real-time availability");
+    $(avBadges).addClass("badge badge-secondary");
+  }
+
+  // Sets the availability badge to indicate that we could not determine the availability
+  update_av_undertermined() {
+    var avBadges = $(`*[data-availability-record='true'] span.availability-icon`);
+    $(avBadges).text("Undetermined");
+    $(avBadges).attr("title", "Cannot determine real-time availability for item at this time.");
+    $(avBadges).addClass("badge badge-secondary");
   }
 
   process_scsb_single(item_records) {
@@ -308,6 +330,7 @@ export default class AvailabilityUpdater {
     let isCdl = availability_info['cdl'];
     status_label = `${status_label}${this.due_date(availability_info["due_date"])}`;
     availability_element.text(status_label);
+    availability_element.attr('title', '');
     if (status_label.toLowerCase() === 'unavailable') {
       availability_element.addClass("badge-danger");
       if (isCdl && addCdlBadge) {

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -163,7 +163,7 @@ describe('AvailabilityUpdater', function() {
 
     let u = new updater
     u.id = '9965126093506421'
-    u.update_single_undetermined();
+    u.update_av_undertermined();
 
     expect(document.body.innerHTML).toContain("Undetermined");
   })


### PR DESCRIPTION
Retry call to availability API when bib data returns HTTP 429 (too many calls per second) in the search page. Notice that we wait a second and a half before retrying. This is the companion to PR https://github.com/pulibrary/orangelight/issues/2413

If the first call to get availability information returns HTTP 429 we will retry and update the page so that user is aware that we are still trying:
![retrying](https://user-images.githubusercontent.com/568286/121589652-55ea5580-ca05-11eb-919d-e8e11d96ff66.png)

Like PR https://github.com/pulibrary/orangelight/issues/2413 if the second call also fails it will display "Undetermined" as the availability.
