### PR TITLE
Numismatics home page error (JSON)

### DIFF
--- a/app/controllers/advanced_controller.rb
+++ b/app/controllers/advanced_controller.rb
@@ -11,6 +11,9 @@ class AdvancedController < BlacklightAdvancedSearch::AdvancedController
 
   def numismatics
     @response = get_advanced_search_facets unless request.method == :post
-    render :numismatics
+    respond_to do |format|
+      format.html { render :numismatics }
+      format.json { render plain: "Format not supported", status: 400 }
+    end
   end
 end

--- a/spec/controllers/advanced_controller_spec.rb
+++ b/spec/controllers/advanced_controller_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AdvancedController do
+  describe "#numismatics" do
+    context "when requesting HTML for numismatics" do
+      it "returns OK" do
+        get :numismatics, params: { format: "html" }
+        expect(response.status).to eq 200
+      end
+    end
+    context "when requesting JSON for numismatics" do
+      it "returns an error" do
+        get :numismatics, params: { format: "json" }
+        expect(response.status).to eq 400
+      end
+    end
+  end
+end


### PR DESCRIPTION
Returns HTTP 400 when requesting numismatics as JSON (instead of crashing and returning an HTTP 500)

Fixes #2502