### PR TITLE
Normalize call numbers by stripping spaces.

### DIFF
--- a/lib/orangelight/string_functions.rb
+++ b/lib/orangelight/string_functions.rb
@@ -4,9 +4,9 @@ module StringFunctions
   class << self
     def cn_normalize(str)
       if /^[a-zA-Z]{2,3} \d+([qQ]?)$/.match? str # the normalizer thinks "CD 104" is valid LC
-        accession_number(str)
+        accession_number(str)&.strip
       else
-        Lcsort.normalize(str.gsub(/x([A-Z])/, '\1')) || accession_number(str)
+        Lcsort.normalize(str.gsub(/x([A-Z])/, '\1'))&.strip || accession_number(str)&.strip
       end
     end
 

--- a/spec/lib/orangelight/browse_lists/call_number_csv_spec.rb
+++ b/spec/lib/orangelight/browse_lists/call_number_csv_spec.rb
@@ -45,7 +45,12 @@ RSpec.describe BrowseLists::CallNumberCSV do
 
       csv_file = output_root.join("call_number_browse_s.csv")
       expect(File.exist?(csv_file)).to be true
-      expect(File.read(csv_file).scan(/\n/).count).to eq 496_049
+      expect(File.read(csv_file).scan(/\n/).count).to eq 496_050
+      # Ensure call numbers with spaces in them are stripped for the CSV.
+      space_call_line = File.open(csv_file).lines.find do |line|
+        line.start_with?("53.8")
+      end
+      expect(space_call_line).to start_with("53.8,53.8")
     end
 
     context "when solr returns a hash with no response key" do


### PR DESCRIPTION
Fixes browsing for bad call numbers in the solr index.

Closes #2532