### PR TITLE
Hide stack map links for certain locations

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -456,8 +456,10 @@ module ApplicationHelper
     HoldingRequestsAdapter.new(@document, Bibdata)
   end
 
+  # Returns true for locations where the use can walk and fetch an item.
+  # Currently this logic is duplicated in Javascript code in availability.es6
   def find_it_location?(location_code)
-    return false if (location_code || "").start_with?("plasma$")
+    return false if (location_code || "").start_with?("plasma$", "marquand$")
     true
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -456,7 +456,7 @@ module ApplicationHelper
     HoldingRequestsAdapter.new(@document, Bibdata)
   end
 
-  # Returns true for locations where the use can walk and fetch an item.
+  # Returns true for locations where the user can walk and fetch an item.
   # Currently this logic is duplicated in Javascript code in availability.es6
   def find_it_location?(location_code)
     return false if (location_code || "").start_with?("plasma$", "marquand$")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -79,7 +79,7 @@ module ApplicationHelper
     link = locate_url(location, document, call_number, library)
     stackmap_url = "/catalog/#{document['id']}/stackmap?loc=#{location}"
     stackmap_url << "&cn=#{call_number}" if call_number
-    if link.nil?
+    if link.nil? || (find_it_location?(location) == false)
       ''
     else
       ' ' + link_to('<span class="fa fa-map-marker" aria-hidden="true"></span>'.html_safe, stackmap_url, title: t('blacklight.holdings.stackmap'), class: 'find-it', 'data-map-location' => location.to_s, 'data-blacklight-modal' => 'trigger', 'aria-label' => 'Where to find it')
@@ -454,5 +454,10 @@ module ApplicationHelper
   # @return [HoldingRequestsAdapter]
   def holding_requests_adapter
     HoldingRequestsAdapter.new(@document, Bibdata)
+  end
+
+  def find_it_location?(location_code)
+    return false if (location_code || "").start_with?("plasma$")
+    true
   end
 end

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -419,7 +419,7 @@ export default class AvailabilityUpdater {
     }
 
     var link = '';
-    if (find_it_location(location)) {
+    if (this.find_it_location(location)) {
       const map_url = `/catalog/${record_id}/stackmap?loc=${location}`;
       const marker_span = "<span class='fa fa-map-marker'></span>";
       link = `<a title='Where to find it' class='find-it' data-location-map='${location}' data-blacklight-modal='trigger' href='${map_url}'>`;
@@ -442,8 +442,11 @@ export default class AvailabilityUpdater {
     return location == "marquand$stacks" || location == "marquand$pj";
   }
 
-  /* Currently this logic is duplicated in Ruby code in ApplicationHelper::find_it_location. */
+  /* Currently this logic is duplicated in Ruby code in application_helper.rb (ApplicationHelper::find_it_location) */
   find_it_location(location) {
-    return location.startsWith("plasma$") == false
+    if (location.startsWith("plasma$") || location.startsWith("marquand$")) {
+      return false
+    }
+    return true
   }
 }

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -417,14 +417,19 @@ export default class AvailabilityUpdater {
     } else {
       location = availability_info['location'];
     }
-    const map_url = `/catalog/${record_id}/stackmap?loc=${location}`;
-    let link = `<a title='Where to find it' class='find-it' data-location-map='${location}' data-blacklight-modal='trigger' href='${map_url}'>`;
-    const marker_span = "<span class='fa fa-map-marker'></span>";
-    if (marker_only) {
-      link = `${link}${marker_span}</a>`;
-    } else {
-      link = `${link}<span class='link-text'>Where to find it</span>${marker_span}</a>`;
+
+    var link = '';
+    if (find_it_location(location)) {
+      const map_url = `/catalog/${record_id}/stackmap?loc=${location}`;
+      const marker_span = "<span class='fa fa-map-marker'></span>";
+      link = `<a title='Where to find it' class='find-it' data-location-map='${location}' data-blacklight-modal='trigger' href='${map_url}'>`;
+      if (marker_only) {
+        link = `${link}${marker_span}</a>`;
+      } else {
+        link = `${link}<span class='link-text'>Where to find it</span>${marker_span}</a>`;
+      }
     }
+
     return link;
   };
 
@@ -435,5 +440,10 @@ export default class AvailabilityUpdater {
 
   on_site_use_marquand_location(location) {
     return location == "marquand$stacks" || location == "marquand$pj";
+  }
+
+  /* Currently this logic is duplicated in Ruby code in ApplicationHelper::find_it_location. */
+  find_it_location(location) {
+    return location.startsWith("plasma$") == false
   }
 }

--- a/app/services/physical_holdings_markup_builder.rb
+++ b/app/services/physical_holdings_markup_builder.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: false
 
 class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
-  include ApplicationHelper # needed for find_it_location method
+  include ApplicationHelper
 
   # Generate <span> markup used in links for browsing by call numbers
   # @return [String] the markup

--- a/app/services/physical_holdings_markup_builder.rb
+++ b/app/services/physical_holdings_markup_builder.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: false
 
 class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
+  include ApplicationHelper # needed for find_it_location method
+
   # Generate <span> markup used in links for browsing by call numbers
   # @return [String] the markup
   def self.call_number_span
@@ -335,17 +337,20 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
     stackmap_url = "/catalog/#{adapter.doc_id}/stackmap?loc=#{location}"
     stackmap_url << "&cn=#{call_number}" if call_number
 
-    child = %(<span class="link-text">#{I18n.t('blacklight.holdings.stackmap')}</span>\
-      <span class="fa fa-map-marker" aria-hidden="true"></span>)
-    markup = link_to(child.html_safe, stackmap_url,
-                     title: I18n.t('blacklight.holdings.stackmap'),
-                     class: 'find-it',
-                     data: {
-                       'map-location' => location.to_s,
-                       'blacklight-modal' => 'trigger',
-                       'call-number' => call_number,
-                       'library' => library
-                     })
+    markup = ''
+    if find_it_location?(location)
+      child = %(<span class="link-text">#{I18n.t('blacklight.holdings.stackmap')}</span>\
+        <span class="fa fa-map-marker" aria-hidden="true"></span>)
+      markup = link_to(child.html_safe, stackmap_url,
+                       title: I18n.t('blacklight.holdings.stackmap'),
+                       class: 'find-it',
+                       data: {
+                         'map-location' => location.to_s,
+                         'blacklight-modal' => 'trigger',
+                         'call-number' => call_number,
+                         'library' => library
+                       })
+    end
     ' ' + markup
   end
 

--- a/spec/helpers/holding_block_spec.rb
+++ b/spec/helpers/holding_block_spec.rb
@@ -275,13 +275,13 @@ RSpec.describe ApplicationHelper do
 
       before { stub_holding_locations }
 
-      # For most locations we display a map icon to help patrons if they want to fetch the item
+      # For most locations a map icon is displayed to help patrons if they want to fetch the item.
       it 'includes the find it icon' do
         search_result = helper.holding_block_search(SolrDocument.new(document_with_find_it_link))
         expect(search_result).to include "fa-map-marker"
       end
 
-      # For certain locations we do not display the map icon since the location is not accessible by patrons
+      # For certain locations a map icon is not displayed if the location is not accessible by patrons.
       it 'does not include the find it icon' do
         search_result = helper.holding_block_search(SolrDocument.new(document_without_find_it_link))
         expect(search_result).not_to include "fa-map-marker"

--- a/spec/helpers/holding_block_spec.rb
+++ b/spec/helpers/holding_block_spec.rb
@@ -240,6 +240,54 @@ RSpec.describe ApplicationHelper do
       end
     end
 
+    context '#holding_block_search and the find it pin icon' do
+      let(:document_with_find_it_link) do
+        {
+          id: '1',
+          format: ['Book'],
+          holdings_1display: {
+            "22123123123" => {
+              location_code: "firestone$stacks",
+              call_number: "FIRE-123",
+              call_number_browse: "FIRE-123",
+              location: "Stacks",
+              library: "Firestone"
+            }
+          }.to_json.to_s
+        }.with_indifferent_access
+      end
+
+      let(:document_without_find_it_link) do
+        {
+          id: '1',
+          format: ['Book'],
+          holdings_1display: {
+            "22789789789" => {
+              location_code: "plasma$stacks",
+              call_number: "PLASMA-123",
+              call_number_browse: "PLASMA-123",
+              location: "Stacks",
+              library: "Plasma"
+            }
+          }.to_json.to_s
+        }.with_indifferent_access
+      end
+
+      before { stub_holding_locations }
+
+      # For mosst locations we display a map icon to help patrons if they want to fetch the item
+      it 'includes the find it icon' do
+        search_result = helper.holding_block_search(SolrDocument.new(document_with_find_it_link))
+        expect(search_result).to include "fa-map-marker"
+      end
+
+      # For certain locations we do not display the map icon since the location is not accessible by patrons
+      it 'does not include the find it icon' do
+        search_result = helper.holding_block_search(SolrDocument.new(document_without_find_it_link))
+        expect(search_result).not_to include "fa-map-marker"
+      end
+    end
+
     context '#holding_block_search with links only' do
       let(:document) do
         {

--- a/spec/helpers/holding_block_spec.rb
+++ b/spec/helpers/holding_block_spec.rb
@@ -275,7 +275,7 @@ RSpec.describe ApplicationHelper do
 
       before { stub_holding_locations }
 
-      # For mosst locations we display a map icon to help patrons if they want to fetch the item
+      # For most locations we display a map icon to help patrons if they want to fetch the item
       it 'includes the find it icon' do
         search_result = helper.holding_block_search(SolrDocument.new(document_with_find_it_link))
         expect(search_result).to include "fa-map-marker"


### PR DESCRIPTION
Removes the "where to find it" link and the pin icon from the search results and the show page for record that are in certain locations (e.g. Plasma library and Marquand) 

Fixes #2495 

Below are few screenshots showing how this look. Notice how the display the "pin" icon and the link for certain holdings but do not display it for holdings in the Plasma library. (Ignore the labels for the library names in the screenshots, the data is not accurate on my local instance.) 

Search Results
![search](https://user-images.githubusercontent.com/568286/133323203-c6291d20-3570-4602-af00-a29a562393a5.png)

Show Page
![show](https://user-images.githubusercontent.com/568286/133323417-76522f86-fce7-4d4a-ba34-45e4082c83e5.png)

