### PR TITLE
Fixes error on error page 

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,7 +2,7 @@
 
 class ErrorsController < ApplicationController
   def error
-    render status: :error
+    render status: 500
   end
 
   def missing

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ErrorsController do
+  it "returns 404 for not found errors" do
+    get :missing
+    expect(response.status).to eq 404
+  end
+  it "returns 500 for general errors" do
+    get :error
+    expect(response.status).to eq 500
+  end
+end


### PR DESCRIPTION
This is not a recursive joke :) The error page was indeed throwing an error when trying to render since `:error` is apparently not a thing. 

Fixes #2626