### PR TITLE
Prevents error when search query ends with empty parenthesis

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -21,7 +21,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   # and unfortunately Parslet gets confused when the user's query ends with "()". Here we tweak the
   # query to prevent the error and let the query to be parsed as if the ending "()" was not present.
   # Notice that we must update the value in `blacklight_params[:q]`
-  def parslet_trick(solr_parameters)
+  def parslet_trick(_solr_parameters)
     return unless (blacklight_params[:q] || "").strip.end_with?("()")
     blacklight_params[:q] = blacklight_params[:q].strip.gsub("()", "")
   end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -22,7 +22,8 @@ class SearchBuilder < Blacklight::SearchBuilder
   # query to prevent the error and let the query to be parsed as if the ending "()" was not present.
   # Notice that we must update the value in `blacklight_params[:q]`
   def parslet_trick(_solr_parameters)
-    return unless (blacklight_params[:q] || "").strip.end_with?("()")
+    return unless blacklight_params[:q].is_a?(String)
+    return unless blacklight_params[:q].strip.end_with?("()")
     blacklight_params[:q] = blacklight_params[:q].strip.gsub("()", "")
   end
 

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -43,5 +43,11 @@ RSpec.describe SearchBuilder do
       search_builder.blacklight_params[:search_field] = 'advanced'
       expect(search_builder.excessive_paging?).to be false
     end
+
+    it 'handles query ending with empty parenthesis' do
+      search_builder.blacklight_params[:q] = 'hello world ()'
+      search_builder.parslet_trick({})
+      expect(search_builder.blacklight_params[:q].end_with?("()")).to be false
+    end
   end
 end


### PR DESCRIPTION
Fixes #1656 