### PR TITLE
Availability display in Show page for CDL items

### DIFF
--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -367,14 +367,26 @@ export default class AvailabilityUpdater {
     availability_element.text(status_label);
     availability_element.attr('title', '');
     if (status_label.toLowerCase() === 'unavailable') {
-      availability_element.addClass("badge-danger");
-      if (isCdl && addCdlBadge) {
-        // The _physical_ copy is not available but we highlight that the _online_ copy is.
-        availability_element.attr('title', 'Physical copy is not available.');
-        let cdlPlaceholder = availability_element.parent().next().find("*[data-availability-cdl='true']");
-        cdlPlaceholder.text('Online');
-        cdlPlaceholder.attr('title', 'Online copy available via Controlled Digital Lending');
-        cdlPlaceholder.addClass('badge badge-primary');
+      if (isCdl) {
+        if (addCdlBadge) {
+          availability_element.addClass("badge-danger");
+          availability_element.attr('title', 'Physical copy is not available.');
+          // The _physical_ copy is not available but we highlight that the _online_ copy is.
+          let cdlPlaceholder = availability_element.parent().next().find("*[data-availability-cdl='true']");
+          cdlPlaceholder.text('Online');
+          cdlPlaceholder.attr('title', 'Online copy available via Controlled Digital Lending');
+          cdlPlaceholder.addClass('badge badge-primary');
+        } else {
+          // Remove the request button and switch the availability to indicate that it's available Online.
+          const location_services_element = $(`.location-services[data-holding-id='${availability_info['id']}'] a`);
+          location_services_element.remove();
+
+          availability_element.text('Online');
+          availability_element.attr('title', 'Online copy available via Controlled Digital Lending');
+          availability_element.addClass("badge-secondary");
+        }
+      } else {
+        availability_element.addClass("badge-danger");
       }
     } else if (status_label.toLowerCase() === 'available') {
       availability_element.addClass("badge-success");

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -367,23 +367,26 @@ export default class AvailabilityUpdater {
     availability_element.text(status_label);
     availability_element.attr('title', '');
     if (status_label.toLowerCase() === 'unavailable') {
+      // The physical copy is not available but we highlight that the online copy is.
       if (isCdl) {
         if (addCdlBadge) {
+          // Add an Online badge, next to Unavailable.
+          // (used in the Search Results page)
           availability_element.addClass("badge-danger");
           availability_element.attr('title', 'Physical copy is not available.');
-          // The _physical_ copy is not available but we highlight that the _online_ copy is.
+
           let cdlPlaceholder = availability_element.parent().next().find("*[data-availability-cdl='true']");
           cdlPlaceholder.text('Online');
           cdlPlaceholder.attr('title', 'Online copy available via Controlled Digital Lending');
           cdlPlaceholder.addClass('badge badge-primary');
         } else {
-          // Remove the request button and switch the availability to indicate that it's available Online.
-          const location_services_element = $(`.location-services[data-holding-id='${availability_info['id']}'] a`);
-          location_services_element.remove();
-
+          // Display Online, instead of Unavailable, and remove the request button.
+          // (used in the Show page)
           availability_element.text('Online');
           availability_element.attr('title', 'Online copy available via Controlled Digital Lending');
           availability_element.addClass("badge-secondary");
+          const location_services_element = $(`.location-services[data-holding-id='${availability_info['id']}'] a`);
+          location_services_element.remove();
         }
       } else {
         availability_element.addClass("badge-danger");

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -392,6 +392,63 @@ describe('AvailabilityUpdater', function() {
     expect(cdl_element.textContent).toContain('Online');
   })
 
+  test('in the Show page we display Online instead of Unavailable for CDL records', () => {
+    document.body.innerHTML = '<table><tbody>' +
+    '<tr class="holding-block">' +
+    '  <td class="library-location" data-holding-id="22745424290006421">' +
+    '    <span class="location-text" data-location="true" data-holding-id="22745424290006421">Firestone Library - Firestone Library</span>' +
+    '    <a title="Where to find it" class="find-it" data-map-location="firestone$stacks" data-blacklight-modal="trigger"' +
+    '      data-call-number="HB172 .G664 2016" data-library="Firestone Library"' +
+    '      href="/catalog/9999490563506421/stackmap?loc=firestone$stacks&amp;cn=HB172 .G664 2016">' +
+    '      <span class="link-text">Where to find it</span>' +
+    '      <span class="fa fa-map-marker" aria-hidden="true"></span>' +
+    '    </a>' +
+    '  </td>' +
+    '  <td class="holding-call-number">HB172 .G664 2016' +
+    '    <a class="browse-cn" title="Browse: HB172 .G664 2016" data-toggle="tooltip"' +
+    '      data-original-title="Browse: HB172 .G664 2016" href="/browse/call_numbers?q=HB172+.G664+2016">' +
+    '      <span class="link-text">Browse related items</span>' +
+    '      <span class="icon-bookslibrary"></span>' +
+    '    </a>' +
+    '  </td>' +
+    '  <td class="holding-status" data-availability-record="true" data-record-id="9999490563506421"' +
+    '    data-holding-id="22745424290006421" data-aeon="false">' +
+    '    <span class="availability-icon badge " title=""></span>' +
+    '  </td>' +
+    '  <td class="location-services service-conditional" data-open="true" data-requestable="true" data-aeon="false"' +
+    '    data-holding-id="22745424290006421"></td>' +
+    '  <td class="holding-details">' +
+    '    <ul class="item-status" data-record-id="9999490563506421" data-holding-id="22745424290006421"></ul>' +
+    '  </td>' +
+    '</tr>' +
+    '</tbody></table>';
+
+    const availability_response = {
+      "9999490563506421": {
+        "22745424290006421": {
+          "on_reserve": "N",
+          "location": "firestone$stacks",
+          "label": "Firestone Library - Firestone Library",
+          "status_label": "Unavailable",
+          "copy_number": null,
+          "cdl": true,
+          "temp_location": false,
+          "id": "22745424290006421"
+        }
+      }
+    }
+
+    const holding_data = availability_response["9999490563506421"]["22745424290006421"];
+
+    const av_element = $(`*[data-availability-record='true'][data-record-id='9999490563506421'][data-holding-id='22745424290006421'] .availability-icon`);
+    let u = new updater;
+    u.id = '9999490563506421';
+
+    expect(av_element[0].textContent).not.toContain('Online');
+    u.apply_availability_label(av_element, holding_data, false);
+    expect(av_element[0].textContent).toContain('Online');
+  })
+
   // TODO: This method isn't covered by the feature tests
   test('scsb_barcodes() on a search results page', () => {
     // This is only used on search results page


### PR DESCRIPTION
Display "Online" as the availability for items in CDL instead of "Unavailable". It also *removes* the Request button from the page. Fixes #2669

The only drawback with the current implementation is that the user will initially see the "Request" button next to each item, and after a few seconds (when the call to BibData/Alma comes back) the Request buttons will be removed. This is a known issue due to the slowness of the Alma API to return when we request this level of information (see #1616) and could be tackled separately.

Below are two screenshots showing the page before and after the change.

 ## Before

![cdl_before](https://user-images.githubusercontent.com/568286/130998402-4d33c183-7edd-49cd-98f7-6e68c95beecd.png)

## After

![cdl_after](https://user-images.githubusercontent.com/568286/130998425-98482356-880a-4b67-9399-3328e0315e83.png)
