### PR TITLE
Remove unused sdoc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,8 +35,6 @@ gem 'high_voltage', '~> 3.0.0'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
-# bundle exec rake doc:rails generates the API under doc/api.
-gem 'sdoc', group: :doc
 
 # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
 gem 'spring', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,7 +393,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rdoc (6.3.0)
     regexp_parser (1.6.0)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -456,8 +455,6 @@ GEM
       sprockets-rails
       tilt
     scrub_rb (1.0.1)
-    sdoc (2.1.0)
-      rdoc (>= 5.0)
     selenium-webdriver (3.142.4)
       childprocess (>= 0.5, < 3.0)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -620,7 +617,6 @@ DEPENDENCIES
   rspec-rails (~> 3.4)
   rubyzip (>= 1.2.2)
   sass-rails (~> 5.0)
-  sdoc
   sitemap_generator (~> 6.0)
   sneakers
   solargraph


### PR DESCRIPTION
This sdoc task doesn't actually run and as far as I can tell we aren't
using it. It has a security issue, but rather than upgrade a thing we
aren't using let's just remove it.