### PR TITLE
Retry on staff_view

### DIFF
--- a/app/models/concerns/blacklight/solr/document/marc.rb
+++ b/app/models/concerns/blacklight/solr/document/marc.rb
@@ -129,6 +129,11 @@ module Blacklight
           'unknown'
         end
 
+        # We allow the user to retry in very specific scenarios.
+        def can_retry?
+          @can_retry
+        end
+
         protected
 
           def build_ctx(format = nil)
@@ -242,6 +247,7 @@ module Blacklight
             id = fetch(_marc_source_field)
 
             response = Faraday.get("#{Requests.config['bibdata_base']}/bibliographic/#{id}")
+            @can_retry = response.status == 429
             response_stream = StringIO.new(response.body)
             marc_reader = MARC::XMLReader.new(response_stream)
             marc_records = marc_reader.to_a

--- a/app/views/catalog/librarian_view.html.erb
+++ b/app/views/catalog/librarian_view.html.erb
@@ -20,6 +20,8 @@
 
 <%- if @document.respond_to?(:to_marc) && @document.to_marc.present? -%>
   <%= render "marc_view", document: @document %>
+<%- elsif @document.respond_to?(:to_marc) && @document.can_retry? %>
+  <%= t('blacklight.search.librarian_view.retry') %>
 <%- else %>
   <%= t('blacklight.search.librarian_view.empty') %>
 <%- end -%>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -52,6 +52,7 @@ en:
       start_over: 'Start over'
       librarian_view:
         title: 'Staff view'
+        retry: 'Could not retrieve MARC data, please reload this page to try again.'
       sort:
         label: 'Sort<span class="d-none d-xl-inline"> by %{field}</span>'
       per_page:


### PR DESCRIPTION
Shows a retry message to the user when we cannot get the MARC data because Alma returns error message "too many requests per second" (HTTP 429). 

Fixes #2414