### PR TITLE
Prevents the no holdings display when there electronic access links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -265,6 +265,12 @@ module ApplicationHelper
                                         class: 'availability-icon more-info', title: 'Click on the record for full availability info',
                                         'data-toggle' => 'tooltip').html_safe, class: 'empty', data: { record_id: document['id'] })
     end
+
+    if block.empty? && links.count > 0
+      # All other options came up empty but since we have electronic access let's show Online rather than no holdings.
+      block << content_tag(:span, 'Online', class: 'availability-icon badge badge-primary', title: 'Electronic access', 'data-toggle' => 'tooltip')
+    end
+
     if block.empty?
       content_tag(:div, t('blacklight.holdings.search_missing'))
     else

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -266,7 +266,7 @@ module ApplicationHelper
                                         'data-toggle' => 'tooltip').html_safe, class: 'empty', data: { record_id: document['id'] })
     end
 
-    if block.empty? && links.count > 0
+    if block.empty? && links.present?
       # All other options came up empty but since we have electronic access let's show Online rather than no holdings.
       block << content_tag(:span, 'Online', class: 'availability-icon badge badge-primary', title: 'Electronic access', 'data-toggle' => 'tooltip')
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -267,8 +267,12 @@ module ApplicationHelper
     end
 
     if block.empty? && links.present?
-      # All other options came up empty but since we have electronic access let's show Online rather than no holdings.
-      block << content_tag(:span, 'Online', class: 'availability-icon badge badge-primary', title: 'Electronic access', 'data-toggle' => 'tooltip')
+      # All other options came up empty but since we have electronic access let's show the
+      # Online badge with the electronic access link (rather than a misleading "No holdings")
+      info = ''
+      info << content_tag(:span, 'Online', class: 'availability-icon badge badge-primary', title: 'Electronic access', 'data-toggle' => 'tooltip')
+      info << links.shift.html_safe
+      block << content_tag(:li, info.html_safe)
     end
 
     if block.empty?

--- a/spec/helpers/holding_block_spec.rb
+++ b/spec/helpers/holding_block_spec.rb
@@ -245,16 +245,16 @@ RSpec.describe ApplicationHelper do
         {
           id: '1',
           format: ['Book'],
-          electronic_access_1display: '{"https://purl.fdlp.gov/GPO/LPS40377":["purl.fdlp.gov"]}'
+          electronic_access_1display: '{"https://library.princeton.edu/resource/28076":["library.princeton.edu"]}'
         }.with_indifferent_access
       end
 
       before { stub_holding_locations }
 
-      it 'includes the online badge since there is an electronic access link' do
-        # In this case we just look for the Online badge (the link is not rendered.)
+      it 'includes the online badge and link since there is an electronic access link' do
         holdings_block = helper.holding_block_search(SolrDocument.new(document))
         expect(holdings_block).to include ">Online</span"
+        expect(holdings_block).to include "library.princeton.edu"
       end
     end
 

--- a/spec/helpers/holding_block_spec.rb
+++ b/spec/helpers/holding_block_spec.rb
@@ -240,6 +240,24 @@ RSpec.describe ApplicationHelper do
       end
     end
 
+    context '#holding_block_search with links only' do
+      let(:document) do
+        {
+          id: '1',
+          format: ['Book'],
+          electronic_access_1display: '{"https://purl.fdlp.gov/GPO/LPS40377":["purl.fdlp.gov"]}'
+        }.with_indifferent_access
+      end
+
+      before { stub_holding_locations }
+
+      it 'includes the online badge for the link' do
+        # In this case we just look the Online badge (the link is not rendered.)
+        holdings_block = helper.holding_block_search(SolrDocument.new(document))
+        expect(holdings_block).to include ">Online</span"
+      end
+    end
+
     context '#holding_block record show - physical holding thesis reading room request' do
       before { stub_holding_locations }
 

--- a/spec/helpers/holding_block_spec.rb
+++ b/spec/helpers/holding_block_spec.rb
@@ -251,8 +251,8 @@ RSpec.describe ApplicationHelper do
 
       before { stub_holding_locations }
 
-      it 'includes the online badge for the link' do
-        # In this case we just look the Online badge (the link is not rendered.)
+      it 'includes the online badge since there is an electronic access link' do
+        # In this case we just look for the Online badge (the link is not rendered.)
         holdings_block = helper.holding_block_search(SolrDocument.new(document))
         expect(holdings_block).to include ">Online</span"
       end


### PR DESCRIPTION
This takes care of the issue in the Search results where we incorrectly display "No holdings available for this record" and instead it displays the Online badge and the electronic access link

![show_elink](https://user-images.githubusercontent.com/568286/131743860-88ca6ca4-f095-4c3d-992b-fa50d3ef1ff3.png)

Compare with the [current display in production](https://catalog.princeton.edu/catalog?utf8=%E2%9C%93&f%5Baccess_facet%5D%5B%5D=Online&f1=in_series&q1=%E4%B8%AD%E5%9C%8B%E8%97%9D%E8%A1%93%E6%96%87%E7%8D%BB%E5%8F%A2%E5%88%8A.&search_field=all_fields&q=99101494203506421)

With this fix the online badge and link will only be added if all other checks for holdings/portfolios come up empty but we do have an "electronic access" link for the record. 

Fixes #2668
