### PR TITLE
Add read-only mode

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -13,8 +13,13 @@ class AccountController < ApplicationController
   before_action :verify_user, except: [:borrow_direct_redirect]
 
   def index
-    set_patron
-    current_account
+    if Orangelight.read_only_mode
+      msg = "Account page is disabled. #{Orangelight.read_only_message}"
+      redirect_to root_path, flash: { notice: msg }
+    else
+      set_patron
+      current_account
+    end
   end
 
   def renew

--- a/app/services/physical_holdings_markup_builder.rb
+++ b/app/services/physical_holdings_markup_builder.rb
@@ -237,8 +237,15 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
   end
 
   def self.requestable_location?(location, adapter, holding)
-    return false if location.nil? || adapter.unavailable_holding?(holding)
-    location[:requestable]
+    if location.nil?
+      false
+    elsif adapter.unavailable_holding?(holding)
+      false
+    elsif Orangelight.read_only_mode
+      false
+    else
+      location[:requestable]
+    end
   end
 
   def self.aeon_location?(location)

--- a/app/views/shared/_announcement.html.erb
+++ b/app/views/shared/_announcement.html.erb
@@ -3,6 +3,8 @@
     <p>
     <% if Rails.configuration.use_alma %>
       <h1>Thank you for testing the Catalog Alma QA site!</h2> Please provide feedback via the <a href="https://docs.google.com/forms/d/e/1FAIpQLSdS0FRa8h-7_iCtBeIRGbD2pI7zcqWAmz5hxLFip6dR7If3Nw/viewform">Alma Catalog Testing Feedback Form</a> or in the #catalog-alma-feedback channel on Slack.
+    <% elsif Orangelight.read_only_mode %>
+      <%= Orangelight.read_only_message %>
     <% else %>
       Many Library services are available online. Please visit our <a href="https://library.princeton.edu/2020-21-resources">information page</a>.
     <% end %>

--- a/config/initializers/read_only_mode.rb
+++ b/config/initializers/read_only_mode.rb
@@ -6,7 +6,7 @@ module Orangelight
   end
 
   def read_only_message
-    default_msg = "Orangelight is in read-only mode."
+    default_msg = "Catalog is in read-only mode."
     @read_only_message ||= ENV.fetch("ORANGELIGHT_READ_ONLY_MESSAGE", default_msg)
   end
 

--- a/config/initializers/read_only_mode.rb
+++ b/config/initializers/read_only_mode.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Orangelight
+  def read_only_mode
+    @read_only_mode ||= ENV.fetch("ORANGELIGHT_READ_ONLY_MODE", false) == "true"
+  end
+
+  module_function :read_only_mode
+end

--- a/config/initializers/read_only_mode.rb
+++ b/config/initializers/read_only_mode.rb
@@ -2,12 +2,12 @@
 
 module Orangelight
   def read_only_mode
-    @read_only_mode ||= ENV.fetch("ORANGELIGHT_READ_ONLY_MODE", false) == "true"
+    @read_only_mode ||= ENV.fetch("OL_READ_ONLY_MODE", false) == "true"
   end
 
   def read_only_message
     default_msg = "Catalog is in read-only mode."
-    @read_only_message ||= ENV.fetch("ORANGELIGHT_READ_ONLY_MESSAGE", default_msg)
+    @read_only_message ||= ENV.fetch("OL_READ_ONLY_MESSAGE", default_msg)
   end
 
   module_function :read_only_mode, :read_only_message

--- a/config/initializers/read_only_mode.rb
+++ b/config/initializers/read_only_mode.rb
@@ -5,5 +5,10 @@ module Orangelight
     @read_only_mode ||= ENV.fetch("ORANGELIGHT_READ_ONLY_MODE", false) == "true"
   end
 
-  module_function :read_only_mode
+  def read_only_message
+    default_msg = "Orangelight is in read-only mode."
+    @read_only_message ||= ENV.fetch("ORANGELIGHT_READ_ONLY_MESSAGE", default_msg)
+  end
+
+  module_function :read_only_mode, :read_only_message
 end

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -31,6 +31,21 @@ RSpec.describe AccountController do
     it "can access the use_alma flag" do
       expect { Rails.configuration.use_alma }.not_to raise_error
     end
+
+    context 'when Orangelight is in read only mode' do
+      let(:valid_user) { FactoryBot.create(:valid_princeton_patron) }
+
+      before do
+        sign_in(valid_user)
+        allow(Orangelight).to receive(:read_only_mode).and_return(true)
+      end
+
+      it 'redirects to root and flashes an explanatory message' do
+        get :index
+        expect(response).to redirect_to(root_path)
+        expect(flash[:notice]).to include("Account page is disabled", "read-only")
+      end
+    end
   end
 
   describe '#cancel_success' do

--- a/spec/features/request_options_spec.rb
+++ b/spec/features/request_options_spec.rb
@@ -24,6 +24,16 @@ describe 'Request Options' do
     end
   end
 
+  describe 'the request button when orangelight is in read-only mode', js: true do
+    it 'does not display a request button' do
+      allow(Orangelight).to receive(:read_only_mode).and_return(true)
+      visit '/catalog/9618072'
+      using_wait_time 5 do
+        expect(page).to have_selector('td[data-requestable="false"]')
+      end
+    end
+  end
+
   describe 'Available status non-requestable location', js: true do
     before do
       visit '/catalog/9222024'

--- a/spec/views/shared/_announcement.html.erb_spec.rb
+++ b/spec/views/shared/_announcement.html.erb_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'shared/_announcement' do
+  it 'renders an announcement' do
+    render
+    expect(rendered).to match(/Many Library services are available online/)
+  end
+
+  context 'in read-only mode' do
+    it 'renders a read-only message' do
+      allow(Orangelight).to receive(:read_only_mode).and_return(true)
+      allow(Orangelight).to receive(:read_only_message).and_return("test message")
+      render
+      expect(rendered).to match(/test message/)
+    end
+  end
+
+  context 'in Alma mode' do
+    it 'renders an Alma message' do
+      allow(Rails.configuration).to receive(:use_alma).and_return(true)
+      render
+      expect(rendered).to match(/Catalog Alma QA site/)
+    end
+  end
+end


### PR DESCRIPTION
Closes #2439 

In read-only mode:

- Hides the request button. This is the simplest method to implement and I think is the least confusing for the user.
- Adds a special announcement; configurable using and env var.
- Redirects the account page to the root page and flashes a notification.

![Screen Shot 2021-06-10 at 4 43 26 PM](https://user-images.githubusercontent.com/784196/121601396-81703e80-ca0b-11eb-8f99-e14d70ca49b6.png)


![Screen Shot 2021-06-10 at 4 43 38 PM](https://user-images.githubusercontent.com/784196/121601407-83d29880-ca0b-11eb-91f3-eba702a5dbac.png)
