### PR TITLE
Indicate that Availability is being checked when the page first loads

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -239,7 +239,7 @@ module ApplicationHelper
             end
           end
         elsif holding['dspace'].nil?
-          info << content_tag(:span, '', class: 'availability-icon').html_safe
+          info << content_tag(:span, 'Loading...', class: 'availability-icon badge badge-secondary').html_safe
           info << content_tag(:span, '', class: 'icon-warning icon-request-reading-room', title: 'Items at this location must be requested', 'data-toggle' => 'tooltip', 'aria-hidden' => 'true').html_safe if aeon_location?(location)
         else
           check_availability = false


### PR DESCRIPTION
Defaults the availability icon to "Loading..." instead of an empty string so that the user gets an indication that something is still going on. When the page is first loaded it looks like this (notice the "Loading..." text):

![loading](https://user-images.githubusercontent.com/568286/121951513-04a1d500-cd29-11eb-97d9-5670556673b2.png)

Once the availability information is available it looks like this (no changes here):

![loaded](https://user-images.githubusercontent.com/568286/121951614-2602c100-cd29-11eb-9d9e-a75ff52e6ab7.png)

Fixes #2412 