### PR TITLE
Fixes problem in Chicago citations when MARC 502|d is missing

### DIFF
--- a/app/models/concerns/blacklight/solr/document/marc.rb
+++ b/app/models/concerns/blacklight/solr/document/marc.rb
@@ -10,6 +10,10 @@ module Blacklight
         include Blacklight::Solr::Document::MarcExport
         include OpenURL
 
+        # Prepend our overloaded method to bypass bug in Blacklight
+        # See https://stackoverflow.com/questions/5944278/overriding-method-by-another-defined-in-module
+        prepend Blacklight::Solr::Document::MarcExportOverride
+
         class UnsupportedMarcFormatType < RuntimeError; end
 
         def self.extended(document)

--- a/app/models/concerns/blacklight/solr/document/marc_export_override.rb
+++ b/app/models/concerns/blacklight/solr/document/marc_export_override.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Blacklight::Solr::Document::MarcExportOverride
+  # Override Blacklight's version to add nil check
+  # See https://github.com/projectblacklight/blacklight-marc/issues/95
+  def clean_end_punctuation(text)
+    # rubocop:disable Style/IfUnlessModifier
+    return "" if text.nil?
+    if [".", ",", ":", ";", "/"].include? text[-1, 1]
+      return text[0, text.length - 1]
+    end
+    text
+    # rubocop:enable Style/IfUnlessModifier
+  end
+end

--- a/spec/models/concerns/blacklight/solr/document/marc_export_override_spec.rb
+++ b/spec/models/concerns/blacklight/solr/document/marc_export_override_spec.rb
@@ -2,15 +2,17 @@
 require 'rails_helper'
 
 RSpec.describe Blacklight::Solr::Document::MarcExportOverride do
-  # See https://mixandgo.com/learn/how-to-test-ruby-modules-with-rspec for information on
-  # testing methods defined in modules.
-  let(:dummy_class) do
-    Class.new do
-      extend Blacklight::Solr::Document::MarcExportOverride
+  describe "#clean_end_punctuation" do
+    # See https://mixandgo.com/learn/how-to-test-ruby-modules-with-rspec for information on
+    # testing methods defined in modules.
+    let(:sample_class) do
+      Class.new do
+        include Blacklight::Solr::Document::MarcExportOverride
+      end
     end
-  end
 
-  it 'handles nil values' do
-    expect(dummy_class.clean_end_punctuation(nil)).to eq ""
+    it 'handles nil values' do
+      expect(sample_class.new.clean_end_punctuation(nil)).to eq ""
+    end
   end
 end

--- a/spec/models/concerns/blacklight/solr/document/marc_export_override_spec.rb
+++ b/spec/models/concerns/blacklight/solr/document/marc_export_override_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Blacklight::Solr::Document::MarcExportOverride do
+  # See https://mixandgo.com/learn/how-to-test-ruby-modules-with-rspec for information on
+  # testing methods defined in modules.
+  let(:dummy_class) do
+    Class.new do
+      extend Blacklight::Solr::Document::MarcExportOverride
+    end
+  end
+
+  it 'handles nil values' do
+    expect(dummy_class.clean_end_punctuation(nil)).to eq ""
+  end
+end
+

--- a/spec/models/concerns/blacklight/solr/document/marc_export_override_spec.rb
+++ b/spec/models/concerns/blacklight/solr/document/marc_export_override_spec.rb
@@ -14,4 +14,3 @@ RSpec.describe Blacklight::Solr::Document::MarcExportOverride do
     expect(dummy_class.clean_end_punctuation(nil)).to eq ""
   end
 end
-


### PR DESCRIPTION
Override method `clean_end_punctuation()` to prevent crash in Chicago style citations when field MARC `502|d` is `nil`. 

Fixes #1874 

The culprit is buried in a method inside Blacklight MARC gem ([code](https://github.com/projectblacklight/blacklight-marc/blob/db85fe39922f556c7dd44126865321848e4b882c/app/models/concerns/blacklight/solr/document/marc_export.rb#L303-L305)) that I was able to override thanks to Ruby's built-in prepend feature ([more info](https://stackoverflow.com/questions/5944278/overriding-method-by-another-defined-in-module)). Notice that I disabled  a Rubocop rule in the overridden method so that its code mimics the structure of the [original implementation in Blacklight MARC](https://github.com/projectblacklight/blacklight-marc/blob/db85fe39922f556c7dd44126865321848e4b882c/app/models/concerns/blacklight/solr/document/marc_export.rb#L493-L498). 



