### PR TITLE
Handles gracefully if the location is invalid.

### DIFF
--- a/app/services/stackmap_service.rb
+++ b/app/services/stackmap_service.rb
@@ -38,6 +38,7 @@ class StackmapService
     end
 
     def location_label
+      return nil if holding_location.nil?
       holding_location[:label].presence || holding_location[:library][:label]
     end
 

--- a/app/views/catalog/stackmap.html.erb
+++ b/app/views/catalog/stackmap.html.erb
@@ -13,7 +13,7 @@
 
   <div class="modal-body">
     <p>
-      Call number <span class="stackmap-cn"><%= @call_number %></span> is located in <span class="stackmap-library"><%= @location_label %></span>.
+      Call number <span class="stackmap-cn"><%= @call_number %></span> is located in <span class="stackmap-library"><%= @location_label || '(cannot be determined)' %></span>.
     </p>
     <div class="stackmap-wrapper">
       <iframe class="stackmap-src" src=<%= @url %>></iframe>

--- a/spec/services/stackmap_service_spec.rb
+++ b/spec/services/stackmap_service_spec.rb
@@ -107,6 +107,9 @@ RSpec.describe StackmapService::Url do
       it 'resolves to catalog show page url' do
         expect(url).to include("/catalog/#{properties[:id]}")
       end
+      it 'returns nil for the location label' do
+        expect(url_service.location_label).to be nil
+      end
     end
     describe 'nil location' do
       let(:location) { nil }


### PR DESCRIPTION
The service will now return `nil` (rather than throwing an Exception) if the location is not valid. The UI will display "location cannot be determined".

Fixes #1582

