### PR TITLE
Updates the show page to make an extra Javascript call to get availab…

### DIFF
--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -199,8 +199,11 @@ export default class AvailabilityUpdater {
     var url = `${this.bibdata_base_url}/bibliographic/${mms_id}/availability.json?deep=true`;
     $.getJSON(url, (data) => { this.update_single(data, mms_id); })
       .fail((jqXHR, textStatus, errorThrown) => {
-        // Notice that this console.error() message shows in the console output when running `yarn test`
-        return console.error(`Failed to retrieve deep availability data for bib. record ${mms_id}: ${errorThrown}`);
+        // Notice that this console.error() message shows in the Terminal output when running `yarn test`
+        // even while all the tests pass. The only way I have found to prevent it from showing up in the
+        // Terminal is by declaring this gratuitous variable WITHOUT var/let/const.
+        dummy_var_1 = true
+        return console.error(`Failed to retrieve deep availability data for bib. record ${mms_id}: ${errorThrown}`)
       });
 
     return;

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -183,7 +183,7 @@ export default class AvailabilityUpdater {
         dataComplete = false; // The data that we get from Alma for temporary locations is incomplete.
         break;
       }
-      if (availability_info['status_label'] == 'Unavailable') {
+      if ((availability_info['status_label'] == 'Unavailable') && (availability_info['cdl'] !== true)) {
         dataComplete = false; // Retry to see if it is available via CDL
         break;
       }
@@ -199,6 +199,7 @@ export default class AvailabilityUpdater {
     var url = `${this.bibdata_base_url}/bibliographic/${mms_id}/availability.json?deep=true`;
     $.getJSON(url, (data) => { this.update_single(data, mms_id); })
       .fail((jqXHR, textStatus, errorThrown) => {
+        // Notice that this console.error() message shows in the console output when running `yarn test`
         return console.error(`Failed to retrieve deep availability data for bib. record ${mms_id}: ${errorThrown}`);
       });
 

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -183,6 +183,10 @@ export default class AvailabilityUpdater {
         dataComplete = false; // The data that we get from Alma for temporary locations is incomplete.
         break;
       }
+      if (availability_info['status_label'] == 'Unavailable') {
+        dataComplete = false; // Retry to see if it is available via CDL
+        break;
+      }
     }
 
     if (dataComplete) {

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -274,13 +274,13 @@ describe('AvailabilityUpdater', function() {
     let u = new updater
     u.bibdata_base_url = 'http://mock_url'
     u.id = '9959958323506421'
-    const getJSON = jest.spyOn($, 'getJSON')
+    let getJSON = jest.spyOn($, 'getJSON')
     u.process_single(holding_records)
-    expect(getJSON).toHaveBeenCalledWith("http://mock_url/bibliographic/9959958323506421/availability.json?deep=true", expect.any(Function) )
+    expect(getJSON).toHaveBeenCalledWith("http://mock_url/bibliographic/9959958323506421/availability.json?deep=true", expect.any(Function))
     getJSON.mockRestore()
   })
 
-  test('record show page with an item not on CDL does not add a link', () => {
+  test('record show page with an item Unavailable and not on CDL it makes an extra call to get the full data', () => {
     document.body.innerHTML =
       '<table><tr>' +
         '<td class="holding-status" data-availability-record="true" data-record-id="9965126093506421" data-holding-id="22202918790006421" data-aeon="false">' +
@@ -289,14 +289,13 @@ describe('AvailabilityUpdater', function() {
       '</tr></table>';
     const holding_records = {"9965126093506421":{"22202918790006421":{"on_reserve":"N","location":"firestone$stacks","label":"Stacks","status_label":"Unavailable","cdl":false,"holding_type":"physical","id":"22202918790006421"}}}
 
-    const spy = jest.spyOn(orangelight_online_link, 'insert_online_link')
-
     let u = new updater
+    u.bibdata_base_url = 'http://mock_url'
     u.id = '9965126093506421'
+    let getJSON = jest.spyOn($, 'getJSON')
     u.process_single(holding_records)
-
-    expect(spy).not.toHaveBeenCalled()
-    spy.mockRestore()
+    expect(getJSON).toHaveBeenCalledWith("http://mock_url/bibliographic/9965126093506421/availability.json?deep=true", expect.any(Function))
+    getJSON.mockRestore()
   })
 
   test('record show page for a bound-with record', () => {

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -154,7 +154,7 @@ describe('AvailabilityUpdater', function() {
     expect(badge.textContent).toEqual('Available')
   })
 
-  test('record show page with an unavailable holding displays the status label in red', () => {
+  test('record show page with unavailable holdings makes a second to get more info', () => {
     document.body.innerHTML =
       '<table><tr>' +
         '<td class="holding-status" data-availability-record="true" data-record-id="99118400923506421" data-holding-id="22105449840006421" data-aeon="false">' +
@@ -163,14 +163,12 @@ describe('AvailabilityUpdater', function() {
       '</tr></table>';
     const holding_records = {"99118400923506421":{"22105449840006421":{"on_reserve":"N","location":"stacks","label":"Firestone Library (F)","status_label":"Unavailable","more_items":false,"holding_type":"physical","id":"22105449840006421"}}}
     let u = new updater
+    u.bibdata_base_url = 'http://mock_url'
     u.id = '99118400923506421'
+    const getJSON = jest.spyOn($, 'getJSON')
     u.process_single(holding_records)
-
-    const badge = document.getElementsByClassName('availability-icon')[0]
-
-    expect(badge.classList.values()).toContain('badge')
-    expect(badge.classList.values()).toContain('badge-danger')
-    expect(badge.textContent).toEqual('Unavailable')
+    expect(getJSON).toHaveBeenCalledWith("http://mock_url/bibliographic/99118400923506421/availability.json?deep=true", expect.any(Function) )
+    getJSON.mockRestore()
   })
 
   test('record show page with an mixed availability holding displays the status label in gray', () => {


### PR DESCRIPTION
This is the Orangelight complement for PR https://github.com/pulibrary/bibdata/pull/1565

Since now bib data will return "Unavailable" for CDL records unless we request a deep check this PR makes a second call to bib data with `deep=true` for any record that is Unavailable. Notice that we only make this second call from the Show page.

This improves the Search Results page performance significantly. The drawback is that if a record is Unavailable according to Alma but available through CDL the user will not notice this unless they go into the Show page for that record. 

~~We could try to make the second call with `deep=true` from the Search results after the initial call with `deep=false` if there are Unavailable records in the search results. I have not tried that.~~