### PR TITLE
Loads Rails environment so that Rails.logger.error() is available

### DIFF
--- a/lib/tasks/browse.rake
+++ b/lib/tasks/browse.rake
@@ -26,7 +26,7 @@ namespace :browse do
   end
 
   desc 'Pull data for call numbers browse'
-  task :call_numbers do
+  task call_numbers: :environment do
     _sql_command, facet_request, conn = BrowseLists.connection
     BrowseLists::CallNumberCSV.new(facet_request, conn).write
   end


### PR DESCRIPTION
Fixes #2639 

Although the real error behind 2639 was a Solr error, the error reported by Honeybadger was because it crashed when it tried to log the error. This PR addresses only the error reported by Honeybadger (i.e. not the Solr error)

I did not add a test since the problem was the declaration of the Rake task, let me know if I should add a test for that kind of mis-declaration of a rake task.