### PR TITLE
Prevents exception if a linked record does not have a title_display

### DIFF
--- a/app/services/decorator_service.rb
+++ b/app/services/decorator_service.rb
@@ -31,7 +31,7 @@ class DecoratorService
     # Access the title
     # @return [String]
     def title
-      @document.fetch(@title_field)
+      @document.fetch(@title_field, nil)
     end
 
     # Access the ID for the Solr Document

--- a/app/views/catalog/_show_linked_record.html.erb
+++ b/app/views/catalog/_show_linked_record.html.erb
@@ -1,5 +1,5 @@
 <li class="linked-block">
-  <%= link_to(linked_record.title, solr_document_url(linked_record.id)) %>
+  <%= link_to(linked_record.title || "Unknown", solr_document_url(linked_record.id)) %>
 
   <% if linked_record.fields.count == 1 %>
     <div class="linked-block-id"><span>

--- a/spec/services/decorator_service_spec.rb
+++ b/spec/services/decorator_service_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe DecoratorService::SolrDocumentDecorator do
   it "handles records without a title" do
-    solr_doc = SolrDocument.new(id: "99123923123506421", author_display: "Wosk, Yosef")
+    solr_doc = SolrDocument.new(id: "99123923123506421", author_display: ["Wosk, Yosef"])
     service = described_class.new(document: solr_doc)
     expect(service.title).to be nil
   end

--- a/spec/services/decorator_service_spec.rb
+++ b/spec/services/decorator_service_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DecoratorService::SolrDocumentDecorator do
+  it "handles records without a title" do
+    solr_doc = SolrDocument.new(id: "99123923123506421", author_display: "Wosk, Yosef")
+    service = described_class.new(document: solr_doc)
+    expect(service.title).to be nil
+  end
+end


### PR DESCRIPTION
Fixes #2614 

The linked record for MMS ID 99123444323506421 is https://catalog.princeton.edu/catalog/99123923123506421 and it does not have a `title_display' which caused the code to crash. 

This PR prevents the crash and displays "Unknown" as the title so that the page can render. Notice that we need some text ("Unknown" or something else) for the link to be rendered to the user.

![linked_record_no_title](https://user-images.githubusercontent.com/568286/128252747-7c2b355c-20b6-4fbd-ba07-9222ba671e90.png)
