### PR TITLE
Remove Request button if item is on reserve.

### DIFF
--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -330,6 +330,9 @@ export default class AvailabilityUpdater {
     if (availability_label_text === "Reserved for digital lending") {
       location_services_element.remove();
     }
+    if (availability_info['on_reserve'] === 'Y') {
+      return location_services_element.remove();
+    }
     if (availability_info['status_label'].toLowerCase() === 'unavailable') {
       display_request = 'false';
     }

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -468,4 +468,75 @@ describe('AvailabilityUpdater', function() {
     u.host_id = '9900126093506421'
     expect(u.availability_url_show()).toEqual('http://mock_url/bibliographic/availability.json?deep=true&bib_ids=9965126093506421,9900126093506421')
   })
+
+  test('does not display Request button for items on reserves', () => {
+    document.body.innerHTML =
+      '<h3>Copies in the Library</h3>' +
+      '<table class="availability-table">' +
+      '    <tbody>' +
+      '        <tr class="holding-block">' +
+      '            <td class="library-location" data-holding-id="22614245530006421"><span class="location-text"' +
+      '                    data-location="true" data-holding-id="22614245530006421">Firestone Library - Stacks</span> <a' +
+      '                    title="Where to find it" class="find-it" data-map-location="firestone$stacks"' +
+      '                    data-blacklight-modal="trigger" data-call-number="HB172.5 .B38 2020"' +
+      '                    data-library="Firestone Library"' +
+      '                    href="/catalog/99115992283506421/stackmap?loc=firestone$stacks&amp;cn=HB172.5 .B38 2020"><span' +
+      '                        class="link-text">Where to find it</span> <span class="fa fa-map-marker"' +
+      '                        aria-hidden="true"></span></a></td>' +
+      '            <td class="holding-call-number">HB172.5 .B38 2020 <a class="browse-cn" title="Browse: HB172.5 .B38 2020"' +
+      '                    data-toggle="tooltip" data-original-title="Browse: HB172.5 .B38 2020"' +
+      '                    href="/browse/call_numbers?q=HB172.5+.B38+2020"><span class="link-text">Browse related items</span>' +
+      '                    <span class="icon-bookslibrary"></span></a></td>' +
+      '            <td class="holding-status" data-availability-record="true" data-record-id="99115992283506421"' +
+      '                data-holding-id="22614245530006421" data-aeon="false"><span class="availability-icon"></span></td>' +
+      '            <td class="location-services service-conditional" data-open="true" data-requestable="true" data-aeon="false"' +
+      '                data-holding-id="22614245530006421"><a title="View Options to Request copies from this Location"' +
+      '                    class="request btn btn-xs btn-primary" data-toggle="tooltip"' +
+      '                    href="/requests/99115992283506421?mfhd=22614245530006421&amp;source=pulsearch">Request</a></td>' +
+      '            <td class="holding-details">' +
+      '                <ul class="item-status" data-record-id="99115992283506421" data-holding-id="22614245530006421"></ul>' +
+      '            </td>' +
+      '        </tr>' +
+      '        <tr class="holding-block">' +
+      '            <td class="library-location" data-holding-id="22614245510006421"><span class="location-text"' +
+      '                    data-location="true" data-holding-id="22614245510006421">Forrestal Annex - Reserve</span></td>' +
+      '            <td class="holding-call-number">HB172.5 .B38 2020 <a class="browse-cn" title="Browse: HB172.5 .B38 2020"' +
+      '                    data-toggle="tooltip" data-original-title="Browse: HB172.5 .B38 2020"' +
+      '                    href="/browse/call_numbers?q=HB172.5+.B38+2020"><span class="link-text">Browse related items</span>' +
+      '                    <span class="icon-bookslibrary"></span></a></td>' +
+      '            <td class="holding-status" data-availability-record="true" data-record-id="99115992283506421"' +
+      '                data-holding-id="22614245510006421" data-aeon="false"><span class="availability-icon"></span></td>' +
+      '            <td class="location-services service-conditional" data-open="false" data-requestable="true"' +
+      '                data-aeon="false" data-holding-id="22614245510006421"><a' +
+      '                    title="View Options to Request copies from this Location" class="request btn btn-xs btn-primary"' +
+      '                    data-toggle="tooltip"' +
+      '                    href="/requests/99115992283506421?mfhd=22614245510006421&amp;source=pulsearch">Request</a></td>' +
+      '            <td class="holding-details">' +
+      '                <ul class="item-status" data-record-id="99115992283506421" data-holding-id="22614245510006421"></ul>' +
+      '            </td>' +
+      '        </tr>' +
+      '    </tbody>' +
+      '</table>';
+
+    const holding_availability_info = {
+      "on_reserve": "Y",
+      "location": "annex$reserve",
+      "label": "Forrestal Annex - Reserve",
+      "status_label": "Available",
+      "copy_number": null,
+      "cdl": false,
+      "temp_location": false,
+      "id": "22614245510006421"
+    }
+
+    const request_button_selector = `.location-services[data-holding-id='22614245510006421'] a`
+
+    expect($(request_button_selector).length).toEqual(1)
+
+    let u = new updater
+    u.id = '9965126093506421'
+    u.update_request_button('22614245510006421', holding_availability_info)
+
+    expect($(request_button_selector).length).toEqual(0)
+  })
 })


### PR DESCRIPTION
@kevinreiss this should remove the request button from the Show page for items that are on reserves. This PR is on draft since I am still testing it but it looks like the change to support this will be minimal.