### PR TITLE
Update location display in the record and search results page when JS…

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -418,9 +418,9 @@ module ApplicationHelper
   # Alma location display on search results
   def alma_location_display(holding, location)
     if location.nil?
-      "#{holding['library']} - #{holding['location']}".rstrip.chomp(' -')
+      [holding['library'], holding['location']].select(&:present?).join(' - ')
     else
-      "#{location['library']['label']} - #{location['label']}".rstrip.chomp(' -')
+      [location['library']['label'], location['label']].select(&:present?).join(' - ')
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -418,9 +418,9 @@ module ApplicationHelper
   # Alma location display on search results
   def alma_location_display(holding, location)
     if location.nil?
-      "#{holding['library']} - #{holding['location']}"
+      "#{holding['library']} - #{holding['location']}".rstrip.chomp(' -')
     else
-      "#{location['library']['label']} - #{location['label']}"
+      "#{location['library']['label']} - #{location['label']}".rstrip.chomp(' -')
     end
   end
 

--- a/app/services/holding_requests_adapter.rb
+++ b/app/services/holding_requests_adapter.rb
@@ -128,6 +128,7 @@ class HoldingRequestsAdapter
   # @return [String] the location label
   # Record page location label display
   def holding_location_label(holding)
+    # location is the information coming from bibdata
     location = holding_location_rules(holding)
     if Rails.configuration.use_alma
       location.nil? ? alma_location_label_display_holding(holding) : alma_location_label_display_bibdata_location(location)
@@ -136,14 +137,16 @@ class HoldingRequestsAdapter
     end
   end
 
-  # Alma location display on record page using the solr indexed holding
-  def alma_location_label_display_holding(holding)
-    "#{holding['library']} - #{holding['location']}"
+  # Alma location display on record page using the location info from bibdata.
+  # This is a location fall back if Javascript does not work.
+  def alma_location_label_display_bibdata_location(location)
+    location['library']['label'].present? ? "#{location['library']['label']} - #{location['label']}".rstrip.chomp(' -') : location['library']['label']
   end
 
-  # Alma location display on record page using the location info from bibdata
-  def alma_location_label_display_bibdata_location(location)
-    "#{location['library']['label']} - #{location['label']}"
+  # Alma location display on record page using the solr indexed holding
+  # This is a location fall back if Javascript does not work and bibdata returns nil.
+  def alma_location_label_display_holding(holding)
+    "#{holding['library']} - #{holding['location']}".rstrip.chomp(' -')
   end
 
   # Retrieve the call number from holding values

--- a/app/services/holding_requests_adapter.rb
+++ b/app/services/holding_requests_adapter.rb
@@ -140,13 +140,13 @@ class HoldingRequestsAdapter
   # Alma location display on record page using the location info from bibdata.
   # This is a location fall back if Javascript does not work.
   def alma_location_label_display_bibdata_location(location)
-    location['library']['label'].present? ? "#{location['library']['label']} - #{location['label']}".rstrip.chomp(' -') : location['library']['label']
+    [location['library']['label'], location['label']].select(&:present?).join(" - ")
   end
 
   # Alma location display on record page using the solr indexed holding
   # This is a location fall back if Javascript does not work and bibdata returns nil.
   def alma_location_label_display_holding(holding)
-    "#{holding['library']} - #{holding['location']}".rstrip.chomp(' -')
+    [holding['library'], holding['location']].select(&:present?).join(' - ')
   end
 
   # Retrieve the call number from holding values

--- a/spec/fixtures/alma/current_fixtures.json
+++ b/spec/fixtures/alma/current_fixtures.json
@@ -100,5 +100,181 @@
           "2016"
         ],
         "format": "Senior thesis"
+      },
+      {
+        "id": "99116547863506421",
+        "numeric_id_b": true,
+        "author_display": [
+          "Nakanoin, Michifuyu, 1315-1363",
+          "中院通冬, 1315-1363"
+        ],
+        "author_citation_display": [
+          "Nakanoin, Michifuyu",
+          "Tōkyō Daigaku"
+        ],
+        "author_roles_1display": "{\"secondary_authors\":[\"中院通冬\"],\"translators\":[],\"editors\":[\"Tōkyō Daigaku\",\"東京大學.\"],\"compilers\":[],\"primary_author\":\"Nakanoin, Michifuyu\"}",
+        "author_s": [
+          "Nakanoin, Michifuyu, 1315-1363",
+          "Tōkyō Daigaku. Shiryō Hensanjo",
+          "中院通冬, 1315-1363",
+          "東京大學. 史料編纂所"
+        ],
+        "marc_relator_display": [
+          "Author"
+        ],
+        "title_display": "Nakanoin ipponki / Tōkyō Daigaku Shiryō Sensanjo hensan.",
+        "title_vern_display": "中院一品記 / 東京大學史料編纂所編纂.",
+        "title_t": [
+          "Nakanoin ipponki / Tōkyō Daigaku Shiryō Sensanjo hensan."
+        ],
+        "title_citation_display": [
+          "Nakanoin ipponki",
+          "中院一品記"
+        ],
+        "compiled_created_t": [
+          "Nakanoin ipponki / Tōkyō Daigaku Shiryō Sensanjo hensan.",
+          "中院一品記 / 東京大學史料編纂所編纂."
+        ],
+        "pub_created_vern_display": [
+          "東京 : 岩波書店, 2018-"
+        ],
+        "pub_created_display": [
+          "Tōkyō : Iwanami Shōten, 2018-",
+          "東京 : 岩波書店, 2018-"
+        ],
+        "pub_created_s": [
+          "Tōkyō : Iwanami Shōten, 2018-",
+          "東京 : 岩波書店, 2018-"
+        ],
+        "pub_citation_display": [
+          "Tōkyō: Iwanami Shōten",
+          "東京: 岩波書店"
+        ],
+        "pub_date_display": [
+          "2018"
+        ],
+        "pub_date_start_sort": 2018,
+        "pub_date_end_sort": 9999,
+        "cataloged_tdt": "2020-12-03T03:12:18Z",
+        "format": [
+          "Book"
+        ],
+        "description_display": [
+          "volumes : illustrations ; 22 cm"
+        ],
+        "description_t": [
+          "volumes : illustrations ; 22 cm"
+        ],
+        "number_of_pages_citation_display": [
+          "volumes"
+        ],
+        "geocode_display": [
+          "Japan"
+        ],
+        "series_display": [
+          "Dai Nihon kokiroku.",
+          "大日本古記錄.",
+          "大日本古記錄"
+        ],
+        "more_in_this_series_t": [
+          "Dai Nihon kokiroku",
+          "大日本古記錄."
+        ],
+        "bib_ref_notes_display": [
+          "Includes bibliographical references and index."
+        ],
+        "language_facet": [
+          "Japanese"
+        ],
+        "language_code_s": [
+          "jpn"
+        ],
+        "language_iana_s": [
+          "ja"
+        ],
+        "contents_display": [
+          "[1]. Kenmu sannen nigatsu yori Kōei gannen rokugatsu ni itaru",
+          "jō. Kenmu 3-nen 2-gatsu yori Kōei gannen 6-gatsu ni itaru",
+          "[1]. 自建武三年二月至康永元年六月",
+          "上. 自建武三年二月至康永元年六月"
+        ],
+        "lc_subject_display": [
+          "Nakanoin, Michifuyu, 1315-1363—Diaries",
+          "Japan—History—Kamakura period, 1185-1333—Sources",
+          "Japan—History—Period of northern and southern courts, 1336-1392—Sources"
+        ],
+        "subject_facet": [
+          "Nakanoin, Michifuyu, 1315-1363—Diaries",
+          "Japan—History—Kamakura period, 1185-1333—Sources",
+          "Japan—History—Period of northern and southern courts, 1336-1392—Sources",
+          "Diaries"
+        ],
+        "lcgft_s": [
+          "Diaries"
+        ],
+        "related_name_json_1display": "{\"Editor\":[\"Tōkyō Daigaku. Shiryō Hensanjo\",\"東京大學. 史料編纂所\"]}",
+        "other_title_display": [
+          "Nakanoin 1-honki",
+          "中院 1品記"
+        ],
+        "alt_title_246_display": [
+          "Nakanoin 1-honki",
+          "中院 1品記"
+        ],
+        "isbn_display": [
+          "9784000099851 ((v. 1))",
+          "400009985X ((v. 1))"
+        ],
+        "lccn_display": [
+          "  2018430599"
+        ],
+        "lccn_s": [
+          "2018430599"
+        ],
+        "isbn_s": [
+          "9784000099851"
+        ],
+        "oclc_s": [
+          "1062349585"
+        ],
+        "other_version_s": [
+          "on1062349585",
+          "9784000099851"
+        ],
+        "subject_era_facet": [
+          "1185-1392",
+          "Japan: Kamakura period, 1185-1333",
+          "Japan: Period of northern and southern courts, 1336-1392"
+        ],
+        "holdings_1display": "{\"22211952510006421\":{\"location_code\":\"eastasian$hy\",\"location\":\"\",\"library\":\"East Asian Library\",\"call_number\":\"J3306/5047.4 pt.31\",\"call_number_browse\":\"J3306/5047.4 pt.31\",\"items\":[{\"holding_id\":\"22211952510006421\",\"id\":\"23211952500006421\",\"status_at_load\":\"1\",\"collection_code\":\"hy\",\"enumeration\":\"vol.1\",\"barcode\":\"32101113265852\",\"copy_number\":\"0\"}]}}",
+        "recap_notes_display": [
+          " - "
+        ],
+        "location_code_s": [
+          "eastasian$hy"
+        ],
+        "location": [
+          "East Asian Library"
+        ],
+        "location_display": [
+          "East Asian Library"
+        ],
+        "advanced_location_s": [
+          "eastasian$hy",
+          "East Asian Library"
+        ],
+        "name_title_browse_s": [
+          "Nakanoin, Michifuyu, 1315-1363. Nakanoin ipponki",
+          "中院通冬, 1315-1363. 中院一品記"
+        ],
+        "call_number_display": [
+          "J3306/5047.4 pt.31 "
+        ],
+        "call_number_browse_s": [
+          "J3306/5047.4 pt.31 "
+        ],
+        "call_number_locator_display": [
+          "J3306/5047.4 pt.31"
+        ]
       }
 ]

--- a/spec/fixtures/bibdata/alma/holding_locations.json
+++ b/spec/fixtures/bibdata/alma/holding_locations.json
@@ -1,0 +1,40 @@
+[
+    {
+      "label": "Stacks",
+      "code": "firestone$stacks",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "remote_storage": "",
+      "url": "https://bibdata-alma-staging.princeton.edu/locations/holding_locations/firestone$stacks.json",
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 0
+      },
+      "holding_library": null,
+      "hours_location": null
+    },
+    {
+      "label": "",
+      "code": "rare$cat",
+      "aeon_location": false,
+      "recap_electronic_delivery_location": false,
+      "open": true,
+      "requestable": true,
+      "always_requestable": false,
+      "circulates": true,
+      "remote_storage": "",
+      "url": "https://bibdata-alma-staging.princeton.edu/locations/holding_locations/rare$cat.json",
+      "library": {
+        "label": "Special Collections",
+        "code": "rare",
+        "order": 0
+      },
+      "holding_library": null,
+      "hours_location": null
+    }
+]

--- a/spec/fixtures/bibdata/holding_locations.json
+++ b/spec/fixtures/bibdata/holding_locations.json
@@ -6593,4 +6593,4 @@
         "code": "firestone"
       }
     }
-  ]
+]

--- a/spec/helpers/locations_spec.rb
+++ b/spec/helpers/locations_spec.rb
@@ -83,16 +83,24 @@ RSpec.describe ApplicationHelper do
     let(:without_code) { { 'library' => 'Library Name', 'location' => fallback } }
     let(:invalid_code) { { 'library' => 'Library Name', 'location' => fallback, 'location_code' => 'invalid' } }
     let(:valid_code) { { 'library' => 'Library Name', 'location' => fallback, 'location_code' => 'aas' } }
+    let(:code_location_blank) { { 'library' => 'Library Name', 'location' => '', 'location_code' => 'aas' } }
 
     it 'returns holding location label when location code lookup successful' do
       stub_holding_locations
       expect(holding_location_label(valid_code)).to eq('Firestone Library - African American Studies Reading Room (AAS). B-7-B')
     end
-    it 'returns holding location value when location code lookup fails' do
-      stub_request(:get, "#{Requests.config['bibdata_base']}/locations/holding_locations.json")
-        .to_return(status: 500,
-                   body: '')
-      expect(holding_location_label(invalid_code)).to eq('Library Name - Fallback')
+    context 'when location code lookup fails' do
+      before do
+        stub_request(:get, "#{Requests.config['bibdata_base']}/locations/holding_locations.json")
+          .to_return(status: 500,
+                     body: '')
+      end
+      it 'returns holding location value' do
+        expect(holding_location_label(invalid_code)).to eq('Library Name - Fallback')
+      end
+      it 'does not include a trailing dash when indexed location is blank' do
+        expect(holding_location_label(code_location_blank)).to eq('Library Name')
+      end
     end
     it 'returns holding location value when no location code' do
       expect(holding_location_label(without_code)).to eq('Library Name - Fallback')

--- a/spec/support/webmock_stubs.rb
+++ b/spec/support/webmock_stubs.rb
@@ -6,6 +6,12 @@ def stub_holding_locations
                body: File.read(File.join(fixture_path, 'bibdata', 'holding_locations.json')))
 end
 
+def stub_alma_holding_locations
+  stub_request(:get, "#{Requests.config['bibdata_base']}/locations/holding_locations.json")
+    .to_return(status: 200,
+               body: File.read(File.join(fixture_path, 'bibdata', 'alma', 'holding_locations.json')))
+end
+
 def stub_test_document
   stub_request(:get, "#{Requests.config['bibdata_base']}/bibliographic/test-id")
     .to_return(status: 200, body: '')


### PR DESCRIPTION
closes #2499

Updates the location display when JS doesn't work. Removes trailing spaces and dash when location is blank or bibdata label is blank. Example records with code `eastasian$hy` dont have a label in bibdata.
the update applies both in the search results and in the record page.