### PR TITLE
Holdings for contained records

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -223,6 +223,7 @@ class CatalogController < ApplicationController
     config.add_index_field 'pub_created_display', label: 'Published/Created'
     config.add_index_field 'format', label: 'Format', helper_method: :format_icon
     config.add_index_field 'holdings_1display', show: false
+    config.add_index_field 'contained_in_s', show: false
     config.add_index_field 'isbn_t', show: false
     config.add_index_field 'score', show: false
     config.add_index_field 'marc_relator_display', show: false

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -204,7 +204,7 @@ module ApplicationHelper
       end
     ]
     links = search_links(document['electronic_access_1display']) + portfolio_links
-    holdings_hash = JSON.parse(document['holdings_1display'] || '{}').merge(portfolio_holdings)
+    holdings_hash = document.holdings_all_display.merge(portfolio_holdings)
     scsb_multiple = false
     holdings_hash.first(2).each do |id, holding|
       location = holding_location(holding)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -247,7 +247,7 @@ module ApplicationHelper
         end
         info << content_tag(:div, search_location_display(holding, document), class: 'library-location', data: { location: true, record_id: document['id'], holding_id: id })
       end
-      block << content_tag(:li, info.html_safe, data: { availability_record: check_availability, record_id: document['id'], holding_id: id, aeon: aeon_location?(location) })
+      block << content_tag(:li, info.html_safe, data: { availability_record: check_availability, record_id: document['id'], holding_id: id, aeon: aeon_location?(location), bound_with: document.bound_with? })
 
       if Rails.configuration.use_alma
         cdl_placeholder = content_tag(:span, '', class: 'badge badge-primary', 'data-availability-cdl' => true)

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -154,6 +154,13 @@ export default class AvailabilityUpdater {
       }
       this.apply_availability_label(availability_element, availability_info, true);
     }
+
+    // Bib data does not know about bound-with records and therefore we don't get availability
+    // information for holdings coming from the host record. For those holdings we ask the user
+    // to check the record since in `process_single()` we do the extra work to get that information.
+    const boundWithBadges = $(`*[data-availability-record='true'][data-record-id='${record_id}'][data-bound-with='true'] span.availability-icon`);
+    boundWithBadges.text("Check record for availability")
+
     return true;
   }
 

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -134,7 +134,7 @@ export default class AvailabilityUpdater {
         // In this case we set all of them to "Check record" because we can get this
         // information in the Show page.
         const badges = $(`*[data-availability-record='true'][data-record-id='${record_id}'] span.availability-icon`);
-        badges.text("Check record for availability")
+        badges.text("View record for availability")
         return true;
       }
 
@@ -159,7 +159,7 @@ export default class AvailabilityUpdater {
     // information for holdings coming from the host record. For those holdings we ask the user
     // to check the record since in `process_single()` we do the extra work to get that information.
     const boundWithBadges = $(`*[data-availability-record='true'][data-record-id='${record_id}'][data-bound-with='true'] span.availability-icon`);
-    boundWithBadges.text("Check record for availability")
+    boundWithBadges.text("View record for availability")
 
     return true;
   }

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -163,7 +163,7 @@ export default class AvailabilityUpdater {
   // `holding_records` has data for two bibs: `this.id` and `this.host_id`.
   process_single(holding_records) {
     this.process_single_for_bib(holding_records, this.id)
-    if (this.host_id) {
+    if (this.host_id !== "") {
       this.process_single_for_bib(holding_records, this.host_id)
     }
   }

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -129,6 +129,21 @@ class SolrDocument
     sibling_documents.flat_map(&:electronic_portfolios)
   end
 
+  # Returns the holdings_1display of the record plus the holdings_1display of the host record
+  def holdings_all_display
+    host_id = self["contained_in_s"]&.first
+    return JSON.parse(self["holdings_1display"] || '{}') if host_id.nil?
+
+    # Get the holdings from the host record
+    # TODO: combine with self["holdings_1display"]
+    @holdings_all ||= begin
+      params = { q: "id:#{RSolr.solr_escape(host_id)}" }
+      host_response = Blacklight.default_index.connection.get('select', params: params)
+      host_doc = host_response["response"]["docs"].first
+      JSON.parse(host_doc["holdings_1display"])
+    end
+  end
+
   private
 
     def electronic_access_uris

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -130,7 +130,7 @@ class SolrDocument
   end
 
   def host_id
-    host_id = self["contained_in_s"]&.first
+    self["contained_in_s"]&.first
   end
 
   # Returns the holdings_1display of the record plus the holdings_1display of the host record

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -139,9 +139,7 @@ class SolrDocument
     @holdings_all ||= begin
       host_doc = doc_by_id(host_id)
       host_holdings = JSON.parse(host_doc&.dig("holdings_1display") || '{}')
-      combined_holdings = holdings
-      host_holdings.each { |k, v| combined_holdings[k] = v }
-      combined_holdings
+      holdings.merge(host_holdings)
     end
   end
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -129,9 +129,12 @@ class SolrDocument
     sibling_documents.flat_map(&:electronic_portfolios)
   end
 
+  def host_id
+    host_id = self["contained_in_s"]&.first
+  end
+
   # Returns the holdings_1display of the record plus the holdings_1display of the host record
   def holdings_all_display
-    host_id = self["contained_in_s"]&.first
     holdings = JSON.parse(self["holdings_1display"] || '{}')
     return holdings if host_id.nil?
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -133,6 +133,11 @@ class SolrDocument
     self["contained_in_s"]&.first
   end
 
+  def bound_with?
+    return true if host_id
+    false
+  end
+
   # Returns the holdings_1display of the record plus the holdings_1display of the host record
   def holdings_all_display
     holdings = JSON.parse(self["holdings_1display"] || '{}')

--- a/app/services/holding_requests_adapter.rb
+++ b/app/services/holding_requests_adapter.rb
@@ -26,8 +26,7 @@ class HoldingRequestsAdapter
   # Retrieve the holdings information from the Solr Document
   # @return [Hash] holdings values
   def doc_holdings
-    values = @document['holdings_1display'] || '{}'
-    JSON.parse(values)
+    @document.holdings_all_display
   rescue StandardError => error
     Rails.logger.warn error
     {}

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,5 +1,5 @@
 <%= render 'previous_next_doc' %>
-<div id="main-content" class="col-12 main-content">
+<div id="main-content" class="col-12 main-content" data-host-id="<%= @document.host_id %>">
   <div id="sidebar" class="<%= render_document_class %>">
     <%= render_document_sidebar_partial %>
     <%= render partial: 'show_restrictions', locals: { document: @document } %>

--- a/spec/fixtures/alma/current_fixtures.json
+++ b/spec/fixtures/alma/current_fixtures.json
@@ -1,280 +1,504 @@
 [
-    {
-        "id": "dsp01wd3760321",
-        "title_t": "The Show Must Go On... And On, And On: The Lasting Appeal of the Stage Comedy",
-        "title_citation_display": "The Show Must Go On... And On, And On: The Lasting Appeal of the Stage Comedy",
-        "title_display": "The Show Must Go On... And On, And On: The Lasting Appeal of the Stage Comedy",
-        "title_sort": "showmustgoonandonandonthelastingappealofthestagecomedy",
-        "author_sort": "White-Mink, Chamari",
-        "electronic_access_1display": "{\"http://arks.princeton.edu/ark:/88435/dsp01wd3760321\":[\"DataSpace\",\"Citation only\"]}",
-        "restrictions_note_display": [
-          "Walk-in Access. This thesis can only be viewed on computer terminals at the <a href=http://mudd.princeton.edu>Mudd Manuscript Library</a>."
-        ],
-        "call_number_display": "AC102",
-        "call_number_browse_s": "AC102",
-        "language_facet": [
-          "English"
-        ],
-        "author_display": [
-          "White-Mink, Chamari"
-        ],
-        "author_s": [
-          "White-Mink, Chamari",
-          "Huerta, Monica",
-          "Princeton University. Department of English",
-          "Princeton University. Program in Theater"
-        ],
-        "advisor_display": [
-          "Huerta, Monica"
-        ],
-        "department_display": [
-          "Princeton University. Department of English"
-        ],
-        "certificate_display": [
-          "Princeton University. Program in Theater"
-        ],
-        "location": "Mudd Manuscript Library",
-        "location_display": "Mudd Manuscript Library",
-        "location_code_s": "mudd$stacks",
-        "advanced_location_s": [
-          "mudd$stacks",
-          "Mudd Manuscript Library"
-        ],
-        "access_facet": "In the Library",
-        "holdings_1display": "{\"thesis\":{\"location\":\"Mudd Manuscript Library\",\"library\":\"Mudd Manuscript Library\",\"location_code\":\"mudd$stacks\",\"call_number\":\"AC102\",\"call_number_browse\":\"AC102\",\"dspace\":true}}",
-        "class_year_s": [
-          "2020"
-        ],
-        "pub_date_start_sort": [
-          "2020"
-        ],
-        "pub_date_end_sort": [
-          "2020"
-        ],
-        "format": "Senior thesis"
-      },
-      {
-        "id": "dsp01w6634604k",
-        "title_t": "Unfinished Business: An Examination of Unrevived, Unproduced, and Incomplete Musical Theatre",
-        "title_citation_display": "Unfinished Business: An Examination of Unrevived, Unproduced, and Incomplete Musical Theatre",
-        "title_display": "Unfinished Business: An Examination of Unrevived, Unproduced, and Incomplete Musical Theatre",
-        "title_sort": "unfinishedbusinessanexaminationofunrevivedunproducedandincompletemusicaltheatre",
-        "author_sort": "Plunkett, William Anderson",
-        "electronic_access_1display": "{\"http://arks.princeton.edu/ark:/88435/dsp01w6634604k\":[\"DataSpace\",\"Full text\"]}",
-        "restrictions_note_display": null,
-        "call_number_display": "AC102",
-        "call_number_browse_s": "AC102",
-        "language_facet": [
-          "English"
-        ],
-        "author_display": [
-          "Plunkett, William Anderson"
-        ],
-        "author_s": [
-          "Plunkett, William Anderson",
-          "Wolf, Stacy",
-          "Wolff, Tamsen",
-          "Princeton University. Program in Theater"
-        ],
-        "advisor_display": [
-          "Wolf, Stacy"
-        ],
-        "contributor_display": [
-          "Wolff, Tamsen"
-        ],
-        "certificate_display": [
-          "Princeton University. Program in Theater"
-        ],
-        "description_display": [
-          "82 pages"
-        ],
-        "access_facet": "Online",
-        "electronic_portfolio_s": "{\"thesis\":{\"call_number\":\"AC102\",\"call_number_browse\":\"AC102\",\"dspace\":true}}",
-        "class_year_s": [
-          "2016"
-        ],
-        "pub_date_start_sort": [
-          "2016"
-        ],
-        "pub_date_end_sort": [
-          "2016"
-        ],
-        "format": "Senior thesis"
-      },
-      {
-        "id": "99116547863506421",
-        "numeric_id_b": true,
-        "author_display": [
-          "Nakanoin, Michifuyu, 1315-1363",
-          "中院通冬, 1315-1363"
-        ],
-        "author_citation_display": [
-          "Nakanoin, Michifuyu",
-          "Tōkyō Daigaku"
-        ],
-        "author_roles_1display": "{\"secondary_authors\":[\"中院通冬\"],\"translators\":[],\"editors\":[\"Tōkyō Daigaku\",\"東京大學.\"],\"compilers\":[],\"primary_author\":\"Nakanoin, Michifuyu\"}",
-        "author_s": [
-          "Nakanoin, Michifuyu, 1315-1363",
-          "Tōkyō Daigaku. Shiryō Hensanjo",
-          "中院通冬, 1315-1363",
-          "東京大學. 史料編纂所"
-        ],
-        "marc_relator_display": [
-          "Author"
-        ],
-        "title_display": "Nakanoin ipponki / Tōkyō Daigaku Shiryō Sensanjo hensan.",
-        "title_vern_display": "中院一品記 / 東京大學史料編纂所編纂.",
-        "title_t": [
-          "Nakanoin ipponki / Tōkyō Daigaku Shiryō Sensanjo hensan."
-        ],
-        "title_citation_display": [
-          "Nakanoin ipponki",
-          "中院一品記"
-        ],
-        "compiled_created_t": [
-          "Nakanoin ipponki / Tōkyō Daigaku Shiryō Sensanjo hensan.",
-          "中院一品記 / 東京大學史料編纂所編纂."
-        ],
-        "pub_created_vern_display": [
-          "東京 : 岩波書店, 2018-"
-        ],
-        "pub_created_display": [
-          "Tōkyō : Iwanami Shōten, 2018-",
-          "東京 : 岩波書店, 2018-"
-        ],
-        "pub_created_s": [
-          "Tōkyō : Iwanami Shōten, 2018-",
-          "東京 : 岩波書店, 2018-"
-        ],
-        "pub_citation_display": [
-          "Tōkyō: Iwanami Shōten",
-          "東京: 岩波書店"
-        ],
-        "pub_date_display": [
-          "2018"
-        ],
-        "pub_date_start_sort": 2018,
-        "pub_date_end_sort": 9999,
-        "cataloged_tdt": "2020-12-03T03:12:18Z",
-        "format": [
-          "Book"
-        ],
-        "description_display": [
-          "volumes : illustrations ; 22 cm"
-        ],
-        "description_t": [
-          "volumes : illustrations ; 22 cm"
-        ],
-        "number_of_pages_citation_display": [
-          "volumes"
-        ],
-        "geocode_display": [
-          "Japan"
-        ],
-        "series_display": [
-          "Dai Nihon kokiroku.",
-          "大日本古記錄.",
-          "大日本古記錄"
-        ],
-        "more_in_this_series_t": [
-          "Dai Nihon kokiroku",
-          "大日本古記錄."
-        ],
-        "bib_ref_notes_display": [
-          "Includes bibliographical references and index."
-        ],
-        "language_facet": [
-          "Japanese"
-        ],
-        "language_code_s": [
-          "jpn"
-        ],
-        "language_iana_s": [
-          "ja"
-        ],
-        "contents_display": [
-          "[1]. Kenmu sannen nigatsu yori Kōei gannen rokugatsu ni itaru",
-          "jō. Kenmu 3-nen 2-gatsu yori Kōei gannen 6-gatsu ni itaru",
-          "[1]. 自建武三年二月至康永元年六月",
-          "上. 自建武三年二月至康永元年六月"
-        ],
-        "lc_subject_display": [
-          "Nakanoin, Michifuyu, 1315-1363—Diaries",
-          "Japan—History—Kamakura period, 1185-1333—Sources",
-          "Japan—History—Period of northern and southern courts, 1336-1392—Sources"
-        ],
-        "subject_facet": [
-          "Nakanoin, Michifuyu, 1315-1363—Diaries",
-          "Japan—History—Kamakura period, 1185-1333—Sources",
-          "Japan—History—Period of northern and southern courts, 1336-1392—Sources",
-          "Diaries"
-        ],
-        "lcgft_s": [
-          "Diaries"
-        ],
-        "related_name_json_1display": "{\"Editor\":[\"Tōkyō Daigaku. Shiryō Hensanjo\",\"東京大學. 史料編纂所\"]}",
-        "other_title_display": [
-          "Nakanoin 1-honki",
-          "中院 1品記"
-        ],
-        "alt_title_246_display": [
-          "Nakanoin 1-honki",
-          "中院 1品記"
-        ],
-        "isbn_display": [
-          "9784000099851 ((v. 1))",
-          "400009985X ((v. 1))"
-        ],
-        "lccn_display": [
-          "  2018430599"
-        ],
-        "lccn_s": [
-          "2018430599"
-        ],
-        "isbn_s": [
-          "9784000099851"
-        ],
-        "oclc_s": [
-          "1062349585"
-        ],
-        "other_version_s": [
-          "on1062349585",
-          "9784000099851"
-        ],
-        "subject_era_facet": [
-          "1185-1392",
-          "Japan: Kamakura period, 1185-1333",
-          "Japan: Period of northern and southern courts, 1336-1392"
-        ],
-        "holdings_1display": "{\"22211952510006421\":{\"location_code\":\"eastasian$hy\",\"location\":\"\",\"library\":\"East Asian Library\",\"call_number\":\"J3306/5047.4 pt.31\",\"call_number_browse\":\"J3306/5047.4 pt.31\",\"items\":[{\"holding_id\":\"22211952510006421\",\"id\":\"23211952500006421\",\"status_at_load\":\"1\",\"collection_code\":\"hy\",\"enumeration\":\"vol.1\",\"barcode\":\"32101113265852\",\"copy_number\":\"0\"}]}}",
-        "recap_notes_display": [
-          " - "
-        ],
-        "location_code_s": [
-          "eastasian$hy"
-        ],
-        "location": [
-          "East Asian Library"
-        ],
-        "location_display": [
-          "East Asian Library"
-        ],
-        "advanced_location_s": [
-          "eastasian$hy",
-          "East Asian Library"
-        ],
-        "name_title_browse_s": [
-          "Nakanoin, Michifuyu, 1315-1363. Nakanoin ipponki",
-          "中院通冬, 1315-1363. 中院一品記"
-        ],
-        "call_number_display": [
-          "J3306/5047.4 pt.31 "
-        ],
-        "call_number_browse_s": [
-          "J3306/5047.4 pt.31 "
-        ],
-        "call_number_locator_display": [
-          "J3306/5047.4 pt.31"
-        ]
-      }
+  {
+    "id": "dsp01wd3760321",
+    "title_t": "The Show Must Go On... And On, And On: The Lasting Appeal of the Stage Comedy",
+    "title_citation_display": "The Show Must Go On... And On, And On: The Lasting Appeal of the Stage Comedy",
+    "title_display": "The Show Must Go On... And On, And On: The Lasting Appeal of the Stage Comedy",
+    "title_sort": "showmustgoonandonandonthelastingappealofthestagecomedy",
+    "author_sort": "White-Mink, Chamari",
+    "electronic_access_1display": "{\"http://arks.princeton.edu/ark:/88435/dsp01wd3760321\":[\"DataSpace\",\"Citation only\"]}",
+    "restrictions_note_display": [
+      "Walk-in Access. This thesis can only be viewed on computer terminals at the <a href=http://mudd.princeton.edu>Mudd Manuscript Library</a>."
+    ],
+    "call_number_display": "AC102",
+    "call_number_browse_s": "AC102",
+    "language_facet": [
+      "English"
+    ],
+    "author_display": [
+      "White-Mink, Chamari"
+    ],
+    "author_s": [
+      "White-Mink, Chamari",
+      "Huerta, Monica",
+      "Princeton University. Department of English",
+      "Princeton University. Program in Theater"
+    ],
+    "advisor_display": [
+      "Huerta, Monica"
+    ],
+    "department_display": [
+      "Princeton University. Department of English"
+    ],
+    "certificate_display": [
+      "Princeton University. Program in Theater"
+    ],
+    "location": "Mudd Manuscript Library",
+    "location_display": "Mudd Manuscript Library",
+    "location_code_s": "mudd$stacks",
+    "advanced_location_s": [
+      "mudd$stacks",
+      "Mudd Manuscript Library"
+    ],
+    "access_facet": "In the Library",
+    "holdings_1display": "{\"thesis\":{\"location\":\"Mudd Manuscript Library\",\"library\":\"Mudd Manuscript Library\",\"location_code\":\"mudd$stacks\",\"call_number\":\"AC102\",\"call_number_browse\":\"AC102\",\"dspace\":true}}",
+    "class_year_s": [
+      "2020"
+    ],
+    "pub_date_start_sort": [
+      "2020"
+    ],
+    "pub_date_end_sort": [
+      "2020"
+    ],
+    "format": "Senior thesis"
+  },
+  {
+    "id": "dsp01w6634604k",
+    "title_t": "Unfinished Business: An Examination of Unrevived, Unproduced, and Incomplete Musical Theatre",
+    "title_citation_display": "Unfinished Business: An Examination of Unrevived, Unproduced, and Incomplete Musical Theatre",
+    "title_display": "Unfinished Business: An Examination of Unrevived, Unproduced, and Incomplete Musical Theatre",
+    "title_sort": "unfinishedbusinessanexaminationofunrevivedunproducedandincompletemusicaltheatre",
+    "author_sort": "Plunkett, William Anderson",
+    "electronic_access_1display": "{\"http://arks.princeton.edu/ark:/88435/dsp01w6634604k\":[\"DataSpace\",\"Full text\"]}",
+    "restrictions_note_display": null,
+    "call_number_display": "AC102",
+    "call_number_browse_s": "AC102",
+    "language_facet": [
+      "English"
+    ],
+    "author_display": [
+      "Plunkett, William Anderson"
+    ],
+    "author_s": [
+      "Plunkett, William Anderson",
+      "Wolf, Stacy",
+      "Wolff, Tamsen",
+      "Princeton University. Program in Theater"
+    ],
+    "advisor_display": [
+      "Wolf, Stacy"
+    ],
+    "contributor_display": [
+      "Wolff, Tamsen"
+    ],
+    "certificate_display": [
+      "Princeton University. Program in Theater"
+    ],
+    "description_display": [
+      "82 pages"
+    ],
+    "access_facet": "Online",
+    "electronic_portfolio_s": "{\"thesis\":{\"call_number\":\"AC102\",\"call_number_browse\":\"AC102\",\"dspace\":true}}",
+    "class_year_s": [
+      "2016"
+    ],
+    "pub_date_start_sort": [
+      "2016"
+    ],
+    "pub_date_end_sort": [
+      "2016"
+    ],
+    "format": "Senior thesis"
+  },
+  {
+    "id": "99116547863506421",
+    "numeric_id_b": true,
+    "author_display": [
+      "Nakanoin, Michifuyu, 1315-1363",
+      "中院通冬, 1315-1363"
+    ],
+    "author_citation_display": [
+      "Nakanoin, Michifuyu",
+      "Tōkyō Daigaku"
+    ],
+    "author_roles_1display": "{\"secondary_authors\":[\"中院通冬\"],\"translators\":[],\"editors\":[\"Tōkyō Daigaku\",\"東京大學.\"],\"compilers\":[],\"primary_author\":\"Nakanoin, Michifuyu\"}",
+    "author_s": [
+      "Nakanoin, Michifuyu, 1315-1363",
+      "Tōkyō Daigaku. Shiryō Hensanjo",
+      "中院通冬, 1315-1363",
+      "東京大學. 史料編纂所"
+    ],
+    "marc_relator_display": [
+      "Author"
+    ],
+    "title_display": "Nakanoin ipponki / Tōkyō Daigaku Shiryō Sensanjo hensan.",
+    "title_vern_display": "中院一品記 / 東京大學史料編纂所編纂.",
+    "title_t": [
+      "Nakanoin ipponki / Tōkyō Daigaku Shiryō Sensanjo hensan."
+    ],
+    "title_citation_display": [
+      "Nakanoin ipponki",
+      "中院一品記"
+    ],
+    "compiled_created_t": [
+      "Nakanoin ipponki / Tōkyō Daigaku Shiryō Sensanjo hensan.",
+      "中院一品記 / 東京大學史料編纂所編纂."
+    ],
+    "pub_created_vern_display": [
+      "東京 : 岩波書店, 2018-"
+    ],
+    "pub_created_display": [
+      "Tōkyō : Iwanami Shōten, 2018-",
+      "東京 : 岩波書店, 2018-"
+    ],
+    "pub_created_s": [
+      "Tōkyō : Iwanami Shōten, 2018-",
+      "東京 : 岩波書店, 2018-"
+    ],
+    "pub_citation_display": [
+      "Tōkyō: Iwanami Shōten",
+      "東京: 岩波書店"
+    ],
+    "pub_date_display": [
+      "2018"
+    ],
+    "pub_date_start_sort": 2018,
+    "pub_date_end_sort": 9999,
+    "cataloged_tdt": "2020-12-03T03:12:18Z",
+    "format": [
+      "Book"
+    ],
+    "description_display": [
+      "volumes : illustrations ; 22 cm"
+    ],
+    "description_t": [
+      "volumes : illustrations ; 22 cm"
+    ],
+    "number_of_pages_citation_display": [
+      "volumes"
+    ],
+    "geocode_display": [
+      "Japan"
+    ],
+    "series_display": [
+      "Dai Nihon kokiroku.",
+      "大日本古記錄.",
+      "大日本古記錄"
+    ],
+    "more_in_this_series_t": [
+      "Dai Nihon kokiroku",
+      "大日本古記錄."
+    ],
+    "bib_ref_notes_display": [
+      "Includes bibliographical references and index."
+    ],
+    "language_facet": [
+      "Japanese"
+    ],
+    "language_code_s": [
+      "jpn"
+    ],
+    "language_iana_s": [
+      "ja"
+    ],
+    "contents_display": [
+      "[1]. Kenmu sannen nigatsu yori Kōei gannen rokugatsu ni itaru",
+      "jō. Kenmu 3-nen 2-gatsu yori Kōei gannen 6-gatsu ni itaru",
+      "[1]. 自建武三年二月至康永元年六月",
+      "上. 自建武三年二月至康永元年六月"
+    ],
+    "lc_subject_display": [
+      "Nakanoin, Michifuyu, 1315-1363—Diaries",
+      "Japan—History—Kamakura period, 1185-1333—Sources",
+      "Japan—History—Period of northern and southern courts, 1336-1392—Sources"
+    ],
+    "subject_facet": [
+      "Nakanoin, Michifuyu, 1315-1363—Diaries",
+      "Japan—History—Kamakura period, 1185-1333—Sources",
+      "Japan—History—Period of northern and southern courts, 1336-1392—Sources",
+      "Diaries"
+    ],
+    "lcgft_s": [
+      "Diaries"
+    ],
+    "related_name_json_1display": "{\"Editor\":[\"Tōkyō Daigaku. Shiryō Hensanjo\",\"東京大學. 史料編纂所\"]}",
+    "other_title_display": [
+      "Nakanoin 1-honki",
+      "中院 1品記"
+    ],
+    "alt_title_246_display": [
+      "Nakanoin 1-honki",
+      "中院 1品記"
+    ],
+    "isbn_display": [
+      "9784000099851 ((v. 1))",
+      "400009985X ((v. 1))"
+    ],
+    "lccn_display": [
+      "  2018430599"
+    ],
+    "lccn_s": [
+      "2018430599"
+    ],
+    "isbn_s": [
+      "9784000099851"
+    ],
+    "oclc_s": [
+      "1062349585"
+    ],
+    "other_version_s": [
+      "on1062349585",
+      "9784000099851"
+    ],
+    "subject_era_facet": [
+      "1185-1392",
+      "Japan: Kamakura period, 1185-1333",
+      "Japan: Period of northern and southern courts, 1336-1392"
+    ],
+    "holdings_1display": "{\"22211952510006421\":{\"location_code\":\"eastasian$hy\",\"location\":\"\",\"library\":\"East Asian Library\",\"call_number\":\"J3306/5047.4 pt.31\",\"call_number_browse\":\"J3306/5047.4 pt.31\",\"items\":[{\"holding_id\":\"22211952510006421\",\"id\":\"23211952500006421\",\"status_at_load\":\"1\",\"collection_code\":\"hy\",\"enumeration\":\"vol.1\",\"barcode\":\"32101113265852\",\"copy_number\":\"0\"}]}}",
+    "recap_notes_display": [
+      " - "
+    ],
+    "location_code_s": [
+      "eastasian$hy"
+    ],
+    "location": [
+      "East Asian Library"
+    ],
+    "location_display": [
+      "East Asian Library"
+    ],
+    "advanced_location_s": [
+      "eastasian$hy",
+      "East Asian Library"
+    ],
+    "name_title_browse_s": [
+      "Nakanoin, Michifuyu, 1315-1363. Nakanoin ipponki",
+      "中院通冬, 1315-1363. 中院一品記"
+    ],
+    "call_number_display": [
+      "J3306/5047.4 pt.31 "
+    ],
+    "call_number_browse_s": [
+      "J3306/5047.4 pt.31 "
+    ],
+    "call_number_locator_display": [
+      "J3306/5047.4 pt.31"
+    ]
+  },
+  {
+    "id": [
+      "9929455793506421"
+    ],
+    "numeric_id_b": [
+      true
+    ],
+    "cjk_all": [
+      ""
+    ],
+    "cjk_notes": [
+      ""
+    ],
+    "author_display": [
+      "Schoeppl, Mizzi, 1895-"
+    ],
+    "author_sort": [
+      "Schoeppl, Mizzi, 1895-"
+    ],
+    "author_citation_display": [
+      "Schoeppl, Mizzi"
+    ],
+    "author_roles_1display": [
+      "{\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[],\"primary_author\":\"Schoeppl, Mizzi\"}"
+    ],
+    "author_s": [
+      "Schoeppl, Mizzi, 1895-"
+    ],
+    "marc_relator_display": [
+      "Author"
+    ],
+    "title_display": [
+      "Zwischenakt; sittenroman, von Oswald Strehlen [pseud.]"
+    ],
+    "title_a_index": [
+      "Zwischenakt"
+    ],
+    "title_sort": [
+      "Zwischenakt; sittenroman, von Oswald Strehlen [pseud.]"
+    ],
+    "title_no_h_index": [
+      "Zwischenakt; sittenroman, von Oswald Strehlen [pseud.]"
+    ],
+    "title_t": [
+      "Zwischenakt; sittenroman, von Oswald Strehlen [pseud.]"
+    ],
+    "title_citation_display": [
+      "Zwischenakt; sittenroman"
+    ],
+    "series_statement_index": [
+      "Mascotte-bücher. 51"
+    ],
+    "linked_title_index": [
+      "Multi-title collection including Suchende seelen; and 2 other(s)."
+    ],
+    "compiled_created_t": [
+      "Zwischenakt; sittenroman, von Oswald Strehlen [pseud.]"
+    ],
+    "pub_created_display": [
+      "Dresden [c1921]"
+    ],
+    "pub_created_s": [
+      "Dresden [c1921]"
+    ],
+    "pub_citation_display": [
+      "Dresden"
+    ],
+    "pub_date_display": [
+      "1921"
+    ],
+    "pub_date_start_sort": [
+      "1921"
+    ],
+    "format": [
+      "Book"
+    ],
+    "description_display": [
+      "80 p."
+    ],
+    "description_t": [
+      "80 p."
+    ],
+    "number_of_pages_citation_display": [
+      "80 p."
+    ],
+    "series_display": [
+      "Mascotte-bücher. 51"
+    ],
+    "geo_related_record_display": [
+      "Multi-title collection including Suchende seelen; and 2 other(s)."
+    ],
+    "contained_in_s": [
+      "99121886293506421"
+    ],
+    "notes_index": [
+      "No. 3 of a volume of pamphlets."
+    ],
+    "notes_display": [
+      "No. 3 of a volume of pamphlets."
+    ],
+    "language_facet": [
+      "German"
+    ],
+    "publication_place_facet": [
+      "Germany"
+    ],
+    "language_code_s": [
+      "ger"
+    ],
+    "language_iana_s": [
+      "de"
+    ],
+    "subject_unstem_search": null,
+    "siku_subject_unstem_search": null,
+    "subject_facet": [
+      "Fiction"
+    ],
+    "lcgft_s": [
+      "Fiction"
+    ],
+    "genre_facet": [
+      "Fiction"
+    ],
+    "in_display": [
+      "Multi-title collection including Suchende seelen; and 2 other(s)."
+    ],
+    "oclc_s": [
+      "43257636"
+    ],
+    "standard_no_index": [
+      "ocm43257636",
+      "2945579",
+      "2945579-princetondb"
+    ],
+    "other_version_s": [
+      "ocm43257636"
+    ],
+    "name_title_browse_s": [
+      "Schoeppl, Mizzi, 1895-. Zwischenakt"
+    ],
+    "access_facet": []
+  },
+  {
+    "id": [
+      "99121886293506421"
+    ],
+    "numeric_id_b": [
+      true
+    ],
+    "cjk_all": [
+      ""
+    ],
+    "cjk_notes": [
+      ""
+    ],
+    "author_roles_1display": [
+      "{\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[]}"
+    ],
+    "title_display": [
+      "Multi-title collection including Suchende seelen; and 2 other(s). updated 4-23-21 11:14 AM"
+    ],
+    "title_a_index": [
+      "Multi-title collection including Suchende seelen; and 2 other(s)."
+    ],
+    "title_sort": [
+      "Multi-title collection including Suchende seelen; and 2 other(s). updated 4-23-21 11:14 AM"
+    ],
+    "title_no_h_index": [
+      "Multi-title collection including Suchende seelen; and 2 other(s). updated 4-23-21 11:14 AM"
+    ],
+    "title_t": [
+      "Multi-title collection including Suchende seelen; and 2 other(s). updated 4-23-21 11:14 AM"
+    ],
+    "title_citation_display": [
+      "Multi-title collection including Suchende seelen; and 2 other(s). updated 4-23-21 11:14 AM"
+    ],
+    "linked_title_index": [
+      "Suchende seelen;",
+      "Zwischenakt; sittenroman,",
+      "Das ewige rätsel; roman,"
+    ],
+    "compiled_created_t": [
+      "Multi-title collection including Suchende seelen; and 2 other(s). updated 4-23-21 11:14 AM"
+    ],
+    "pub_date_display": [
+      "2013"
+    ],
+    "pub_date_start_sort": [
+      "2013"
+    ],
+    "format": [
+      "Book"
+    ],
+    "related_record_s": [
+      "9929455783506421",
+      "9929455793506421",
+      "9929455773506421"
+    ],
+    "language_facet": [
+      "English",
+      "German"
+    ],
+    "publication_place_facet": [
+      "No place, unknown, or undetermined",
+      "Germany"
+    ],
+    "language_code_s": [
+      "eng",
+      "ger"
+    ],
+    "language_iana_s": [
+      "en",
+      "de"
+    ],
+    "subject_unstem_search": null,
+    "siku_subject_unstem_search": null,
+    "constituent_part_display": [
+      "Suchende seelen",
+      "Zwischenakt; sittenroman",
+      "Das ewige rätsel; roman"
+    ],
+    "access_facet": [],
+    "holdings_1display":"{\"22269289940006421\":{\"location_code\":\"recap$pa\",\"location\":\"Remote Storage\",\"library\":\"ReCAP\",\"call_number\":\"3488.93344.333\",\"call_number_browse\":\"3488.93344.333\",\"items\":[{\"holding_id\":\"22269289940006421\",\"id\":\"23269289930006421\",\"status_at_load\":\"1\",\"barcode\":\"32101066958685\",\"copy_number\":\"1\"}]}}"
+  }
 ]

--- a/spec/helpers/holding_block_spec.rb
+++ b/spec/helpers/holding_block_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe ApplicationHelper do
     let(:library) { 'Rare Books and Special Collections' }
     let(:location) { 'Rare Books and Special Collections - Reference Collection in Dulles Reading Room' }
     let(:call_number) { 'PS3539.A74Z93 2000' }
-    let(:search_result) { helper.holding_block_search(document) }
-    let(:search_result_thesis) { helper.holding_block_search(document_thesis) }
-    let(:empty_search_result) { helper.holding_block_search(document_no_holdings) }
+    let(:search_result) { helper.holding_block_search(SolrDocument.new(document)) }
+    let(:search_result_thesis) { helper.holding_block_search(SolrDocument.new(document_thesis)) }
+    let(:empty_search_result) { helper.holding_block_search(SolrDocument.new(document_no_holdings)) }
 
     let(:show_result) { helper.holding_request_block(SolrDocument.new(document)) }
     let(:show_result_journal) { helper.holding_request_block(SolrDocument.new(document_journal)) }

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -321,6 +321,24 @@ describe('AvailabilityUpdater', function() {
     process_single_for_bib.mockRestore()
   })
 
+
+  test('record search results page for a bound-with record', () => {
+    // Notice the data-bound-with="true"
+    document.body.innerHTML =
+      '<table><tr>' +
+        '<td class="holding-status" data-availability-record="true" data-record-id="9929455793506421" data-holding-id="22269289940006421" data-aeon="false" data-bound-with="true">' +
+          '<span class="availability-icon"></span>' +
+        '</td>' +
+      '</tr></table>';
+    const holding_records = {"9929455793506421":{}}
+    const holding_badge = $("*[data-availability-record='true'][data-record-id='9929455793506421'][data-bound-with='true'] span.availability-icon")[0];
+
+    let u = new updater
+    u.process_result("9929455793506421", holding_records)
+
+    expect(holding_badge.textContent).toContain('Check record for availability');
+  })
+
   test('extra Online availability added for CDL records that are reported as unavailable', () => {
     document.body.innerHTML = '<ul>'+
       '  <li data-availability-record="true" data-record-id="9965126093506421" data-holding-id="22202918790006421" data-aeon="false">' +

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -132,7 +132,7 @@ describe('AvailabilityUpdater', function() {
     u.process_result(bibId, holdingData)
 
     const badgesAfter = document.getElementsByClassName('availability-icon')
-    expect(badgesAfter[0].textContent).toEqual('Check record for availability')
+    expect(badgesAfter[0].textContent).toEqual('View record for availability')
   })
 
   test('record show page with an available holding displays the status label in green', () => {
@@ -336,7 +336,7 @@ describe('AvailabilityUpdater', function() {
     let u = new updater
     u.process_result("9929455793506421", holding_records)
 
-    expect(holding_badge.textContent).toContain('Check record for availability');
+    expect(holding_badge.textContent).toContain('View record for availability');
   })
 
   test('extra Online availability added for CDL records that are reported as unavailable', () => {

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -297,6 +297,30 @@ describe('AvailabilityUpdater', function() {
     spy.mockRestore()
   })
 
+  test('record show page for a bound-with record', () => {
+    document.body.innerHTML =
+      '<table><tr>' +
+        '<td class="holding-status" data-availability-record="true" data-record-id="9929455793506421" data-holding-id="22269289940006421" data-aeon="false">' +
+          '<span class="availability-icon"></span>' +
+        '</td>' +
+      '</tr></table>';
+    const holding_records = {
+      "9929455793506421":{},
+      "99121886293506421":{"22269289940006421":{"on_reserve":"N","location":"recap$pa","label":"ReCAP - ReCAP - rcppa RECAP","status_label":"Available","copy_number":null,"cdl":false,"temp_location":false,"id":"22269289940006421"}}
+    }
+
+    let u = new updater
+    u.id = '9929455793506421'         // contained bib
+    u.host_id = '99121886293506421'   // host bib
+
+    const process_single_for_bib = jest.spyOn(u, 'process_single_for_bib')
+    u.process_single(holding_records)
+
+    expect(process_single_for_bib).toHaveBeenCalledWith(holding_records, u.id)
+    expect(process_single_for_bib).toHaveBeenCalledWith(holding_records, u.host_id)
+    process_single_for_bib.mockRestore()
+  })
+
   test('extra Online availability added for CDL records that are reported as unavailable', () => {
     document.body.innerHTML = '<ul>'+
       '  <li data-availability-record="true" data-record-id="9965126093506421" data-holding-id="22202918790006421" data-aeon="false">' +

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -412,10 +412,7 @@ RSpec.describe SolrDocument do
     end
 
     let(:combined_holdings) do
-      combined = {}
-      JSON.parse(host_doc_holdings).each { |k, v| combined[k] = v }
-      JSON.parse(contained_doc_holdings).each { |k, v| combined[k] = v }
-      combined
+      JSON.parse(host_doc_holdings).merge(JSON.parse(contained_doc_holdings))
     end
 
     it 'returns the original holdings if the record is not contained' do

--- a/spec/services/holding_requests_adapter_spec.rb
+++ b/spec/services/holding_requests_adapter_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe HoldingRequestsAdapter do
     end
 
     context 'with repeared restrictions' do
-      let(:document) { { 'holdings_1display' => holdings_hash.to_json } }
+      let(:document) { SolrDocument.new({ 'holdings_1display' => holdings_hash.to_json }) }
 
       it 'they appear only once' do
         expect(holdings.restrictions).to eq ['In Library Use']
@@ -113,7 +113,7 @@ RSpec.describe HoldingRequestsAdapter do
           '671799' => { 'location_code' => 'scsbnypl' }
         }
       end
-      let(:document) { { 'holdings_1display' => holdings_hash.to_json } }
+      let(:document) { SolrDocument.new({ 'holdings_1display' => holdings_hash.to_json }) }
       let(:holding_locations) { { 'scsbnypl' => [] } }
 
       it 'holding is sorted last' do

--- a/spec/services/holding_requests_adapter_spec.rb
+++ b/spec/services/holding_requests_adapter_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe HoldingRequestsAdapter do
     end
 
     context 'with repeared restrictions' do
-      let(:document) { SolrDocument.new({ 'holdings_1display' => holdings_hash.to_json }) }
+      let(:document) { SolrDocument.new('holdings_1display' => holdings_hash.to_json) }
 
       it 'they appear only once' do
         expect(holdings.restrictions).to eq ['In Library Use']
@@ -113,7 +113,7 @@ RSpec.describe HoldingRequestsAdapter do
           '671799' => { 'location_code' => 'scsbnypl' }
         }
       end
-      let(:document) { SolrDocument.new({ 'holdings_1display' => holdings_hash.to_json }) }
+      let(:document) { SolrDocument.new('holdings_1display' => holdings_hash.to_json) }
       let(:holding_locations) { { 'scsbnypl' => [] } }
 
       it 'holding is sorted last' do


### PR DESCRIPTION
Adds host's holdings when a bib record is bound-with in another. Below is an example of how the holdings show for record `9929455793506421` in the search results:

![bound_with_search](https://user-images.githubusercontent.com/568286/124990096-ebc9ce00-e00d-11eb-891a-034f9851889c.png)

and on the show page:

![bound_with_show](https://user-images.githubusercontent.com/568286/124990117-f1271880-e00d-11eb-9b71-add8e939e106.png)

In both cases, the holding "3488.93344.333" comes from the host record `99121886293506421`.

Notice that because we cannot (easily) fetch availability information for the host record during the search, the availability of the host holdings in the bound-with is displayed as "Check record."

Fixes #2431 