### PR TITLE
Handles bad session

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -74,7 +74,7 @@ module Users
       # @return [OmniAuth::AuthHash,nil] the access token
       def barcode_token_in_request_params
         access_token = access_token_in_request_params
-        access_token.uid = access_token.uid.gsub(/\s/, '') unless access_token.nil? || access_token.uid.empty?
+        access_token.uid = access_token.uid.gsub(/\s/, '') unless access_token.nil? || access_token.uid.blank?
         access_token
       end
   end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -26,6 +26,21 @@ RSpec.describe Users::OmniauthCallbacksController do
     end
   end
 
+  describe 'bad omniauth session' do
+    let(:omniauth_response_nil_uid) do
+      OmniAuth::AuthHash.new(provider: 'barcode', uid: nil, info: { last_name: "" })
+    end
+    before do
+      controller.request.env['omniauth.auth'] = omniauth_response_nil_uid
+    end
+    it 'handles nil UID' do
+      allow(User).to receive(:from_barcode) { valid_barcode_user }
+      allow(Bibdata).to receive(:get_patron) { guest_response }
+      get :barcode
+      expect(response).to redirect_to(account_path)
+    end
+  end
+
   describe 'logging in' do
     it 'valid cas login redirects to account page' do
       allow(User).to receive(:from_cas) { FactoryBot.create(:valid_princeton_patron) }


### PR DESCRIPTION
This PR handles the bad session so that now instead of crashing and showing an HTTP 500 

![http_500](https://user-images.githubusercontent.com/568286/128563139-6da391e6-3c5c-4829-ba70-64325f957a3c.png)

we handle the error and that results in the (expected?) workflow to take place: redirect the user and show a flash warning indicating that the session in invalid.

![redirect_flash](https://user-images.githubusercontent.com/568286/128563169-de2401f1-284b-49ab-8b0f-29aaf3d0ef3e.png)

Fixes #2635