### PR TITLE
Added specific logic to handle the display of Marquand unavailable items

### DIFF
--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -428,7 +428,7 @@ export default class AvailabilityUpdater {
     return ` - ${date_string}`;
   };
 
-  on_site_use_location(location) {
-    return location == "marquand$stacks";
+  on_site_use_marquand_location(location) {
+    return location == "marquand$stacks" || location == "marquand$pj";
   }
 }

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -389,7 +389,12 @@ export default class AvailabilityUpdater {
           const location_services_element = $(`.location-services[data-holding-id='${availability_info['id']}'] a`);
           location_services_element.remove();
         }
-      } else {
+      } else if (this.on_site_use_marquand_location(availability_info["location"])) {
+        availability_element.text("Ask Staff");
+        availability_element.attr('title', 'Ask a member of our staff for access to this item.');
+        badgeClass = "badge-secondary"
+      }
+      else {
         availability_element.addClass("badge-danger");
       }
     } else if (status_label.toLowerCase() === 'available') {

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -363,6 +363,7 @@ export default class AvailabilityUpdater {
     availability_element.addClass("badge");
     let status_label = availability_info['status_label'];
     let isCdl = availability_info['cdl'];
+    let badgeClass = "badge-danger";
     status_label = `${status_label}${this.due_date(availability_info["due_date"])}`;
     availability_element.text(status_label);
     availability_element.attr('title', '');
@@ -392,10 +393,11 @@ export default class AvailabilityUpdater {
         availability_element.addClass("badge-danger");
       }
     } else if (status_label.toLowerCase() === 'available') {
-      availability_element.addClass("badge-success");
+      badgeClass = "badge-success";
     } else {
-      availability_element.addClass("badge-secondary");
+      badgeClass = "badge-secondary";
     }
+    availability_element.addClass(badgeClass);
   }
 
   title_case(str) {
@@ -425,4 +427,8 @@ export default class AvailabilityUpdater {
     if (date_string == null) { return ""; }
     return ` - ${date_string}`;
   };
+
+  on_site_use_location(location) {
+    return location == "marquand$stacks";
+  }
 }

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -454,7 +454,7 @@ describe('AvailabilityUpdater', function() {
       '<tbody>' +
       '  <tr class="holding-block">' +
       '    <td class="library-location" data-holding-id="22555592710006421">' +
-      '      <span class="location-text" data-location="true" data-holding-id="22555592710006421">Marquand Library - Marquand Library</span>' +
+      '      <span class="location-text" data-location="true" data-holding-id="22555592710006421">Marquand Library - Remote Storage: Marquand Use Only</span>' +
       '    </td>' +
       '    <td class="holding-call-number"></td>' +
       '    <td class="holding-status" data-availability-record="true" data-record-id="99101378413506421" data-holding-id="22555592710006421" data-aeon="false">'  +

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -460,7 +460,7 @@ describe('AvailabilityUpdater', function() {
       '    <td class="holding-status" data-availability-record="true" data-record-id="99101378413506421" data-holding-id="22555592710006421" data-aeon="false">'  +
       '      <span class="availability-icon badge badge-secondary" title=""></span>' +
       '    </td>' +
-      '    <td class="location-services service-conditional" data-open="true" data-requestable="true" data-aeon="false" data-holding-id="22555592710006421">' +
+      '    <td class="location-services service-conditional" data-open="false" data-requestable="true" data-aeon="false" data-holding-id="22555592710006421">' +
       '     <a title="View Options to Request copies from this Location" class="request btn btn-xs btn-primary" data-toggle="tooltip" href="/requests/99101378413506421?mfhd=22555592710006421&amp;source=pulsearch">Request</a>' +
       '    </td>' +
       '    <td class="holding-details">' +
@@ -475,7 +475,7 @@ describe('AvailabilityUpdater', function() {
         "22555592710006421":{
           "on_reserve":"N",
           "location":"marquand$stacks",
-          "label":"Marquand Library - Marquand Library",
+          "label":"Marquand Library - Remote Storage: Marquand Use Only",
           "status_label":"Unavailable",
           "copy_number":null,
           "cdl":false,

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -490,9 +490,9 @@ describe('AvailabilityUpdater', function() {
     let u = new updater;
     u.id = '99101378413506421';
 
-    expect(av_element[0].textContent).not.toContain('Ask a librarian');
+    expect(av_element[0].textContent).not.toContain('Ask Staff');
     u.apply_availability_label(av_element, holding_data, true);
-    expect(av_element[0].textContent).toContain('Ask a librarian');
+    expect(av_element[0].textContent).toContain('Ask Staff');
   })
 
   // TODO: This method isn't covered by the feature tests

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -449,6 +449,52 @@ describe('AvailabilityUpdater', function() {
     expect(av_element[0].textContent).toContain('Online');
   })
 
+  test('special case for Marquand Stacks items reported as unavailable', () => {
+    document.body.innerHTML = '<table class="availability-table">' +
+      '<tbody>' +
+      '  <tr class="holding-block">' +
+      '    <td class="library-location" data-holding-id="22555592710006421">' +
+      '      <span class="location-text" data-location="true" data-holding-id="22555592710006421">Marquand Library - Marquand Library</span>' +
+      '    </td>' +
+      '    <td class="holding-call-number"></td>' +
+      '    <td class="holding-status" data-availability-record="true" data-record-id="99101378413506421" data-holding-id="22555592710006421" data-aeon="false">'  +
+      '      <span class="availability-icon badge badge-secondary" title=""></span>' +
+      '    </td>' +
+      '    <td class="location-services service-conditional" data-open="true" data-requestable="true" data-aeon="false" data-holding-id="22555592710006421">' +
+      '     <a title="View Options to Request copies from this Location" class="request btn btn-xs btn-primary" data-toggle="tooltip" href="/requests/99101378413506421?mfhd=22555592710006421&amp;source=pulsearch">Request</a>' +
+      '    </td>' +
+      '    <td class="holding-details">' +
+      '      <ul class="item-status" data-record-id="99101378413506421" data-holding-id="22555592710006421"></ul>' +
+      '    </td>' +
+      '  </tr>' +
+      '</tbody>' +
+      '</table>';
+
+    const availability_response = {
+      "99101378413506421":{
+        "22555592710006421":{
+          "on_reserve":"N",
+          "location":"marquand$stacks",
+          "label":"Marquand Library - Marquand Library",
+          "status_label":"Unavailable",
+          "copy_number":null,
+          "cdl":false,
+          "temp_location":false,
+          "id":"22555592710006421"
+        }
+      }
+    }
+    const holding_data = availability_response["99101378413506421"]["22555592710006421"];
+    const av_element = $(`*[data-availability-record='true'][data-record-id='99101378413506421'][data-holding-id='22555592710006421'] .availability-icon`);
+
+    let u = new updater;
+    u.id = '99101378413506421';
+
+    expect(av_element[0].textContent).not.toContain('Ask a librarian');
+    u.apply_availability_label(av_element, holding_data, true);
+    expect(av_element[0].textContent).toContain('Ask a librarian');
+  })
+
   // TODO: This method isn't covered by the feature tests
   test('scsb_barcodes() on a search results page', () => {
     // This is only used on search results page


### PR DESCRIPTION
Displays "Ask a Librarian" as the status for unavailable Marquand items. Fixes #2659 

The logic is currently hard-coded for "marquand$stacks", we could make this more dynamic if there are other locations that need this type of display and/or they change frequently.

![marquand_list](https://user-images.githubusercontent.com/568286/129940761-1e7a5c76-5cbb-41df-911c-7cc90bc9978e.png)

![marquand_show](https://user-images.githubusercontent.com/568286/129940784-b79c2329-e45c-4693-b08b-79e690cbf580.png)

