### PR TITLE
Minor fix for CDL check

### DIFF
--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -27,6 +27,7 @@ export default class AvailabilityUpdater {
     this.update_single = this.update_single.bind(this);
     this.update_availability_undetermined = this.update_availability_undetermined.bind(this);
     this.process_scsb_single = this.process_scsb_single.bind(this);
+    this.availability_url_show = this.availability_url_show.bind(this);
   }
 
   request_availability(allowRetry) {
@@ -66,11 +67,7 @@ export default class AvailabilityUpdater {
           });
 
       } else {
-        url = `${this.bibdata_base_url}/bibliographic/availability.json?deep=true&bib_ids=${this.id}`;
-        if (this.host_id !== "") {
-          url += `,${this.host_id}`
-        }
-        return $.getJSON(url, this.process_single)
+        return $.getJSON(this.availability_url_show(), this.process_single)
           .fail((jqXHR, textStatus, errorThrown) => {
             if (jqXHR.status == 429) {
               if (allowRetry) {
@@ -89,6 +86,14 @@ export default class AvailabilityUpdater {
           });
       }
     }
+  }
+
+  availability_url_show() {
+    let url = `${this.bibdata_base_url}/bibliographic/availability.json?deep=true&bib_ids=${this.id}`
+    if (this.host_id !== "") {
+      url += `,${this.host_id}`
+    }
+    return url
   }
 
   scsb_search_availability() {

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -66,7 +66,7 @@ export default class AvailabilityUpdater {
           });
 
       } else {
-        url = `${this.bibdata_base_url}/bibliographic/availability.json?bib_ids=${this.id}&deep=true`;
+        url = `${this.bibdata_base_url}/bibliographic/availability.json?deep=true&bib_ids=${this.id}`;
         if (this.host_id !== "") {
           url += `,${this.host_id}`
         }

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -458,4 +458,14 @@ describe('AvailabilityUpdater', function() {
     let u = new updater
     expect(u.record_ids()).toEqual(['2939035', '3821268'])
   })
+
+  test('account for bound-with records when building URL to request availability', () => {
+    let u = new updater
+    u.bibdata_base_url = 'http://mock_url'
+    u.id = '9965126093506421'
+    expect(u.availability_url_show()).toEqual('http://mock_url/bibliographic/availability.json?deep=true&bib_ids=9965126093506421')
+
+    u.host_id = '9900126093506421'
+    expect(u.availability_url_show()).toEqual('http://mock_url/bibliographic/availability.json?deep=true&bib_ids=9965126093506421,9900126093506421')
+  })
 })


### PR DESCRIPTION
Moved the `deep=true` parameter to the front of the URL so that we don't build a bad URL if the record is a bound-with and we request availability information for more than one bib. 

See also https://github.com/pulibrary/orangelight/pull/2601