### PR TITLE
Availability for records in temporary locations

### DIFF
--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -129,7 +129,7 @@ export default class AvailabilityUpdater {
         // In this case we set all of them to "Check record" because we can get this
         // information in the Show page.
         const badges = $(`*[data-availability-record='true'][data-record-id='${record_id}'] span.availability-icon`);
-        badges.text("Check record")
+        badges.text("Check record for availability")
         return true;
       }
 

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -123,15 +123,25 @@ export default class AvailabilityUpdater {
   // search results
   process_result(record_id, holding_records) {
     for (let holding_id in holding_records) {
-      const availability_info = holding_records[holding_id];
+      if (holding_id.startsWith('fake_id_')) {
+        // In this case we cannot correlate the holding data from the availability API
+        // (holding_records) with the holding data already on the page (from Solr).
+        // In this case we set all of them to "Check record" because we can get this
+        // information in the Show page.
+        const badges = $(`*[data-availability-record='true'][data-record-id='${record_id}'] span.availability-icon`);
+        badges.text("Check record")
+        return true;
+      }
+
       // In Alma the label from the endpoint includes both the library name and the location.
+      const availability_info = holding_records[holding_id];
       if (availability_info['label']) {
         const location = $(`*[data-location='true'][data-record-id='${record_id}'][data-holding-id='${holding_id}'] .results_location`);
         location.text(availability_info['label']);
       }
       const availability_element = $(`*[data-availability-record='true'][data-record-id='${record_id}'][data-holding-id='${holding_id}'] .availability-icon`);
 
-      if (availability_info['temp_loc']) {
+      if (availability_info['temp_location']) {
         const current_map_link = $(`*[data-location='true'][data-record-id='${record_id}'][data-holding-id='${holding_id}'] .find-it`);
         $(availability_element).next('.icon-warning').hide();
         const temp_map_link = this.stackmap_link(record_id, availability_info, true);

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -75,6 +75,66 @@ describe('AvailabilityUpdater', function() {
     expect(mixed_result.text()).toEqual("Some items not available")
   })
 
+  test('search results availability for records in temporary locations says Check Record', () => {
+    document.body.innerHTML =
+      '<li class="blacklight-holdings">' +
+      '    <ul>' +
+      '        <li data-availability-record="true" data-record-id="9959958323506421" data-holding-id="22272063570006421" data-aeon="false">' +
+      '            <span class="availability-icon badge badge-secondary">Loading...</span>' +
+      '            <div class="library-location" data-location="true" data-record-id="9959958323506421" data-holding-id="22272063570006421">' +
+      '                <span class="results_location">Lewis Library - Lewis Library</span> &raquo; ' +
+      '                <span class="call-number">QC33 .M52 2003 ' +
+      '                    <a title="Where to find it" class="find-it" data-map-location="lewis$stacks" data-blacklight-modal="trigger" aria-label="Where to find it" href="...">' +
+      '                        <span class="fa fa-map-marker" aria-hidden="true"></span>' +
+      '                    </a>' +
+      '                </span>' +
+      '            </div>' +
+      '        </li>' +
+      '        <li data-availability-record="true" data-record-id="9959958323506421" data-holding-id="22272063520006421" data-aeon="false">' +
+      '            <span class="availability-icon badge badge-secondary">Loading...</span>' +
+      '            <div class="library-location" data-location="true" data-record-id="9959958323506421" data-holding-id="22272063520006421">' +
+      '                <span class="results_location">Lewis Library - Lewis Library</span> &raquo; ' +
+      '                <span class="call-number">QC33 .M52 2003 ' +
+      '                    <a title="Where to find it" class="find-it" data-map-location="lewis$stacks" data-blacklight-modal="trigger" aria-label="Where to find it" href="...">' +
+      '                        <span class="fa fa-map-marker" aria-hidden="true"></span>' +
+      '                    </a>' +
+      '                </span>' +
+      '            </div>' +
+      '        </li>' +
+      '        <li class="empty" data-record-id="9959958323506421">' +
+      '            <a class="availability-icon more-info" title="Click on the record for full availability info" data-toggle="tooltip" href="/catalog/9959958323506421"></a>' +
+      '        </li>' +
+      '    </ul>' +
+      '</li>'
+
+    const apiResponse = {
+      "9959958323506421": {
+        "fake_id_1": {
+          "on_reserve":"Y",
+          "location":"lewis$resterm",
+          "label":"Lewis Library - sciresp Lewis: Term Loan",
+          "status_label":"Available",
+          "copy_number":null,
+          "cdl":false,
+          "temp_location":true,
+          "id":"fake_id_1"
+        }
+      }
+    }
+
+
+    const badgesBefore = document.getElementsByClassName('availability-icon')
+    expect(badgesBefore[0].textContent).toEqual('Loading...')
+
+    const bibId = '9959958323506421'
+    const holdingData = apiResponse[bibId]
+    let u = new updater
+    u.process_result(bibId, holdingData)
+
+    const badgesAfter = document.getElementsByClassName('availability-icon')
+    expect(badgesAfter[0].textContent).toEqual('Check record for availability')
+  })
+
   test('record show page with an available holding displays the status label in green', () => {
     document.body.innerHTML =
       '<table><tr>' +


### PR DESCRIPTION
Use 'Check record' as the label for records in temp locations since otherwise they stay with the 'Loading...' label. Notice that we cannot determine the availability for these records because Alma does not return it to us on the normal bib level API call. In the show page we make a second (and slow-ish) API call to fetch the complete information and hence the hint to "Check Record" to allow the user to view all the information if they are indeed interested in this record.

Fixes #2524

![temp_location_av](https://user-images.githubusercontent.com/568286/122985548-53282280-d36c-11eb-9c82-81f1af0ff869.png)
