### PR TITLE
Adjusted values to new values now that we have migrated to Alma

### DIFF
--- a/app/services/stackmap_service.rb
+++ b/app/services/stackmap_service.rb
@@ -74,20 +74,20 @@ class StackmapService
       end
 
       def stackmap_libs
-        %w[architecture eastasian engineering lewis mendel plasma stokes]
+        %w[arch eastasian engineer lewis mendel plasma stokes]
       end
 
       def missing_stackmap_reserves
         {
-          'ueso' => 'https://library.princeton.edu/architecture',
-          'piaprr' => 'https://library.princeton.edu/stokes',
-          'pplr' => 'https://library.princeton.edu/plasma-physics',
-          'scigr' => 'https://library.princeton.edu/lewis'
+          'arch$res3hr' => 'https://library.princeton.edu/architecture',
+          'stokes$respiapr' => 'https://library.princeton.edu/stokes',
+          'plasma$res' => 'https://library.princeton.edu/plasma-physics',
+          'lewis$gr' => 'https://library.princeton.edu/lewis'
         }
       end
 
       def by_title_locations
-        %w[sciss pplps sprps spiaps]
+        %w[lewis$serial plasma$ps stokes$sprps stokes$spiaps]
       end
 
       def holding_location

--- a/spec/controllers/orangelight/stackmap_spec.rb
+++ b/spec/controllers/orangelight/stackmap_spec.rb
@@ -6,13 +6,13 @@ RSpec.describe CatalogController do
   describe 'stackmap action' do
     before { stub_holding_locations }
     it 'assigns the expected instance variables with provided call number' do
-      get :stackmap, params: { id: 9_222_024, loc: 'f', cn: 'Call number' }
-      expect(assigns(:location_label)).to eq('Firestone Library')
+      get :stackmap, params: { id: 9_222_024, loc: 'firestone$stacks', cn: 'Call number' }
+      expect(assigns(:location_label)).to eq('Stacks')
       expect(assigns(:call_number)).to eq('Call number')
     end
 
     it 'assigns the first document call number when cn param not provided' do
-      get :stackmap, params: { id: 9_222_024, loc: 'f' }
+      get :stackmap, params: { id: 9_222_024, loc: 'firestone$stacks' }
       expect(assigns(:call_number)).to eq('PS3566.I428 A6 2015')
     end
   end

--- a/spec/fixtures/bibdata/holding_locations.json
+++ b/spec/fixtures/bibdata/holding_locations.json
@@ -1,6596 +1,9810 @@
 [
-    {
-      "label": "African American Studies Reading Room (AAS). B-7-B",
-      "code": "aas",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/aas.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "",
-      "code": "anxa",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/anxa.json",
-      "library": {
-        "label": "Forrestal Annex",
-        "code": "annexa",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Documents Off-Site Storage",
-      "code": "anxadoc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/anxadoc.json",
-      "library": {
-        "label": "Forrestal Annex",
-        "code": "annexa",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Temporary",
-      "code": "anxafst",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/anxafst.json",
-      "library": {
-        "label": "Forrestal Annex",
-        "code": "annexa",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "",
-      "code": "anxb",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/anxb.json",
-      "library": {
-        "label": "Fine Annex",
-        "code": "annexb",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Locked",
-      "code": "anxbl",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/anxbl.json",
-      "library": {
-        "label": "Fine Annex",
-        "code": "annexb",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Non Circulating",
-      "code": "anxbnc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/anxbnc.json",
-      "library": {
-        "label": "Fine Annex",
-        "code": "annexb",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "",
-      "code": "ast",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ast.json",
-      "library": {
-        "label": "Engineering Library",
-        "code": "engineering",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Engineering Library",
-        "code": "engineering"
-      }
-    },
-    {
-      "label": "Media Collection",
-      "code": "astrf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/astrf.json",
-      "library": {
-        "label": "Engineering Library",
-        "code": "engineering",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Engineering Library",
-        "code": "engineering"
-      }
-    },
-    {
-      "label": "Sylvia Beach Collection",
-      "code": "beac",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/beac.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "",
-      "code": "c",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/c.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Classics Collection (Clas)",
-      "code": "clas",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/clas.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Classics Collection (Clas): Non Circulating",
-      "code": "clasnc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/clasnc.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Eugene B. Cook Chess Collection",
-      "code": "cook",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/cook.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Rare Books",
-      "code": "crare",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/crare.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Reference",
-      "code": "cref",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/cref.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Cotsen Children's Library",
-      "code": "ctsn",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ctsn.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Cotsen Children's Library - Research Collection",
-        "code": "cotsenresearch"
-      }
-    },
-    {
-      "label": "Cotsen Children's Library: Reference",
-      "code": "ctsnrf",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ctsnrf.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Cotsen Children's Library - Research Collection",
-        "code": "cotsenresearch"
-      }
-    },
-    {
-      "label": "Cataloging and Metadata Services",
-      "code": "dc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/dc.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Dixon Books",
-      "code": "dixn",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/dixn.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Government Documents Collection (DOCS)",
-      "code": "docs",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/docs.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Government Documents Collection (DOCS): Microforms",
-      "code": "docsm",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/docsm.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Trustee Reading Room Reference (DR)",
-      "code": "dr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/dr.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Trustee Reading Room Reference (DR): Atlases",
-      "code": "dra",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/dra.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Trustee Reading Room Reference (DR): Ready Reference",
-      "code": "drrr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/drrr.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Data and Statistical Services (DSS)",
-      "code": "dss",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/dss.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Edwards Collection",
-      "code": "ed",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ed.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "English Graduate Study Room",
-      "code": "egsr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/egsr.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Online Resources",
-      "code": "elf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/elf.json",
-      "library": {
-        "label": "Online",
-        "code": "online",
-        "order": 4
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "*ONLINE*",
-      "code": "elf1",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/elf1.json",
-      "library": {
-        "label": "Online",
-        "code": "online",
-        "order": 4
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Accessible from Library Web Computers",
-      "code": "elf2",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/elf2.json",
-      "library": {
-        "label": "Online",
-        "code": "online",
-        "order": 4
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Online Resources",
-      "code": "elf3",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/elf3.json",
-      "library": {
-        "label": "Online",
-        "code": "online",
-        "order": 4
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Dixon eBooks",
-      "code": "elf4",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/elf4.json",
-      "library": {
-        "label": "Online",
-        "code": "online",
-        "order": 4
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Rare Books",
-      "code": "ex",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ex.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Reference Collection in Dulles Reading Room",
-      "code": "exb",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/exb.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "J. Harlin O'Connell Collection",
-      "code": "exc",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/exc.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Laurance Roberts Carton Hunting Collection",
-      "code": "exca",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/exca.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Kenneth McKenzie Fable Collection",
-      "code": "exf",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/exf.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Miriam Y. Holden Collection",
-      "code": "exho",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/exho.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Incunabula Collection",
-      "code": "exi",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/exi.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Kane Collection",
-      "code": "exka",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/exka.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Otto von Kienbusch Angling Collection",
-      "code": "exki",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/exki.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Charles Scribner Collection of Charles Lamb",
-      "code": "exl",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/exl.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Robert Metzdorf Collection",
-      "code": "exme",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/exme.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Oversize ",
-      "code": "exov",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/exov.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Morris L. Parrish Collection",
-      "code": "expa",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/expa.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Kenneth H. Rockey Angling Collection",
-      "code": "exrc",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/exrc.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Leonard Milberg Coll. of American Poetry",
-      "code": "exrl",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/exrl.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Rare Books",
-      "code": "extr",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/extr.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Technical Services Reference",
-      "code": "extsf",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/extsf.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Harry B. Vandeventer Poetry Collection",
-      "code": "exv",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/exv.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Orlando F. Weber Coll. of Economic History",
-      "code": "exw",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/exw.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "",
-      "code": "f",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/f.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "French & Italian Graduate Study Room (FIS)",
-      "code": "fis",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/fis.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Microforms Services (Film)",
-      "code": "flm",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/flm.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Microforms Service",
-        "code": "microforms"
-      }
-    },
-    {
-      "label": "Microforms Services (FilmB)",
-      "code": "flmb",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/flmb.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Microforms Service",
-        "code": "microforms"
-      }
-    },
-    {
-      "label": "Microforms Services (FilmM)",
-      "code": "flmm",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/flmm.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Microforms Service",
-        "code": "microforms"
-      }
-    },
-    {
-      "label": "Microforms Services (FilmP)",
-      "code": "flmp",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/flmp.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Microforms Service",
-        "code": "microforms"
-      }
-    },
-    {
-      "label": "Non Circulating",
-      "code": "fnc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/fnc.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Graphic Arts Collection",
-      "code": "ga",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ga.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Graphic Arts: Reference Collection",
-      "code": "garf",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/garf.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Graphic Arts Collection",
-      "code": "gax",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/gax.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Western",
-      "code": "gest",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/gest.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Microforms Services: East Asian",
-      "code": "gestf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/gestf.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Western Periodicals",
-      "code": "gestpe",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/gestpe.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Permanent Reserve",
-      "code": "gestpr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/gestpr.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Rare Books",
-      "code": "gestrare",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/gestrare.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Reference",
-      "code": "gestrf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/gestrf.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Reserve",
-      "code": "gstr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/gstr.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Reference",
-      "code": "gstrf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/gstrf.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Miriam Y. Holden Collection",
-      "code": "hldn",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hldn.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "South East (CTSN)",
-      "code": "hsvc",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hsvc.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "South East (East Asian)",
-      "code": "hsve",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hsve.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "South East (GA)",
-      "code": "hsvg",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hsvg.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "South East (MSS)",
-      "code": "hsvm",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hsvm.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "South East (Num)",
-      "code": "hsvn",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hsvn.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "South East (HM)",
-      "code": "hsvp",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hsvp.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "South East (RB)",
-      "code": "hsvr",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hsvr.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Rare Books: South East (Western Americana)",
-      "code": "hsvw",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hsvw.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Laurence Hutton Collection",
-      "code": "htn",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/htn.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "",
-      "code": "hyc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hyc.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Periodicals",
-      "code": "hycpe",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hycpe.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Rare Books",
-      "code": "hycrare",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hycrare.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Reference",
-      "code": "hycrf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hycrf.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "",
-      "code": "hyg",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hyg.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Microforms Services: East Asian",
-      "code": "hygf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hygf.json",
-      "library": {
-        "label": "Forrestal Annex",
-        "code": "annexa",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "",
-      "code": "hyj",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hyj.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "",
-      "code": "hyjpe",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hyjpe.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Rare Books",
-      "code": "hyjrare",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hyjrare.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Reference",
-      "code": "hyjrf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hyjrf.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "",
-      "code": "hyk",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hyk.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Rare Books",
-      "code": "hykrare",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hykrare.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Reference",
-      "code": "hykrf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/hykrf.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "",
-      "code": "j",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/j.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Rare Books",
-      "code": "jrare",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/jrare.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Reference",
-      "code": "jref",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/jref.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "",
-      "code": "k",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/k.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Rare Books",
-      "code": "krare",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/krare.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Reference",
-      "code": "kref",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/kref.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
-    },
-    {
-      "label": "Locked Books",
-      "code": "l",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/l.json",
-      "library": {
-        "label": "Forrestal Annex",
-        "code": "annexa",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Law Cases and Statutes",
-      "code": "law",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/law.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Circulation Desk",
-      "code": "lrc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/lrc.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Permanent Reserve",
-      "code": "lrcpt",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/lrcpt.json",
-      "library": {
-        "label": "Video Library",
-        "code": "hrc",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Reserve",
-      "code": "lrcr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/lrcr.json",
-      "library": {
-        "label": "Video Library",
-        "code": "hrc",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Computer Media",
-      "code": "ltop",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ltop.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Computer Media",
-      "code": "ltoppiapr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ltoppiapr.json",
-      "library": {
-        "label": "Stokes Library",
-        "code": "stokes",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Stokes Library",
-        "code": "stokes"
-      }
-    },
-    {
-      "label": "Computer Media",
-      "code": "ltopsa",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ltopsa.json",
-      "library": {
-        "label": "Marquand Library",
-        "code": "marquand",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Marquand Library of Art and Archaeology",
-        "code": "marquand"
-      }
-    },
-    {
-      "label": "Computer Media",
-      "code": "ltopsci",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ltopsci.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "Computer Media",
-      "code": "ltopst",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ltopst.json",
-      "library": {
-        "label": "Engineering Library",
-        "code": "engineering",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Engineering Library",
-        "code": "engineering"
-      }
-    },
-    {
-      "label": "Historic Maps Collection",
-      "code": "map",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/map.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Audio Visual (Circulation Desk)",
-      "code": "mlis",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/mlis.json",
-      "library": {
-        "label": "Mendel Music Library",
-        "code": "mendel",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Mendel Music Library",
-        "code": "music"
-      }
-    },
-    {
-      "label": "Manuscripts Collection",
-      "code": "mss",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/mss.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "",
+  {
+    "label": "Cataloging",
+    "code": "annex$cat",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/annex$cat.json",
+    "library": {
+      "label": "Forrestal Annex",
+      "code": "annex",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Circulation",
+    "code": "annex$circ",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/annex$circ.json",
+    "library": {
+      "label": "Forrestal Annex",
+      "code": "annex",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Documents Off-Site Storage; contact docstor@Princeton.edu",
+    "code": "annex$doc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/annex$doc.json",
+    "library": {
+      "label": "Forrestal Annex",
+      "code": "annex",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "A",
+    "code": "annex$fst",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/annex$fst.json",
+    "library": {
+      "label": "Forrestal Annex",
+      "code": "annex",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Locked",
+    "code": "annex$locked",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/annex$locked.json",
+    "library": {
+      "label": "Forrestal Annex",
+      "code": "annex",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Non-Circulating",
+    "code": "annex$noncirc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/annex$noncirc.json",
+    "library": {
+      "label": "Forrestal Annex",
+      "code": "annex",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Princeton Collection",
+    "code": "annex$princeton",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/annex$princeton.json",
+    "library": {
+      "label": "Forrestal Annex",
+      "code": "annex",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Reserve",
+    "code": "annex$reserve",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/annex$reserve.json",
+    "library": {
+      "label": "Forrestal Annex",
+      "code": "annex",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Classics Theses",
+    "code": "annex$sct",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/annex$sct.json",
+    "library": {
+      "label": "Forrestal Annex",
+      "code": "annex",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "German Theses",
+    "code": "annex$sdt",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/annex$sdt.json",
+    "library": {
+      "label": "Forrestal Annex",
+      "code": "annex",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "English Theses",
+    "code": "annex$set",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/annex$set.json",
+    "library": {
+      "label": "Forrestal Annex",
+      "code": "annex",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "History Theses",
+    "code": "annex$sht",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/annex$sht.json",
+    "library": {
+      "label": "Forrestal Annex",
+      "code": "annex",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Philosophy Theses",
+    "code": "annex$spt",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/annex$spt.json",
+    "library": {
+      "label": "Forrestal Annex",
+      "code": "annex",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "A: Romance Language Theses",
+    "code": "annex$srt",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/annex$srt.json",
+    "library": {
+      "label": "Forrestal Annex",
+      "code": "annex",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Stacks",
+    "code": "annex$stacks",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/annex$stacks.json",
+    "library": {
+      "label": "Forrestal Annex",
+      "code": "annex",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "A: Theses Collection",
+    "code": "annex$t",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/annex$t.json",
+    "library": {
+      "label": "Forrestal Annex",
+      "code": "annex",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "annex$UNASSIGNED",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/annex$UNASSIGNED.json",
+    "library": {
+      "label": "Forrestal Annex",
+      "code": "annex",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Circulation",
+    "code": "arch$circ",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/arch$circ.json",
+    "library": {
+      "label": "Architecture Library",
+      "code": "arch",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Librarian's Office",
+    "code": "arch$la",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/arch$la.json",
+    "library": {
+      "label": "Architecture Library",
+      "code": "arch",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "New Book Shelf",
+    "code": "arch$newbook",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/arch$newbook.json",
+    "library": {
+      "label": "Architecture Library",
+      "code": "arch",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Architecture Library Use Only",
+    "code": "arch$pw",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": true,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/arch$pw.json",
+    "library": {
+      "label": "Architecture Library",
+      "code": "arch",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Architecture Library",
+      "code": "arch",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Reference",
+    "code": "arch$ref",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/arch$ref.json",
+    "library": {
+      "label": "Architecture Library",
+      "code": "arch",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Reserve 3-Hour",
+    "code": "arch$res3hr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/arch$res3hr.json",
+    "library": {
+      "label": "Architecture Library",
+      "code": "arch",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Reserve Closed",
+    "code": "arch$resclosed",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/arch$resclosed.json",
+    "library": {
+      "label": "Architecture Library",
+      "code": "arch",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Stacks",
+    "code": "arch$stacks",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/arch$stacks.json",
+    "library": {
+      "label": "Architecture Library",
+      "code": "arch",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "arch$UNASSIGNED",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/arch$UNASSIGNED.json",
+    "library": {
+      "label": "Architecture Library",
+      "code": "arch",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Acquisitions",
+    "code": "eastasian$acq",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$acq.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Cataloging",
+    "code": "eastasian$cat",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$cat.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Circulation",
+    "code": "eastasian$circ",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$circ.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "eastasian$cjk",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$cjk.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Reference",
+    "code": "eastasian$cjkref",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$cjkref.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Western Languages",
+    "code": "eastasian$gest",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$gest.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Western Periodicals",
+    "code": "eastasian$gestpe",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$gestpe.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Permanent Reserve",
+    "code": "eastasian$gestpr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$gestpr.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "eastasian$hy",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$hy.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Microfilms: Forrestal Annex",
+    "code": "eastasian$hygf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$hygf.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Periodicals",
+    "code": "eastasian$hype",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$hype.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Reference ",
+    "code": "eastasian$hyref",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$hyref.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): East Asian Library Use Only",
+    "code": "eastasian$pl",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$pl.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): East Asian Microforms",
+    "code": "eastasian$ql",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$ql.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Reference",
+    "code": "eastasian$ref",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$ref.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Reserve",
+    "code": "eastasian$reserve",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$reserve.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "eastasian$UNASSIGNED",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$UNASSIGNED.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Wilhelm Collection",
+    "code": "eastasian$wilhelm",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/eastasian$wilhelm.json",
+    "library": {
+      "label": "East Asian Library",
+      "code": "eastasian",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "A",
+    "code": "engineer$ast",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$ast.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Cataloging",
+    "code": "engineer$cat",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$cat.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Circulation",
+    "code": "engineer$circ",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$circ.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Indexes and Abstracts",
+    "code": "engineer$index",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$index.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Laptops",
+    "code": "engineer$ltop",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Media",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$ltop.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Media Collection",
+    "code": "engineer$media",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Media",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$media.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Microforms",
+    "code": "engineer$mic",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$mic.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "New Book Shelf",
+    "code": "engineer$nb",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$nb.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Engineering Library Use Only",
+    "code": "engineer$pt",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": true,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$pt.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Reference",
+    "code": "engineer$ref",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$ref.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Reserve",
+    "code": "engineer$res",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$res.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Term Loan Reserve",
+    "code": "engineer$resterm",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$resterm.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Friend Center Archive",
+    "code": "engineer$scc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$scc.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Serials",
+    "code": "engineer$serial",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$serial.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Stacks",
+    "code": "engineer$stacks",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$stacks.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "S",
+    "code": "engineer$str",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$str.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Theses",
+    "code": "engineer$theses",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$theses.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "engineer$UNASSIGNED",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/engineer$UNASSIGNED.json",
+    "library": {
+      "label": "Engineering Library",
+      "code": "engineer",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "African American Studies Reading Room",
+    "code": "firestone$aas",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$aas.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Cataloging",
+    "code": "firestone$cat",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$cat.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Circulation",
+    "code": "firestone$circ",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$circ.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Classics Collection",
+    "code": "firestone$clas",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$clas.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Classics Collection Non-Circulating",
+    "code": "firestone$clasnc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$clasnc.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Dixon Books",
+    "code": "firestone$dixn",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$dixn.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Government Documents Collection",
+    "code": "firestone$docs",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$docs.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Government Documents Collection Microforms",
+    "code": "firestone$docsm",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$docsm.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Trustee Reading Room Reference",
+    "code": "firestone$dr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$dr.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Trustee Reading Room Reference: Atlases",
+    "code": "firestone$dra",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$dra.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Trustee Reading Room Reference: Ready Reference",
+    "code": "firestone$drrr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$drrr.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Data and Statistical Services",
+    "code": "firestone$dss",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$dss.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "English Graduate Study Room",
+    "code": "firestone$egsr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$egsr.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Faculty Publications",
+    "code": "firestone$fac",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$fac.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "French & Italian Graduate Study Room",
+    "code": "firestone$fis",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$fis.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Microforms Services (Film)",
+    "code": "firestone$flm",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$flm.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Microforms Services (Film B)",
+    "code": "firestone$flmb",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$flmb.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Microforms Services (Film M)",
+    "code": "firestone$flmm",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$flmm.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Microforms Services (Film P)",
+    "code": "firestone$flmp",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$flmp.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Microforms Services: East Asian",
+    "code": "firestone$gestf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$gestf.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Gender & Sexuality Studies Research Collection",
+    "code": "firestone$gss",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$gss.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Miriam Y. Holden Collection",
+    "code": "firestone$hldn",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$hldn.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Law Cases and Statutes",
+    "code": "firestone$law",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$law.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Video Collection: Firestone Circulation Desk",
+    "code": "firestone$lrc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$lrc.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Video Library Reserve",
+    "code": "firestone$lrcpt",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$lrcpt.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Video Library Reserve",
+    "code": "firestone$lrcr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$lrcr.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Computer Media",
+    "code": "firestone$ltop",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Media",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$ltop.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Near East Collections",
+    "code": "firestone$nec",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$nec.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Near East Collections: Non-Circulating",
+    "code": "firestone$necnc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$necnc.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Non-Circulating",
+    "code": "firestone$noncirc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$noncirc.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Newspaper Collection: Recent Issues",
+    "code": "firestone$nr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$nr.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Supervised use in Firestone A-16-H-3",
+    "code": "firestone$pb",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": true,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$pb.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Firestone Library Use Only",
+    "code": "firestone$pf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$pf.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Periodicals Collection",
+    "code": "firestone$pr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$pr.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Preservation Office: Contact fstcirc@princeton.edu",
+    "code": "firestone$pres",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$pres.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Near East Periodicals Collection",
+    "code": "firestone$prne",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$prne.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "African American Studies Reading Room: Reserve",
+    "code": "firestone$raas",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$raas.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Circulation Desk (24 Hour Reserve)",
+    "code": "firestone$res24hr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$res24hr.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Circulation Desk (3 Hour Reserve)",
+    "code": "firestone$res3hr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$res3hr.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Religion Graduate Study: Reserve",
+    "code": "firestone$rrel",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$rrel.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Classics Graduate Study: Reserve",
+    "code": "firestone$rsc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$rsc.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Germanic Languages Graduate Study Room: Reserve",
+    "code": "firestone$rsd",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$rsd.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "English Graduate Study Room: Reserve",
+    "code": "firestone$rse",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$rse.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "History Reference: Reserve",
+    "code": "firestone$rsh",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$rsh.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Russian Study Room: Reserve",
+    "code": "firestone$rslv",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$rslv.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Near East Graduate Study Room: Reserve",
+    "code": "firestone$rsne",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$rsne.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Comparative Literature Graduate Study Room: Reserve",
+    "code": "firestone$rspc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$rspc.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Sociology Graduate Study Room: Reserve",
+    "code": "firestone$rssa",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$rssa.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Classics Graduate Study Room",
+    "code": "firestone$sc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$sc.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Germanic Languages Graduate Study Room",
+    "code": "firestone$sd",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$sd.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Scribner Room",
+    "code": "firestone$se",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$se.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Scribner Library: Common Works Collection",
+    "code": "firestone$secw",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$secw.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Scribner Room: Reference",
+    "code": "firestone$seref",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$seref.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "History Reference",
+    "code": "firestone$sh",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$sh.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Hellenic Studies Reading Room",
+    "code": "firestone$shs",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$shs.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Slavic Graduate Study Room",
+    "code": "firestone$slav",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$slav.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Near East Graduate Study Room",
+    "code": "firestone$sne",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$sne.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Comparative Literature Graduate Study Room",
+    "code": "firestone$spc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$spc.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Spanish & Portuguese Graduate Study Room",
+    "code": "firestone$sps",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$sps.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Religion Graduate Study Room",
+    "code": "firestone$srel",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$srel.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Sociology Graduate Study Room",
+    "code": "firestone$ssa",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$ssa.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "History Graduate Study Room",
+    "code": "firestone$sss",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$sss.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Stacks",
+    "code": "firestone$stacks",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$stacks.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Travel Guides",
+    "code": "firestone$trv",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$trv.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "United Nations Collection",
+    "code": "firestone$un",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$un.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "firestone$UNASSIGNED",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$UNASSIGNED.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Video Collection: Circulation Desk",
+    "code": "firestone$vidl",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$vidl.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Video Library Reserve",
+    "code": "firestone$vidlr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$vidlr.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Very large books",
+    "code": "firestone$xl",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$xl.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Very large books: Non-Circulating",
+    "code": "firestone$xlnc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$xlnc.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Zeiss Wildlife Collection",
+    "code": "firestone$zeiss",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/firestone$zeiss.json",
+    "library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Cataloging",
+    "code": "lewis$cat",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$cat.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Circ",
+    "code": "lewis$circ",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$circ.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Documents",
+    "code": "lewis$doc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$doc.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "E/F Oversize and Atlases",
+    "code": "lewis$efa",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$efa.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "GIS and Digital Map Center",
+    "code": "lewis$gis",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$gis.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Graduate Reading",
+    "code": "lewis$gr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$gr.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Limited Access",
+    "code": "lewis$laf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$laf.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Limited Access",
+    "code": "lewis$lal",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$lal.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Computer Media",
+    "code": "lewis$ltop",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Media",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$ltop.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Map Collection",
+    "code": "lewis$map",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$map.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Map Collection. Lateral File",
+    "code": "lewis$maplf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$maplf.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Map Collection. Reference Maps",
+    "code": "lewis$maplref",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$maplref.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Map Collection. Map Case",
+    "code": "lewis$mapmc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$mapmc.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Map Collection. Map Case Max",
+    "code": "lewis$mapmcm",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$mapmcm.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Multimedia",
+    "code": "lewis$media",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Media",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$media.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Microforms",
+    "code": "lewis$mic",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$mic.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "New Book Shelf",
+    "code": "lewis$nb",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$nb.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Pamphlet",
+    "code": "lewis$pam",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$pam.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Peyton Hall Observing Room",
+    "code": "lewis$ph",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$ph.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Lewis Library Use Only",
+    "code": "lewis$pn",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": true,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$pn.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Lewis Library Use Only",
+    "code": "lewis$ps",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$ps.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Reference (Fine Hall Wing)",
+    "code": "lewis$ref",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$ref.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Reference (Information Desk)",
+    "code": "lewis$refid",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$refid.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Course Reserve",
+    "code": "lewis$res",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$res.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Term Loan Reserves",
+    "code": "lewis$resterm",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$resterm.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Serials (shelved by serial title)",
+    "code": "lewis$serial",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$serial.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Stacks",
+    "code": "lewis$stacks",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$stacks.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "SuDoc Collection",
+    "code": "lewis$sudoc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$sudoc.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Theses",
+    "code": "lewis$theses",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$theses.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "lewis$UNASSIGNED",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/lewis$UNASSIGNED.json",
+    "library": {
+      "label": "Lewis Library",
+      "code": "lewis",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Cataloging",
+    "code": "marquand$cat",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$cat.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Circulation",
+    "code": "marquand$circ",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$circ.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Tang Reading Room Remote Storage: Marquand Use Only",
+    "code": "marquand$fesrf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$fesrf.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Computer Media",
+    "code": "marquand$ltop",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Media",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$ltop.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Microforms Remote Storage: Marquand Use Only",
+    "code": "marquand$mic",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$mic.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Manuscripts",
+    "code": "marquand$ms",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$ms.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Manuscripts: Reference",
+    "code": "marquand$msref",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$msref.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Photography",
+    "code": "marquand$ph",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$ph.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Photography Reference",
+    "code": "marquand$phref",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$phref.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Marquand Library Use Only",
+    "code": "marquand$pj",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": true,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$pj.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Marquand Library Use Only Rare Books",
+    "code": "marquand$pz",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$pz.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Reference Remote Storage: Marquand Use Only",
+    "code": "marquand$ref",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$ref.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Reserve",
+    "code": "marquand$res",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$res.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Storage",
+    "code": "marquand$rp",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$rp.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Barr Ferree Collection",
+    "code": "marquand$saf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$saf.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage: Marquand Use Only",
+    "code": "marquand$stacks",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$stacks.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Rare Books: Miscellanea",
+    "code": "marquand$t",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$t.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "marquand$UNASSIGNED",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$UNASSIGNED.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Workroom",
+    "code": "marquand$wr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$wr.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Rare Books",
+    "code": "marquand$x",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/marquand$x.json",
+    "library": {
+      "label": "Marquand Library",
+      "code": "marquand",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Audio Visual (Circulation Desk)",
+    "code": "mendel$av",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mendel$av.json",
+    "library": {
+      "label": "Mendel Music Library",
+      "code": "mendel",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Cataloging",
+    "code": "mendel$cat",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mendel$cat.json",
+    "library": {
+      "label": "Mendel Music Library",
+      "code": "mendel",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Circulation",
+    "code": "mendel$circ",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mendel$circ.json",
+    "library": {
+      "label": "Mendel Music Library",
+      "code": "mendel",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Facsimiles",
+    "code": "mendel$facs",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mendel$facs.json",
+    "library": {
+      "label": "Mendel Music Library",
+      "code": "mendel",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Graduate Reserve",
+    "code": "mendel$g",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mendel$g.json",
+    "library": {
+      "label": "Mendel Music Library",
+      "code": "mendel",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Locked",
+    "code": "mendel$locked",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mendel$locked.json",
+    "library": {
+      "label": "Mendel Music Library",
+      "code": "mendel",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "New Book Shelf",
+    "code": "mendel$nb",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mendel$nb.json",
+    "library": {
+      "label": "Mendel Music Library",
+      "code": "mendel",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Bound Periodicals",
+    "code": "mendel$pe",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mendel$pe.json",
+    "library": {
+      "label": "Mendel Music Library",
+      "code": "mendel",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP)",
+    "code": "mendel$pk",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": true,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mendel$pk.json",
+    "library": {
+      "label": "Mendel Music Library",
+      "code": "mendel",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Mendel Music Library",
+      "code": "mendel",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Mendel Music Library Use Only",
+    "code": "mendel$qk",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mendel$qk.json",
+    "library": {
+      "label": "Mendel Music Library",
+      "code": "mendel",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Mendel Music Library",
+      "code": "mendel",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Reference",
+    "code": "mendel$ref",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mendel$ref.json",
+    "library": {
+      "label": "Mendel Music Library",
+      "code": "mendel",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Reserve",
+    "code": "mendel$res",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mendel$res.json",
+    "library": {
+      "label": "Mendel Music Library",
+      "code": "mendel",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Reading Room",
+    "code": "mendel$rg",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mendel$rg.json",
+    "library": {
+      "label": "Mendel Music Library",
+      "code": "mendel",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Stacks",
+    "code": "mendel$stacks",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mendel$stacks.json",
+    "library": {
+      "label": "Mendel Music Library",
+      "code": "mendel",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "mendel$UNASSIGNED",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mendel$UNASSIGNED.json",
+    "library": {
+      "label": "Mendel Music Library",
+      "code": "mendel",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Cataloging",
+    "code": "mudd$cat",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mudd$cat.json",
+    "library": {
+      "label": "Mudd Manuscript Library",
       "code": "mudd",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/mudd.json",
-      "library": {
-        "label": "Mudd Manuscript Library",
-        "code": "mudd",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Mudd Manuscript Library and University Archives",
-        "code": "mudd"
-      }
+      "order": 0
     },
-    {
-      "label": "Microforms",
-      "code": "mudf",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/mudf.json",
-      "library": {
-        "label": "Mudd Manuscript Library",
-        "code": "mudd",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Mudd Manuscript Library and University Archives",
-        "code": "mudd"
-      }
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Circulation",
+    "code": "mudd$circ",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mudd$circ.json",
+    "library": {
+      "label": "Mudd Manuscript Library",
+      "code": "mudd",
+      "order": 0
     },
-    {
-      "label": "",
-      "code": "mus",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/mus.json",
-      "library": {
-        "label": "Mendel Music Library",
-        "code": "mendel",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Mendel Music Library",
-        "code": "music"
-      }
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Microforms",
+    "code": "mudd$mic",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mudd$mic.json",
+    "library": {
+      "label": "Mudd Manuscript Library",
+      "code": "mudd",
+      "order": 0
     },
-    {
-      "label": "Graduate Reserve",
-      "code": "musg",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/musg.json",
-      "library": {
-        "label": "Mendel Music Library",
-        "code": "mendel",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Mendel Music Library",
-        "code": "music"
-      }
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Mudd Library Use Only",
+    "code": "mudd$ph",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mudd$ph.json",
+    "library": {
+      "label": "Mudd Manuscript Library",
+      "code": "mudd",
+      "order": 0
     },
-    {
-      "label": "New Book Shelf",
-      "code": "musnb",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/musnb.json",
-      "library": {
-        "label": "Mendel Music Library",
-        "code": "mendel",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Mendel Music Library",
-        "code": "music"
-      }
+    "holding_library": {
+      "label": "Mudd Manuscript Library",
+      "code": "mudd",
+      "order": 0
     },
-    {
-      "label": "Bound Periodicals",
-      "code": "muspe",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/muspe.json",
-      "library": {
-        "label": "Mendel Music Library",
-        "code": "mendel",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Mendel Music Library",
-        "code": "music"
-      }
+    "hours_location": null
+  },
+  {
+    "label": "Princetoniana Collection",
+    "code": "mudd$prnc",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mudd$prnc.json",
+    "library": {
+      "label": "Mudd Manuscript Library",
+      "code": "mudd",
+      "order": 0
     },
-    {
-      "label": "Reserve",
-      "code": "musr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/musr.json",
-      "library": {
-        "label": "Mendel Music Library",
-        "code": "mendel",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Mendel Music Library",
-        "code": "music"
-      }
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Stacks",
+    "code": "mudd$stacks",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mudd$stacks.json",
+    "library": {
+      "label": "Mudd Manuscript Library",
+      "code": "mudd",
+      "order": 0
     },
-    {
-      "label": "Reading Room (2nd Floor)",
-      "code": "musrg",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/musrg.json",
-      "library": {
-        "label": "Mendel Music Library",
-        "code": "mendel",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Mendel Music Library",
-        "code": "music"
-      }
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "mudd$UNASSIGNED",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/mudd$UNASSIGNED.json",
+    "library": {
+      "label": "Mudd Manuscript Library",
+      "code": "mudd",
+      "order": 0
     },
-    {
-      "label": "Near East Collections (NEC)",
-      "code": "nec",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/nec.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "ETAS",
+    "code": "online$etas",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/online$etas.json",
+    "library": {
+      "label": "Electronic Access",
+      "code": "online",
+      "order": 0
     },
-    {
-      "label": "Near East Collections (NECnc): Non-Circulating",
-      "code": "necnc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/necnc.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
+    "holding_library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
     },
-    {
-      "label": "Near East Department Collection (NED). Jones Hall",
-      "code": "ned",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ned.json",
-      "library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "East Asian Library",
-        "code": "eastasian"
-      }
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "online$etasrcp",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": true,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/online$etasrcp.json",
+    "library": {
+      "label": "Electronic Access",
+      "code": "online",
+      "order": 0
     },
-    {
-      "label": "New Order Request",
-      "code": "new",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/new.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
+    "holding_library": {
+      "label": "ReCAP",
+      "code": "recap",
+      "order": 0
     },
-    {
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "online$UNASSIGNED",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/online$UNASSIGNED.json",
+    "library": {
+      "label": "Electronic Access",
+      "code": "online",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Cataloging",
+    "code": "plasma$cat",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/plasma$cat.json",
+    "library": {
+      "label": "Harold P. Furth Plasma Physics Library",
+      "code": "plasma",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Circulation",
+    "code": "plasma$circ",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/plasma$circ.json",
+    "library": {
+      "label": "Harold P. Furth Plasma Physics Library",
+      "code": "plasma",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Indexes & Abstracts",
+    "code": "plasma$index",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/plasma$index.json",
+    "library": {
+      "label": "Harold P. Furth Plasma Physics Library",
+      "code": "plasma",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Seminar Room",
+    "code": "plasma$la",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/plasma$la.json",
+    "library": {
+      "label": "Harold P. Furth Plasma Physics Library",
+      "code": "plasma",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Office",
+    "code": "plasma$li",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/plasma$li.json",
+    "library": {
+      "label": "Harold P. Furth Plasma Physics Library",
+      "code": "plasma",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "New Book Shelf",
+    "code": "plasma$nb",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/plasma$nb.json",
+    "library": {
+      "label": "Harold P. Furth Plasma Physics Library",
+      "code": "plasma",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Periodicals",
+    "code": "plasma$ps",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/plasma$ps.json",
+    "library": {
+      "label": "Harold P. Furth Plasma Physics Library",
+      "code": "plasma",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Tech. Reports",
+    "code": "plasma$rdr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/plasma$rdr.json",
+    "library": {
+      "label": "Harold P. Furth Plasma Physics Library",
+      "code": "plasma",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Reference",
+    "code": "plasma$ref",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/plasma$ref.json",
+    "library": {
+      "label": "Harold P. Furth Plasma Physics Library",
+      "code": "plasma",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Reserve",
+    "code": "plasma$res",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/plasma$res.json",
+    "library": {
+      "label": "Harold P. Furth Plasma Physics Library",
+      "code": "plasma",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Ready Reference",
+    "code": "plasma$rr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/plasma$rr.json",
+    "library": {
+      "label": "Harold P. Furth Plasma Physics Library",
+      "code": "plasma",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Serials",
+    "code": "plasma$serial",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/plasma$serial.json",
+    "library": {
+      "label": "Harold P. Furth Plasma Physics Library",
+      "code": "plasma",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Stacks",
+    "code": "plasma$stacks",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/plasma$stacks.json",
+    "library": {
+      "label": "Harold P. Furth Plasma Physics Library",
+      "code": "plasma",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Theses",
+    "code": "plasma$theses",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/plasma$theses.json",
+    "library": {
+      "label": "Harold P. Furth Plasma Physics Library",
+      "code": "plasma",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "plasma$UNASSIGNED",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/plasma$UNASSIGNED.json",
+    "library": {
+      "label": "Harold P. Furth Plasma Physics Library",
+      "code": "plasma",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Sylvia Beach Collection (Beach)",
+    "code": "rare$beac",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$beac.json",
+    "library": {
       "label": "Special Collections",
-      "code": "njpg",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/njpg.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Newspaper Collection (NR): Recent Issues",
-      "code": "nr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/nr.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Numismatics Collection",
-      "code": "num",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/num.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Numismatics Collection: Reference",
-      "code": "numrf",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/numrf.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "",
-      "code": "other",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/other.json",
-      "library": {
-        "label": "Other Location",
-        "code": "other",
-        "order": 4
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Princeton Collection",
-      "code": "p",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/p.json",
-      "library": {
-        "label": "Forrestal Annex",
-        "code": "annexa",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Princeton Borough Collection",
-      "code": "pb",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/pb.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "",
-      "code": "piapr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/piapr.json",
-      "library": {
-        "label": "Stokes Library",
-        "code": "stokes",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Stokes Library",
-        "code": "stokes"
-      }
-    },
-    {
-      "label": "Reserve",
-      "code": "piaprr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/piaprr.json",
-      "library": {
-        "label": "Stokes Library",
-        "code": "stokes",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Stokes Library",
-        "code": "stokes"
-      }
-    },
-    {
-      "label": "",
-      "code": "ppl",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ppl.json",
-      "library": {
-        "label": "Harold P. Furth Plasma Physics Library",
-        "code": "plasma",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Plasma Physics Library",
-        "code": "plasma"
-      }
-    },
-    {
-      "label": "Indexes",
-      "code": "pplia",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplia.json",
-      "library": {
-        "label": "Harold P. Furth Plasma Physics Library",
-        "code": "plasma",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Plasma Physics Library",
-        "code": "plasma"
-      }
-    },
-    {
-      "label": "Seminar Room",
-      "code": "pplla",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplla.json",
-      "library": {
-        "label": "Harold P. Furth Plasma Physics Library",
-        "code": "plasma",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Plasma Physics Library",
-        "code": "plasma"
-      }
-    },
-    {
-      "label": "Office",
-      "code": "pplli",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplli.json",
-      "library": {
-        "label": "Harold P. Furth Plasma Physics Library",
-        "code": "plasma",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Plasma Physics Library",
-        "code": "plasma"
-      }
-    },
-    {
-      "label": "New Book Shelf",
-      "code": "pplnb",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplnb.json",
-      "library": {
-        "label": "Harold P. Furth Plasma Physics Library",
-        "code": "plasma",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Plasma Physics Library",
-        "code": "plasma"
-      }
-    },
-    {
-      "label": "Periodicals",
-      "code": "pplps",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplps.json",
-      "library": {
-        "label": "Harold P. Furth Plasma Physics Library",
-        "code": "plasma",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Plasma Physics Library",
-        "code": "plasma"
-      }
-    },
-    {
-      "label": "Reserve",
-      "code": "pplr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplr.json",
-      "library": {
-        "label": "Harold P. Furth Plasma Physics Library",
-        "code": "plasma",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Plasma Physics Library",
-        "code": "plasma"
-      }
-    },
-    {
-      "label": "Technical Reports",
-      "code": "pplrdr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplrdr.json",
-      "library": {
-        "label": "Harold P. Furth Plasma Physics Library",
-        "code": "plasma",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Plasma Physics Library",
-        "code": "plasma"
-      }
-    },
-    {
-      "label": "Reference",
-      "code": "pplrf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplrf.json",
-      "library": {
-        "label": "Harold P. Furth Plasma Physics Library",
-        "code": "plasma",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Plasma Physics Library",
-        "code": "plasma"
-      }
-    },
-    {
-      "label": "Ready Reference",
-      "code": "pplrr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplrr.json",
-      "library": {
-        "label": "Harold P. Furth Plasma Physics Library",
-        "code": "plasma",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Plasma Physics Library",
-        "code": "plasma"
-      }
-    },
-    {
-      "label": "Theses",
-      "code": "pplt",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/pplt.json",
-      "library": {
-        "label": "Harold P. Furth Plasma Physics Library",
-        "code": "plasma",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Plasma Physics Library",
-        "code": "plasma"
-      }
-    },
-    {
-      "label": "Periodicals Collection (PR)",
-      "code": "pr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/pr.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Preservation Office",
-      "code": "pres",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/pres.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Princetoniana Collection",
-      "code": "prnc",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/prnc.json",
-      "library": {
-        "label": "Mudd Manuscript Library",
-        "code": "mudd",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Mudd Manuscript Library and University Archives",
-        "code": "mudd"
-      }
-    },
-    {
-      "label": "Near East Periodicals Collection",
-      "code": "prne",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/prne.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Robert Patterson Collection",
-      "code": "ptt",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ptt.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "African American Studies Reading Room (AAS): Reserve. B-7-B",
-      "code": "raas",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/raas.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Gov Docs",
-      "code": "rcpgp",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": true,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpgp.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "hours_location": null
-    },
-    {
-      "label": "JSTOR Restricted",
-      "code": "rcpjq",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": true,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpjq.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "",
-      "code": "rcppa",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": true,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppa.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Supervised use in Firestone ",
-      "code": "rcppb",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": true,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppb.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Restricted Backup Copies",
-      "code": "rcppe",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppe.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Use in Firestone Microforms only",
-      "code": "rcppf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppf.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "hours_location": null
-    },
-    {
-      "label": "RBSC Off-Site Storage",
-      "code": "rcppg",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppg.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Mudd Off-Site Storage",
-      "code": "rcpph",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpph.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Mudd Manuscript Library",
-        "code": "mudd",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Marquand Library use only",
-      "code": "rcppj",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": true,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppj.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Marquand Library",
-        "code": "marquand",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Mendel Music Library use only",
-      "code": "rcppk",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": true,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppk.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Mendel Music Library",
-        "code": "mendel",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "East Asian Library use only",
-      "code": "rcppl",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppl.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Donald E. Stokes Library use only",
-      "code": "rcppm",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppm.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Stokes Library",
-        "code": "stokes",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Lewis Library use only",
-      "code": "rcppn",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": true,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppn.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Plasma Physics use only",
-      "code": "rcppq",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": true,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppq.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Harold P. Furth Plasma Physics Library",
-        "code": "plasma",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Lewis Library (Rare) use only",
-      "code": "rcpps",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpps.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Technical Reports Offsite. Contact techrpts@princeton.edu",
-      "code": "rcppt",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": true,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppt.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Engineering Library",
-        "code": "engineering",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Architecture Library use only",
-      "code": "rcppw",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": true,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppw.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Architecture Library",
-        "code": "architecture",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Marquand Library (Rare) use only",
-      "code": "rcppz",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcppz.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Marquand Library",
-        "code": "marquand",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Reading Room use only",
-      "code": "rcpqb",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpqb.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Mendel Music Library use only",
-      "code": "rcpqk",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpqk.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Mendel Music Library",
-        "code": "mendel",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Firestone Microforms or East Asian Library use only",
-      "code": "rcpql",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpql.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "East Asian Library",
-        "code": "eastasian",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Video Collection",
-      "code": "rcpqv",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpqv.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Broadcast Center use only",
-      "code": "rcpqx",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpqx.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Cotsen Library Off-Site Storage",
-      "code": "rcpxc",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpxc.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Graphic Arts Off-Site Storage",
-      "code": "rcpxg",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpxg.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Manuscripts Off-Site Storage",
-      "code": "rcpxm",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpxm.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Numismatics Off-Site Storage",
-      "code": "rcpxn",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpxn.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Historic Maps Off-Site Storage",
-      "code": "rcpxp",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpxp.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Rare Books Off-Site Storage",
-      "code": "rcpxr",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpxr.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Western Amercian Off-Site Storage",
-      "code": "rcpxw",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": true,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpxw.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Special Items Off-Site Storage",
-      "code": "rcpxx",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rcpxx.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "hours_location": null
-    },
-    {
-      "label": "Reserve",
-      "code": "res",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/res.json",
-      "library": {
-        "label": "Forrestal Annex",
-        "code": "annexa",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Circulation Desk (3 Hour Reserve)",
-      "code": "resc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/resc.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Circulation Desk (24 Hour Reserve)",
-      "code": "reso",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/reso.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Robert H. Taylor Collection",
-      "code": "rht",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rht.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Religion Graduate Study Room (SREL): Reserve",
-      "code": "rrel",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rrel.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Classics Graduate Study (SC): Reserve",
-      "code": "rsc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rsc.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Germanic Languages Graduate Study Room (SD): Reserve",
-      "code": "rsd",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rsd.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "English Graduate Study Room (EGSR): Reserve",
-      "code": "rse",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rse.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "History Reference (SH): Reserve",
-      "code": "rsh",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rsh.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Politics Graduate Study Room: Reserve",
-      "code": "rshp",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rshp.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Russian Studies Reading Room (SLV): Reserve",
-      "code": "rslv",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rslv.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Near East Graduate Study Room (SNE): Reserve",
-      "code": "rsne",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rsne.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Anthropology Graduate Study Room: Reserve",
-      "code": "rsnst",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rsnst.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Philosophy Graduate Study Room: Reserve",
-      "code": "rsp",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rsp.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Comparative Literature Graduate Study Room (SPC): Reserve",
-      "code": "rspc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rspc.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Sociology Graduate Study Room (SSA): Reserve",
-      "code": "rssa",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rssa.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Economics Graduate Study Room: Reserve",
-      "code": "rsx",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/rsx.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "",
-      "code": "sa",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sa.json",
-      "library": {
-        "label": "Marquand Library",
-        "code": "marquand",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Marquand Library of Art and Archaeology",
-        "code": "marquand"
-      }
-    },
-    {
-      "label": "Barr Ferree Collection",
-      "code": "saf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/saf.json",
-      "library": {
-        "label": "Marquand Library",
-        "code": "marquand",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Marquand Library of Art and Archaeology",
-        "code": "marquand"
-      }
-    },
-    {
-      "label": "Tang Reading Room",
-      "code": "safesrf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/safesrf.json",
-      "library": {
-        "label": "Marquand Library",
-        "code": "marquand",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Marquand Library of Art and Archaeology",
-        "code": "marquand"
-      }
-    },
-    {
-      "label": "Microforms",
-      "code": "safi",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/safi.json",
-      "library": {
-        "label": "Marquand Library",
-        "code": "marquand",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Marquand Library of Art and Archaeology",
-        "code": "marquand"
-      }
-    },
-    {
-      "label": "Manuscripts",
-      "code": "sams",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sams.json",
-      "library": {
-        "label": "Marquand Library",
-        "code": "marquand",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Marquand Library of Art and Archaeology",
-        "code": "marquand"
-      }
-    },
-    {
-      "label": "Manuscripts: Reference",
-      "code": "samsrf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/samsrf.json",
-      "library": {
-        "label": "Marquand Library",
-        "code": "marquand",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Marquand Library of Art and Archaeology",
-        "code": "marquand"
-      }
-    },
-    {
-      "label": "Photography",
-      "code": "saph",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/saph.json",
-      "library": {
-        "label": "Marquand Library",
-        "code": "marquand",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Marquand Library of Art and Archaeology",
-        "code": "marquand"
-      }
-    },
-    {
-      "label": "Photography Reference",
-      "code": "saphrf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/saphrf.json",
-      "library": {
-        "label": "Marquand Library",
-        "code": "marquand",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Marquand Library of Art and Archaeology",
-        "code": "marquand"
-      }
-    },
-    {
-      "label": "Reserve",
-      "code": "sar",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sar.json",
-      "library": {
-        "label": "Marquand Library",
-        "code": "marquand",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Marquand Library of Art and Archaeology",
-        "code": "marquand"
-      }
-    },
-    {
-      "label": "Reference",
-      "code": "sarf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sarf.json",
-      "library": {
-        "label": "Marquand Library",
-        "code": "marquand",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Marquand Library of Art and Archaeology",
-        "code": "marquand"
-      }
-    },
-    {
-      "label": "Storage",
-      "code": "sarp",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sarp.json",
-      "library": {
-        "label": "Marquand Library",
-        "code": "marquand",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Marquand Library of Art and Archaeology",
-        "code": "marquand"
-      }
-    },
-    {
-      "label": "Rare Books: Miscellanea",
-      "code": "sat",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sat.json",
-      "library": {
-        "label": "Marquand Library",
-        "code": "marquand",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Marquand Library of Art and Archaeology",
-        "code": "marquand"
-      }
-    },
-    {
-      "label": "Workroom",
-      "code": "sawr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sawr.json",
-      "library": {
-        "label": "Marquand Library",
-        "code": "marquand",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Marquand Library of Art and Archaeology",
-        "code": "marquand"
-      }
-    },
-    {
-      "label": "Rare Books",
-      "code": "sax",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sax.json",
-      "library": {
-        "label": "Marquand Library",
-        "code": "marquand",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Marquand Library of Art and Archaeology",
-        "code": "marquand"
-      }
-    },
-    {
-      "label": "Classics Graduate Study (SC)",
-      "code": "sc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sc.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Friend Center Archive",
-      "code": "scc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scc.json",
-      "library": {
-        "label": "Engineering Library",
-        "code": "engineering",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Engineering Library",
-        "code": "engineering"
-      }
-    },
-    {
-      "label": "",
-      "code": "sci",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sci.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "Documents",
-      "code": "scidoc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scidoc.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "E/F Oversize and Atlases",
-      "code": "sciefa",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sciefa.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "GIS and Digital Map Center",
-      "code": "scigis",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scigis.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "Graduate Reading",
-      "code": "scigr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scigr.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "Limited Access (Fine Hall Wing A-Floor)",
-      "code": "scilaf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scilaf.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "Limited Access",
-      "code": "scilal",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scilal.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "Map Collection",
-      "code": "scimap",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scimap.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Map and Geospatial Information Center",
-        "code": "geoscimap"
-      }
-    },
-    {
-      "label": "Map Collection. Map Case",
-      "code": "scimc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scimc.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Map and Geospatial Information Center",
-        "code": "geoscimap"
-      }
-    },
-    {
-      "label": "Map Collection. Map Case Max",
-      "code": "scimcm",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scimcm.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Map and Geospatial Information Center",
-        "code": "geoscimap"
-      }
-    },
-    {
-      "label": "Microforms",
-      "code": "scimic",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scimic.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "Map Collection. Lateral File",
-      "code": "sciml",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sciml.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Map and Geospatial Information Center",
-        "code": "geoscimap"
-      }
-    },
-    {
-      "label": "Map Collection. Reference Maps",
-      "code": "scimlrf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scimlrf.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Map and Geospatial Information Center",
-        "code": "geoscimap"
-      }
-    },
-    {
-      "label": "Multimedia",
-      "code": "scimm",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scimm.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "New Book Shelf",
-      "code": "scinb",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scinb.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "Pamphlet",
-      "code": "scipam",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scipam.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "Peyton Hall Observing Room",
-      "code": "sciph",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sciph.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "Reference (Fine Hall Wing)",
-      "code": "sciref",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sciref.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "Reference (Information Desk)",
-      "code": "scirefl",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scirefl.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "Course Reserve",
-      "code": "scires",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scires.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "Term Loan Reserves",
-      "code": "sciresp",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sciresp.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "SuDoc Collection",
-      "code": "scisd",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scisd.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "Serials (shelved by serial title)",
-      "code": "sciss",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sciss.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "Theses",
-      "code": "scith",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scith.json",
-      "library": {
-        "label": "Lewis Library",
-        "code": "lewis",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Lewis Library",
-        "code": "lewis"
-      }
-    },
-    {
-      "label": "",
-      "code": "scsbcul",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": true,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scsbcul.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "",
-      "code": "scsbnypl",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": true,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/scsbnypl.json",
-      "library": {
-        "label": "ReCAP",
-        "code": "recap",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Classics Theses",
-      "code": "sct",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sct.json",
-      "library": {
-        "label": "Forrestal Annex",
-        "code": "annexa",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Germanic Languages Graduate Study Room (SD)",
-      "code": "sd",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sd.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "German Languages Theses",
-      "code": "sdt",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sdt.json",
-      "library": {
-        "label": "Forrestal Annex",
-        "code": "annexa",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Scribner Room (SE)",
-      "code": "se",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/se.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Scribner Room (SEREF): Reference",
-      "code": "seref",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/seref.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "English Theses",
-      "code": "set",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/set.json",
-      "library": {
-        "label": "Forrestal Annex",
-        "code": "annexa",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "History Reference (SH)",
-      "code": "sh",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sh.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Politics Graduate Study Room",
-      "code": "shp",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/shp.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Hellenic Studies Reading Room (SHS)",
-      "code": "shs",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/shs.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "History Theses",
-      "code": "sht",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sht.json",
-      "library": {
-        "label": "Forrestal Annex",
-        "code": "annexa",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Slavic Graduate Study Room (SLAV)",
-      "code": "slav",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/slav.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Near East Graduate Study Room (SNE)",
-      "code": "sne",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sne.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Philosophy Graduate Study Room",
-      "code": "sp",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sp.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Comparative Literature Graduate Study Room (SPC)",
-      "code": "spc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/spc.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "SPIA",
-      "code": "spia",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/spia.json",
-      "library": {
-        "label": "Stokes Library",
-        "code": "stokes",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Stokes Library",
-        "code": "stokes"
-      }
-    },
-    {
-      "label": "Atlases",
-      "code": "spiaa",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/spiaa.json",
-      "library": {
-        "label": "Stokes Library",
-        "code": "stokes",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Stokes Library",
-        "code": "stokes"
-      }
-    },
-    {
-      "label": "Indexes",
-      "code": "spiai",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/spiai.json",
-      "library": {
-        "label": "Stokes Library",
-        "code": "stokes",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Stokes Library",
-        "code": "stokes"
-      }
-    },
-    {
-      "label": "Periodicals",
-      "code": "spiaps",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/spiaps.json",
-      "library": {
-        "label": "Stokes Library",
-        "code": "stokes",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Stokes Library",
-        "code": "stokes"
-      }
-    },
-    {
-      "label": "Reference",
-      "code": "spiarf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/spiarf.json",
-      "library": {
-        "label": "Stokes Library",
-        "code": "stokes",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Stokes Library",
-        "code": "stokes"
-      }
-    },
-    {
-      "label": "Writing Shelf",
-      "code": "spiaws",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/spiaws.json",
-      "library": {
-        "label": "Stokes Library",
-        "code": "stokes",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Stokes Library",
-        "code": "stokes"
-      }
-    },
-    {
-      "label": "Reserve",
-      "code": "spir",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/spir.json",
-      "library": {
-        "label": "Stokes Library",
-        "code": "stokes",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Stokes Library",
-        "code": "stokes"
-      }
-    },
-    {
-      "label": "Comparative Literature Graduate Study Room",
-      "code": "spl",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/spl.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "SPR",
-      "code": "spr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/spr.json",
-      "library": {
-        "label": "Stokes Library",
-        "code": "stokes",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Stokes Library",
-        "code": "stokes"
-      }
-    },
-    {
-      "label": "Microforms",
-      "code": "sprf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sprf.json",
-      "library": {
-        "label": "Stokes Library",
-        "code": "stokes",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Stokes Library",
-        "code": "stokes"
-      }
-    },
-    {
-      "label": "Periodicals",
-      "code": "sprps",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sprps.json",
-      "library": {
-        "label": "Stokes Library",
-        "code": "stokes",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Stokes Library",
-        "code": "stokes"
-      }
-    },
-    {
-      "label": "Spanish & Portuguese Graduate Study Room (SPS)",
-      "code": "sps",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sps.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Philosophy Theses",
-      "code": "spt",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/spt.json",
-      "library": {
-        "label": "Forrestal Annex",
-        "code": "annexa",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Religion Graduate Study (SREL)",
-      "code": "srel",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/srel.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Romance Theses",
-      "code": "srt",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/srt.json",
-      "library": {
-        "label": "Forrestal Annex",
-        "code": "annexa",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Sociology Graduate Study Room",
-      "code": "ssa",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ssa.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Social Science Reference Center",
-      "code": "ssrc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ssrc.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Government Documents Collection (DOCS): Census",
-      "code": "ssrcdc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ssrcdc.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Data and Statistical Services (DSS): Stat Abstracts",
-      "code": "ssrcfo",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ssrcfo.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Social Science Reference Center: Ready Reference",
-      "code": "ssrcrr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ssrcrr.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "History Graduate Study (SSS)",
-      "code": "sss",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sss.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "",
-      "code": "st",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/st.json",
-      "library": {
-        "label": "Engineering Library",
-        "code": "engineering",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Engineering Library",
-        "code": "engineering"
-      }
-    },
-    {
-      "label": "Microforms",
-      "code": "stf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/stf.json",
-      "library": {
-        "label": "Fine Annex",
-        "code": "annexb",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Indexes and Abstracts",
-      "code": "stia",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/stia.json",
-      "library": {
-        "label": "Engineering Library",
-        "code": "engineering",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Engineering Library",
-        "code": "engineering"
-      }
-    },
-    {
-      "label": "Engineering",
-      "code": "stlo",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/stlo.json",
-      "library": {
-        "label": "Forrestal Annex",
-        "code": "annexa",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "New Book Shelf",
-      "code": "stnb",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/stnb.json",
-      "library": {
-        "label": "Engineering Library",
-        "code": "engineering",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Engineering Library",
-        "code": "engineering"
-      }
-    },
-    {
-      "label": "",
-      "code": "str",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/str.json",
-      "library": {
-        "label": "Engineering Library",
-        "code": "engineering",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Engineering Library",
-        "code": "engineering"
-      }
-    },
-    {
-      "label": "Reference",
-      "code": "strf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/strf.json",
-      "library": {
-        "label": "Engineering Library",
-        "code": "engineering",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Engineering Library",
-        "code": "engineering"
-      }
-    },
-    {
-      "label": "Term Loan Reserve",
-      "code": "strp",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/strp.json",
-      "library": {
-        "label": "Engineering Library",
-        "code": "engineering",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Engineering Library",
-        "code": "engineering"
-      }
-    },
-    {
-      "label": "Reserve",
-      "code": "strr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/strr.json",
-      "library": {
-        "label": "Engineering Library",
-        "code": "engineering",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Engineering Library",
-        "code": "engineering"
-      }
-    },
-    {
-      "label": "Serials",
-      "code": "stss",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/stss.json",
-      "library": {
-        "label": "Engineering Library",
-        "code": "engineering",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Engineering Library",
-        "code": "engineering"
-      }
-    },
-    {
-      "label": "Theses",
-      "code": "stt",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/stt.json",
-      "library": {
-        "label": "Engineering Library",
-        "code": "engineering",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Engineering Library",
-        "code": "engineering"
-      }
-    },
-    {
-      "label": "Reference",
-      "code": "sv",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sv.json",
-      "library": {
-        "label": "Mendel Music Library",
-        "code": "mendel",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Mendel Music Library",
-        "code": "music"
-      }
-    },
-    {
-      "label": "Facsimiles",
-      "code": "svf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/svf.json",
-      "library": {
-        "label": "Mendel Music Library",
-        "code": "mendel",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Mendel Music Library",
-        "code": "music"
-      }
-    },
-    {
-      "label": "Locked",
-      "code": "svl",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/svl.json",
-      "library": {
-        "label": "Mendel Music Library",
-        "code": "mendel",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Mendel Music Library",
-        "code": "music"
-      }
-    },
-    {
-      "label": "Economics Graduate Study Room",
-      "code": "sx",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sx.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Social Science Reference Center: Index Tables",
-      "code": "sxfa",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sxfa.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Pliny Fisk Library: Financial Serv.",
-      "code": "sxffi",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sxffi.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Pliny Fisk Library: Federal Reserve",
-      "code": "sxffr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sxffr.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Pliny Fisk Library: Index Tables",
-      "code": "sxfit",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sxfit.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Pliny Fisk Library: Ready Reference",
-      "code": "sxfrr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/sxfrr.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Theses Collection",
-      "code": "t",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": true,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/t.json",
-      "library": {
-        "label": "Forrestal Annex",
-        "code": "annexa",
-        "order": 3
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Theatre Collection",
-      "code": "thx",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/thx.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Theatre Collection: Reference",
-      "code": "thxr",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/thxr.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Travel Guides (TRV)",
-      "code": "trv",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/trv.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "",
-      "code": "ues",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ues.json",
-      "library": {
-        "label": "Architecture Library",
-        "code": "architecture",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Architecture Library",
-        "code": "architecture"
-      }
-    },
-    {
-      "label": "Indexes",
-      "code": "uesia",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/uesia.json",
-      "library": {
-        "label": "Architecture Library",
-        "code": "architecture",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Architecture Library",
-        "code": "architecture"
-      }
-    },
-    {
-      "label": "Librarian's Office",
-      "code": "uesla",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/uesla.json",
-      "library": {
-        "label": "Architecture Library",
-        "code": "architecture",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Architecture Library",
-        "code": "architecture"
-      }
-    },
-    {
-      "label": "New Book Shelf",
-      "code": "uesnb",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/uesnb.json",
-      "library": {
-        "label": "Architecture Library",
-        "code": "architecture",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Architecture Library",
-        "code": "architecture"
-      }
-    },
-    {
-      "label": "Reserve 3 Hour",
-      "code": "ueso",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/ueso.json",
-      "library": {
-        "label": "Architecture Library",
-        "code": "architecture",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Architecture Library",
-        "code": "architecture"
-      }
-    },
-    {
-      "label": "Reserve Closed",
-      "code": "uesr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/uesr.json",
-      "library": {
-        "label": "Architecture Library",
-        "code": "architecture",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Architecture Library",
-        "code": "architecture"
-      }
-    },
-    {
-      "label": "Reference",
-      "code": "uesrf",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/uesrf.json",
-      "library": {
-        "label": "Architecture Library",
-        "code": "architecture",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Architecture Library",
-        "code": "architecture"
-      }
-    },
-    {
-      "label": "United Nations Collection",
-      "code": "un",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/un.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Circulation Desk",
-      "code": "vidl",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/vidl.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Reserve: Firestone (B-15-H)",
-      "code": "vidlr",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/vidlr.json",
-      "library": {
-        "label": "Video Library",
-        "code": "hrc",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": null
-    },
-    {
-      "label": "Junius Morgan Collection",
-      "code": "vrg",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/vrg.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "John Shaw Pierson Civil War Collection",
-      "code": "w",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/w.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Western Americana Collection",
-      "code": "wa",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/wa.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Western Americana: Reference Collection (WARF)",
-      "code": "warf",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/warf.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "William H. Scheide Library",
-      "code": "whs",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/whs.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "John Witherspoon Library",
-      "code": "wit",
-      "aeon_location": true,
-      "recap_electronic_delivery_location": false,
-      "open": false,
-      "requestable": false,
-      "always_requestable": true,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/wit.json",
-      "library": {
-        "label": "Rare Books and Special Collections",
-        "code": "rare",
-        "order": 2
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Rare Books and Special Collections",
-        "code": "rbsc"
-      }
-    },
-    {
-      "label": "Very large books (XL)",
-      "code": "xl",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/xl.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Very large books (XLnc): Non-Circulating",
-      "code": "xlnc",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": false,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/xlnc.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    },
-    {
-      "label": "Zeiss Wildlife Collection",
-      "code": "zeis",
-      "aeon_location": false,
-      "recap_electronic_delivery_location": false,
-      "open": true,
-      "requestable": false,
-      "always_requestable": false,
-      "circulates": true,
-      "url": "https://bibdata.princeton.edu/locations/holding_locations/zeis.json",
-      "library": {
-        "label": "Firestone Library",
-        "code": "firestone",
-        "order": 1
-      },
-      "holding_library": null,
-      "hours_location": {
-        "label": "Firestone Library - Building and Circulation/Reserves Hours",
-        "code": "firestone"
-      }
-    }
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Rare Books Cataloging",
+    "code": "rare$cat",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$cat.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Eugene B. Cook Chess Collection (Cook)",
+    "code": "rare$cook",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$cook.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "East Asian Library (Gest) Rare Books",
+    "code": "rare$crare",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$crare.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Cotsen Children's Library",
+    "code": "rare$ctsn",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$ctsn.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Cotsen Children's Library Reference Collection",
+    "code": "rare$ctsnrf",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$ctsnrf.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Edwards Collection",
+    "code": "rare$ed",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$ed.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Rare Books",
+    "code": "rare$ex",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$ex.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Dulles Reference Collection",
+    "code": "rare$exb",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$exb.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "J. Harlin O'Connell Collection",
+    "code": "rare$exc",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$exc.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Laurance Roberts Carton Hunting Collection",
+    "code": "rare$exca",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$exca.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Kenneth McKenzie Fable Collection",
+    "code": "rare$exf",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$exf.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Miriam Y. Holden Collection",
+    "code": "rare$exho",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$exho.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Incunabula Collection",
+    "code": "rare$exi",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$exi.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Kane Collection",
+    "code": "rare$exka",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$exka.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Otto von Kienbusch Angling Collection",
+    "code": "rare$exki",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$exki.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Charles Scribner Collection of Charles Lamb",
+    "code": "rare$exl",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$exl.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Robert Metzdorf Collection",
+    "code": "rare$exme",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$exme.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Rare Books Oversize",
+    "code": "rare$exov",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$exov.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Morris L. Parrish Collection",
+    "code": "rare$expa",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$expa.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Kenneth H. Rockey Angling Collection",
+    "code": "rare$exrc",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$exrc.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Leonard Milberg Coll. of American Poetry",
+    "code": "rare$exrl",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$exrl.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Rare Books Transfer",
+    "code": "rare$extr",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$extr.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Technical Services Reference",
+    "code": "rare$extsf",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$extsf.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Harry B. Vandeventer Poetry Collection",
+    "code": "rare$exv",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$exv.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Orlando F. Weber Collection of Economic History",
+    "code": "rare$exw",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$exw.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Graphic Arts Collection",
+    "code": "rare$ga",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$ga.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Graphic Arts Reference Collection",
+    "code": "rare$garf",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$garf.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Graphic Arts Collection",
+    "code": "rare$gax",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$gax.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "East Asian Library Rare Books",
+    "code": "rare$gestrare",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$gestrare.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Cotsen Children's Library",
+    "code": "rare$hsvc",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$hsvc.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "East Asian",
+    "code": "rare$hsve",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$hsve.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Graphic Arts",
+    "code": "rare$hsvg",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$hsvg.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Manuscripts",
+    "code": "rare$hsvm",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$hsvm.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Numismatics",
+    "code": "rare$hsvn",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$hsvn.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Historic Maps",
+    "code": "rare$hsvp",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$hsvp.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Rare Books",
+    "code": "rare$hsvr",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$hsvr.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Western Americana",
+    "code": "rare$hsvw",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$hsvw.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Laurence Hutton Collection",
+    "code": "rare$htn",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$htn.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "East Asian Library Rare Books",
+    "code": "rare$hycrare",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$hycrare.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "East Asian Library Rare Books",
+    "code": "rare$hyjrare",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$hyjrare.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "East Asian Library Rare Books",
+    "code": "rare$hykrare",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$hykrare.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "East Asian Library Rare Books",
+    "code": "rare$jrare",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$jrare.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "East Asian Library Rare Books",
+    "code": "rare$krare",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$krare.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Rare Books Historic Map Collection",
+    "code": "rare$map",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$map.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Manuscripts Collection",
+    "code": "rare$mss",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$mss.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "rare$njpg",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$njpg.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Numismatics Collection",
+    "code": "rare$num",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$num.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Numismatics Collection Reference",
+    "code": "rare$numrf",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$numrf.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Princeton Borough Collection",
+    "code": "rare$pb",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$pb.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP):  Special Collections Use Only",
+    "code": "rare$pg",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$pg.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Robert Patterson Collection",
+    "code": "rare$ptt",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$ptt.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Robert H. Taylor Collection",
+    "code": "rare$rht",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$rht.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Theatre Collection",
+    "code": "rare$thx",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$thx.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Theatre Collection Reference",
+    "code": "rare$thxr",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$thxr.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "rare$UNASSIGNED",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$UNASSIGNED.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Junius Morgan Collection",
+    "code": "rare$vrg",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$vrg.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "John Shaw Pierson Civil War Collection",
+    "code": "rare$w",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$w.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Western Americana Collection",
+    "code": "rare$wa",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$wa.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Western Americana Reference Collection",
+    "code": "rare$warf",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$warf.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "William H. Scheide Library",
+    "code": "rare$whs",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$whs.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "John Witherspoon Library",
+    "code": "rare$wit",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$wit.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Cotsen Children's Library. Special Collections Use Only",
+    "code": "rare$xc",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$xc.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Graphic Arts. Special Collections Use Only",
+    "code": "rare$xg",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$xg.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Manuscripts. Special Collections Use Only",
+    "code": "rare$xm",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$xm.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Numismatics. Special Collections Use Only",
+    "code": "rare$xn",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$xn.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Historic Maps. Special Collections Use Only",
+    "code": "rare$xp",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$xp.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Rare Books. Special Collections Use Only",
+    "code": "rare$xr",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$xr.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Western Americana. Special Collections Use Only",
+    "code": "rare$xw",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$xw.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP):  Special Collections Use Only",
+    "code": "rare$xx",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/rare$xx.json",
+    "library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Special Collections",
+      "code": "rare",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage: Government Documents",
+    "code": "recap$gp",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": true,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/recap$gp.json",
+    "library": {
+      "label": "ReCAP",
+      "code": "recap",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage: JSTOR Restricted",
+    "code": "recap$jq",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": true,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/recap$jq.json",
+    "library": {
+      "label": "ReCAP",
+      "code": "recap",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage",
+    "code": "recap$pa",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": true,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/recap$pa.json",
+    "library": {
+      "label": "ReCAP",
+      "code": "recap",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage: Restricted Backup Copies",
+    "code": "recap$pe",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/recap$pe.json",
+    "library": {
+      "label": "ReCAP",
+      "code": "recap",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage: Plasma Physics use only",
+    "code": "recap$pq",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": true,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/recap$pq.json",
+    "library": {
+      "label": "ReCAP",
+      "code": "recap",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Harold P. Furth Plasma Physics Library",
+      "code": "plasma",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage: Reading Room use only",
+    "code": "recap$qb",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/recap$qb.json",
+    "library": {
+      "label": "ReCAP",
+      "code": "recap",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage: Video Collection",
+    "code": "recap$qv",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/recap$qv.json",
+    "library": {
+      "label": "ReCAP",
+      "code": "recap",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Firestone Library",
+      "code": "firestone",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage: Broadcast Center use only",
+    "code": "recap$qx",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/recap$qx.json",
+    "library": {
+      "label": "ReCAP",
+      "code": "recap",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "recap$UNASSIGNED",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/recap$UNASSIGNED.json",
+    "library": {
+      "label": "ReCAP",
+      "code": "recap",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Borrow Direct Service. Princeton University Library",
+    "code": "resshare$bdirect",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/resshare$bdirect.json",
+    "library": {
+      "label": "Resource Sharing",
+      "code": "resshare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "ILL Circ",
+    "code": "resshare$circ",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/resshare$circ.json",
+    "library": {
+      "label": "Resource Sharing",
+      "code": "resshare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "ReCAP Partner Materials",
+    "code": "resshare$htcsc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/resshare$htcsc.json",
+    "library": {
+      "label": "Resource Sharing",
+      "code": "resshare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Lending Resource Sharing Requests",
+    "code": "RES_SHARE$IN_RS_REQ",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "RES_FU",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/RES_SHARE$IN_RS_REQ.json",
+    "library": {
+      "label": "Resource Sharing Library",
+      "code": "RES_SHARE",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Borrowing Resource Sharing Requests",
+    "code": "RES_SHARE$OUT_RS_REQ",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "RES_FU",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/RES_SHARE$OUT_RS_REQ.json",
+    "library": {
+      "label": "Resource Sharing Library",
+      "code": "RES_SHARE",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "resshare$UNASSIGNED",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/resshare$UNASSIGNED.json",
+    "library": {
+      "label": "Resource Sharing",
+      "code": "resshare",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage",
+    "code": "scsbcul",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": true,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": null,
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/scsbcul.json",
+    "library": {
+      "label": "ReCAP",
+      "code": "recap",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage",
+    "code": "scsbhl",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": true,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": null,
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/scsbhl.json",
+    "library": {
+      "label": "ReCAP",
+      "code": "recap",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage",
+    "code": "scsbnypl",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": true,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": null,
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/scsbnypl.json",
+    "library": {
+      "label": "ReCAP",
+      "code": "recap",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Circulation",
+    "code": "stokes$circ",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/stokes$circ.json",
+    "library": {
+      "label": "Stokes Library",
+      "code": "stokes",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Indexes. Wallace Hall",
+    "code": "stokes$index",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/stokes$index.json",
+    "library": {
+      "label": "Stokes Library",
+      "code": "stokes",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Computer Media",
+    "code": "stokes$ltop",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Media",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/stokes$ltop.json",
+    "library": {
+      "label": "Stokes Library",
+      "code": "stokes",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Microforms. Wallace Hall",
+    "code": "stokes$mic",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/stokes$mic.json",
+    "library": {
+      "label": "Stokes Library",
+      "code": "stokes",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Wallace Hall",
+    "code": "stokes$piapr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/stokes$piapr.json",
+    "library": {
+      "label": "Stokes Library",
+      "code": "stokes",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Remote Storage (ReCAP): Stokes Library Use Only",
+    "code": "stokes$pm",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/stokes$pm.json",
+    "library": {
+      "label": "Stokes Library",
+      "code": "stokes",
+      "order": 0
+    },
+    "holding_library": {
+      "label": "Stokes Library",
+      "code": "stokes",
+      "order": 0
+    },
+    "hours_location": null
+  },
+  {
+    "label": "Reference. Wallace Hall",
+    "code": "stokes$ref",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/stokes$ref.json",
+    "library": {
+      "label": "Stokes Library",
+      "code": "stokes",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Reserve. Wallace Hall",
+    "code": "stokes$respiapr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/stokes$respiapr.json",
+    "library": {
+      "label": "Stokes Library",
+      "code": "stokes",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Wallace Hall (SPIA)",
+    "code": "stokes$spia",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/stokes$spia.json",
+    "library": {
+      "label": "Stokes Library",
+      "code": "stokes",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Atlases. Wallace Hall",
+    "code": "stokes$spiaa",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/stokes$spiaa.json",
+    "library": {
+      "label": "Stokes Library",
+      "code": "stokes",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Periodicals. Wallace Hall",
+    "code": "stokes$spiaps",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/stokes$spiaps.json",
+    "library": {
+      "label": "Stokes Library",
+      "code": "stokes",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Writing Shelf. Wallace Hall",
+    "code": "stokes$spiaws",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/stokes$spiaws.json",
+    "library": {
+      "label": "Stokes Library",
+      "code": "stokes",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Reserve. Wallace Hall",
+    "code": "stokes$spir",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": false,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Reserves",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/stokes$spir.json",
+    "library": {
+      "label": "Stokes Library",
+      "code": "stokes",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Wallace Hall (SPR)",
+    "code": "stokes$spr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/stokes$spr.json",
+    "library": {
+      "label": "Stokes Library",
+      "code": "stokes",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Periodicals. Wallace Hall",
+    "code": "stokes$sprps",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "General",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/stokes$sprps.json",
+    "library": {
+      "label": "Stokes Library",
+      "code": "stokes",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "stokes$UNASSIGNED",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/stokes$UNASSIGNED.json",
+    "library": {
+      "label": "Stokes Library",
+      "code": "stokes",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Acquisitions",
+    "code": "techserv$acq",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/techserv$acq.json",
+    "library": {
+      "label": "Technical Services",
+      "code": "techserv",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Acqord Orders ACQ",
+    "code": "techserv$acqord",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/techserv$acqord.json",
+    "library": {
+      "label": "Technical Services",
+      "code": "techserv",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Acqord Orders ACQ",
+    "code": "techserv$acqper",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/techserv$acqper.json",
+    "library": {
+      "label": "Technical Services",
+      "code": "techserv",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Acqord Orders ACQ",
+    "code": "techserv$acqser",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/techserv$acqser.json",
+    "library": {
+      "label": "Technical Services",
+      "code": "techserv",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Cataloging",
+    "code": "techserv$cat",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/techserv$cat.json",
+    "library": {
+      "label": "Technical Services",
+      "code": "techserv",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Circulation",
+    "code": "techserv$circ",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/techserv$circ.json",
+    "library": {
+      "label": "Technical Services",
+      "code": "techserv",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Cataloging and Metadata Services",
+    "code": "techserv$dc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/techserv$dc.json",
+    "library": {
+      "label": "Technical Services",
+      "code": "techserv",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "techserv$UNASSIGNED",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/techserv$UNASSIGNED.json",
+    "library": {
+      "label": "Technical Services",
+      "code": "techserv",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "zobsolete$REVIEW",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Limited",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$REVIEW.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "",
+    "code": "zobsolete$UNASSIGNED",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$UNASSIGNED.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "American Civilization (AC) OBSOLETE",
+    "code": "zobsolete$zac",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zac.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "OBSOLETE",
+    "code": "zobsolete$zanga",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zanga.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "OBSOLETE",
+    "code": "zobsolete$zangb",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zangb.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Books in Arabic (Arab). Firestone OBSOLETE",
+    "code": "zobsolete$zarab",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zarab.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "OBS Cataloging",
+    "code": "zobsolete$zcat",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zcat.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "OBS Circ",
+    "code": "zobsolete$zcirc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zcirc.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Data Statistical Services (DSS). Firestone OBSOLETE",
+    "code": "zobsolete$zcomc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zcomc.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "East Asian Library (Gest): Periodicals OBSOLETE",
+    "code": "zobsolete$zcp",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zcp.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "David Paton Collection (DPA). OBSOLETE",
+    "code": "zobsolete$zdpa",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zdpa.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Online Resources",
+    "code": "zobsolete$zelf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zelf.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Folio Databases (Fol) OBSOLETE",
+    "code": "zobsolete$zfol",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zfol.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "East Asian Library (Gest)OBSOLETE",
+    "code": "zobsolete$zgst",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zgst.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Firestone Microforms Services: East Asian OBSOLETE",
+    "code": "zobsolete$zgstf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zgstf.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "East Asian Library (Gest): Periodicals OBSOLETE",
+    "code": "zobsolete$zgstpe",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zgstpe.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "East Asian Library (Gest): Permanent Reserve OBSOLETE",
+    "code": "zobsolete$zgstpr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zgstpr.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "East Asian Library (Gest): Periodicals OBSOLETE",
+    "code": "zobsolete$zhygpe",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zhygpe.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "East Asian Library (Gest): Rare Books OBSOLETE",
+    "code": "zobsolete$zhygrare",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zhygrare.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Indo-European Philology Coll. (Indo). Firestone OBSOLETE",
+    "code": "zobsolete$zindo",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zindo.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Industrial Relations Library (IR). Firestone OBSOLETE",
+    "code": "zobsolete$zir",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zir.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Spoken Word Recordings (LISC): OBSOLETE",
+    "code": "zobsolete$zlisc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zlisc.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Magie Coll. OBSOLETE",
+    "code": "zobsolete$zmagi",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zmagi.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Mycenaean Collection (Mycen). Firestone OBSOLETE",
+    "code": "zobsolete$zmycn",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zmycn.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Near East Department Collection (NED). Jones Hall",
+    "code": "zobsolete$zned",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zned.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "New Order Request OBSOLETE",
+    "code": "zobsolete$znew",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$znew.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "ZOPAC Circulation Desk",
+    "code": "zobsolete$zopac",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zopac.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Pliny Fisk Library (PF). Firestone OBSOLETE",
+    "code": "zobsolete$zpf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zpf.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Donald E. Stokes Library (PIAPR): Periodicals. OBSOLETE",
+    "code": "zobsolete$zpiaprpe",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zpiaprpe.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Princeton Inn College (PIC) OBSOLETE",
+    "code": "zobsolete$zpic",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zpic.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": ".Choose a Pickup Location",
+    "code": "zobsolete$zpickup",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zpickup.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Pitney Collection (PITN). Firestone OBSOLETE",
+    "code": "zobsolete$zpitn",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zpitn.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Problem Record OBSOLETE",
+    "code": "zobsolete$zprob",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zprob.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "OBS Reference",
+    "code": "zobsolete$zref",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zref.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Romance Languages Grad.S.Rm (RS):Reserve.Firestone OBSOLETE",
+    "code": "zobsolete$zrrs",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zrrs.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Temporarily shelved in Room B-1-M Firestone Library OBSOLETE",
+    "code": "zobsolete$zrs",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zrs.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Politics Graduate Study Rm (SHP) Reserve. Firestone OBSOLETE",
+    "code": "zobsolete$zrshp",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zrshp.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Anthropology Grad. Study Rm. (SNST): Reserve. OBSOLETE",
+    "code": "zobsolete$zrsnst",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zrsnst.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Philosophy GSR (SP): Reserve. Firestone OBSOLETE",
+    "code": "zobsolete$zrsp",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zrsp.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "History of Science Grad S.Rm. (SSS): Reserve. OBSOLETE",
+    "code": "zobsolete$zrsss",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zrsss.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Economics GSR (SX): Reserve. Firestone OBSOLETE",
+    "code": "zobsolete$zrsx",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zrsx.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Marquand Library (SA) OBSOLETE",
+    "code": "zobsolete$zsaphwr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsaphwr.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Classics Graduate Study (SCG). OBSOLETE",
+    "code": "zobsolete$zscg",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zscg.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Classics Graduate Study (SCL). OBSOLETE",
+    "code": "zobsolete$zscl",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zscl.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Classics Graduate Study (SCP). OBSOLETE",
+    "code": "zobsolete$zscp",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zscp.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Public Administration Collection (SF). Firestone OBSOLETE",
+    "code": "zobsolete$zsf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsf.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Geosciences Library (SG) OBSOLETE",
+    "code": "zobsolete$zsg",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsg.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Geosciences Library (SG): Atlases A/E OversizeOBSOLETE",
+    "code": "zobsolete$zsgae",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsgae.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Geosciences Library (SG): CageOBSOLETE",
+    "code": "zobsolete$zsgca",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsgca.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Geosciences Library (SG): CD-ROMsOBSOLETE",
+    "code": "zobsolete$zsgcd",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsgcd.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Geosciences Library (SG): Digital Map and GIS CenterOBSOLETE",
+    "code": "zobsolete$zsgcdt",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsgcdt.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Geosciences Library (SG): DictionariesOBSOLETE",
+    "code": "zobsolete$zsgdi",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsgdi.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Geosciences Library (SG): DocumentsOBSOLETE",
+    "code": "zobsolete$zsgdo",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsgdo.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Geosciences Library (SG): Desk ReferenceOBSOLETE",
+    "code": "zobsolete$zsgdr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsgdr.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Geosciences Library (SG): MicroformsOBSOLETE",
+    "code": "zobsolete$zsgf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsgf.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Geosciences Library (SG): Librarian's OfficeOBSOLETE",
+    "code": "zobsolete$zsglo",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsglo.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Geosciences Library (SG): Map CollectionOBSOLETE",
+    "code": "zobsolete$zsgma",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsgma.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Geosciences Library (SG): ReserveOBSOLETE",
+    "code": "zobsolete$zsgr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsgr.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Geosciences Library (SG): Reference AtlasesOBSOLETE",
+    "code": "zobsolete$zsgrat",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsgrat.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Geosciences Library (SG): Permanent ReserveOBSOLETE",
+    "code": "zobsolete$zsgrp",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsgrp.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Geosciences Library (SG): SuDocs CollectionOBSOLETE",
+    "code": "zobsolete$zsgsd",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsgsd.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Geosciences Library (SG): Serials Shelved by Series TitleOBS",
+    "code": "zobsolete$zsgss",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsgss.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Politics Graduate Study Room (SHP). Firestone OBSOLETE",
+    "code": "zobsolete$zshp",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zshp.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Fine Hall Library (SM)OBSOLETE",
+    "code": "zobsolete$zsk",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsk.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Fine Hall Library (SM): Lower LevelOBSOLETE",
+    "code": "zobsolete$zskir",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zskir.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Latin American Graduate Study Room (SLA). OBSOLETE",
+    "code": "zobsolete$zsla",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsla.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Fine Hall Library (SM) OBSOLETE",
+    "code": "zobsolete$zsm",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsm.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Fine Hall Library (SM): Microforms OBSOLETE",
+    "code": "zobsolete$zsmf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsmf.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Fine Hall Library (SM): Graduate Reserve OBSOLETE",
+    "code": "zobsolete$zsmgr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsmgr.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Fine Hall Library (SM): Serials (shelved by title) OBSOLETE",
+    "code": "zobsolete$zsmir",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsmir.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Fine Hall Library (SM): Limited Access OBSOLETE",
+    "code": "zobsolete$zsmla",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsmla.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Fine Hall Library (SM): Oversize OBSOLETE",
+    "code": "zobsolete$zsmo",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsmo.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Fine Hall Library (SM): Pamphlet OBSOLETE",
+    "code": "zobsolete$zsmpa",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsmpa.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Fine Hall Library (SM): Reserve OBSOLETE",
+    "code": "zobsolete$zsmr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsmr.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Fine Hall Library (SM): Shelved with Books OBSOLETE",
+    "code": "zobsolete$zsmsb",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsmsb.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Fine Hall Library (SM): Theses - Limited Access OBSOLETE",
+    "code": "zobsolete$zsmt",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsmt.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Astrophysics Library (SO) OBSOLETE",
+    "code": "zobsolete$zso",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zso.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Astrophysics Library (SO): Peyton Hall Observing Rm OBSOLETE",
+    "code": "zobsolete$zsoar",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsoar.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Astrophysics Library (SO): CD-ROMs and Videos OBSOLETE",
+    "code": "zobsolete$zsocd",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsocd.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Astrophysics Library (SO):Serials (shelved by title)OBSOLETE",
+    "code": "zobsolete$zsoj",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsoj.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Astrophysics Library (SO):Journals, Shelved by TitleOBSOLETE",
+    "code": "zobsolete$zsojs",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsojs.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Astrophysics Library (SO): Librarian's Office OBSOLETE",
+    "code": "zobsolete$zsolo",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsolo.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Astrophysics Library (SO): Slide Collection OBSOLETE",
+    "code": "zobsolete$zsonb",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsonb.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Astrophysics Library (SO): Reserve OBSOLETE",
+    "code": "zobsolete$zsor",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsor.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Astrophysics Library (SO):Serials (shelved by title)OBSOLETE",
+    "code": "zobsolete$zsoric",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsoric.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Astrophysics Library (SO):Serials (shelved by title)OBSOLETE",
+    "code": "zobsolete$zsoris",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsoris.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Astrophysics Library (SO): Theses OBSOLETE",
+    "code": "zobsolete$zsot",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsot.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Philosophy Graduate Study Room (SP). Firestone OBSOLETE",
+    "code": "zobsolete$zsp",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsp.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "OBSOLETE",
+    "code": "zobsolete$zsphx",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsphx.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Donald E. Stokes Library (SPIA): Pamphlets. OBSOLETE",
+    "code": "zobsolete$zspiap",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zspiap.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Comparative Literature GSR. (SPL).Firestone OBSOLETE",
+    "code": "zobsolete$zspl",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zspl.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "OBSOLETE",
+    "code": "zobsolete$zsprcirc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsprcirc.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Chemistry Library (SQ) OBSOLETE",
+    "code": "zobsolete$zsq",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsq.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Chemistry Library (SQ): Closed Stacks OBSOLETE",
+    "code": "zobsolete$zsqc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsqc.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Chemistry Library (SQ): Desk Reference OBSOLETE",
+    "code": "zobsolete$zsqdr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsqdr.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Chemistry Library (SQ): Microforms OBSOLETE",
+    "code": "zobsolete$zsqf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsqf.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Chemistry Library (SQ): Permanent Reserve OBSOLETE",
+    "code": "zobsolete$zsqp",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsqp.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Chemistry Library (SQ): Periodicals OBSOLETE",
+    "code": "zobsolete$zsqpe",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsqpe.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Chemistry Library (SQ): Reserve OBSOLETE",
+    "code": "zobsolete$zsqr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsqr.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Chemistry Library (SQ): Theses (Closed Stacks) OBSOLETE",
+    "code": "zobsolete$zsqt",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsqt.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Social Science Reference Center (SSRC). OBSOLETE",
+    "code": "zobsolete$zssrc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zssrc.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Government Documents Collection (DOCS). Census. Firestone",
+    "code": "zobsolete$zssrcdc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zssrcdc.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Data and Statistical Services (DSS):Stat Abstracts Firestone",
+    "code": "zobsolete$zssrcfo",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zssrcfo.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Social Sci. Ref. Center (SSRC): Ready Ref. OBSOLETE",
+    "code": "zobsolete$zssrcrr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zssrcrr.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Annex A, Forrestal (Engineering) OBSOLETE",
+    "code": "zobsolete$zstlo",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zstlo.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Street Library (Street) OBSOLETE",
+    "code": "zobsolete$zstre",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zstre.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Psychology Library (SW) OBSOLETE",
+    "code": "zobsolete$zsw",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsw.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Psychology Library (SW): Microforms OBSOLETE",
+    "code": "zobsolete$zswf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zswf.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Psychology Library (SW): Limited Access OBSOLETE",
+    "code": "zobsolete$zswla",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zswla.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Psychology Library (SW): Librarian's Office OBSOLETE",
+    "code": "zobsolete$zswlo",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zswlo.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Psychology Library (SW): Periodicals OBSOLETE",
+    "code": "zobsolete$zswpe",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zswpe.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Psychology Library (SW): Reserve OBSOLETE",
+    "code": "zobsolete$zswr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zswr.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Psychology Library (SW): Bibliography OBSOLETE",
+    "code": "zobsolete$zswrbb",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zswrbb.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Psychology Library (SW): Biography OBSOLETE",
+    "code": "zobsolete$zswrbo",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zswrbo.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Psychology Library (SW): Career Shelf OBSOLETE",
+    "code": "zobsolete$zswrcs",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zswrcs.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Psychology Library (SW): Dictionaries OBSOLETE",
+    "code": "zobsolete$zswrdc",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zswrdc.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Psychology Library (SW): Drug Information OBSOLETE",
+    "code": "zobsolete$zswrdi",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zswrdi.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Psychology Library (SW): Directories OBSOLETE",
+    "code": "zobsolete$zswrdr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zswrdr.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Psychology Library (SW): Encyclopedias OBSOLETE",
+    "code": "zobsolete$zswre",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zswre.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Psychology Library (SW): General Reference OBSOLETE",
+    "code": "zobsolete$zswrg",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zswrg.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Psychology Library (SW): Indexes and Abstracts OBSOLETE",
+    "code": "zobsolete$zswri",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zswri.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Psychology Library (SW): Tests and Measurements OBSOLETE",
+    "code": "zobsolete$zswrt",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zswrt.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Psychology Library (SW): Writing information OBSOLETE",
+    "code": "zobsolete$zswrw",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zswrw.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Economics Graduate Study Room (SX). Firestone OBSOLETE",
+    "code": "zobsolete$zsx",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsx.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Pliny Fisk Library (SXF). Firestone OBSOLETE",
+    "code": "zobsolete$zsxf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsxf.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Social Science Reference (SSRC): Index Tables.F OBSOLETE",
+    "code": "zobsolete$zsxfa",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsxfa.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Pliny Fisk Library (SXF): Financial Serv. Firestone OBSOLETE",
+    "code": "zobsolete$zsxffi",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsxffi.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Pliny Fisk Library (SXF): Federal Reserve.Firestone OBSOLETE",
+    "code": "zobsolete$zsxffr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsxffr.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Pliny Fisk Library (SXF): Index Tables. Firestone OBSOLETE",
+    "code": "zobsolete$zsxfit",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsxfit.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Pliny Fisk Library (SXF): Ready Reference. FirestoneOBSOLETE",
+    "code": "zobsolete$zsxfrr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": false,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsxfrr.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Near East Collection (SY). Firestone OBSOLETE",
+    "code": "zobsolete$zsy",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsy.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Near East Periodicals (SYS). Firestone OBSOLETE",
+    "code": "zobsolete$zsys",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsys.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Biology Library (SZ) OBSOLETE",
+    "code": "zobsolete$zsz",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zsz.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Biology Library (SZ): Microforms OBSOLETE",
+    "code": "zobsolete$zszf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zszf.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Biology Library (SZ): Indexes OBSOLETE",
+    "code": "zobsolete$zszi",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zszi.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Biology Library (SZ): Librarian's Office OBSOLETE",
+    "code": "zobsolete$zszli",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zszli.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Biology Library (SZ): Library Office OBSOLETE",
+    "code": "zobsolete$zszof",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zszof.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Fine Hall Library (SM): Permanent Reserve OBSOLETE",
+    "code": "zobsolete$zszp",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zszp.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Biology Library (SZ): Periodicals OBSOLETE",
+    "code": "zobsolete$zszpe",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zszpe.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Biology Library (SZ): Periodicals OBSOLETE",
+    "code": "zobsolete$zszpr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zszpr.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Biology Library (SZ): Reserve OBSOLETE",
+    "code": "zobsolete$zszr",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zszr.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "OBSOLETE",
+    "code": "zobsolete$zszrfa",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zszrfa.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Biology Library (SZ): Shelved with Books OBSOLETE",
+    "code": "zobsolete$zszsb",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zszsb.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Annex, Fine Hall (AnnexB): Biology Storage OBSOLETE",
+    "code": "zobsolete$zszstor",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zszstor.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Biology Library (SZ): Theses OBSOLETE",
+    "code": "zobsolete$zszt",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zszt.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Architecture Library (UES): Microforms OBSOLETE",
+    "code": "zobsolete$zuesf",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zuesf.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Architecture Library (UES): Indexes OBSOLETE",
+    "code": "zobsolete$zuesia",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zuesia.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "Architecture Library (UES): Permanent Reserve OBSOLETE",
+    "code": "zobsolete$zuesp",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zuesp.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  },
+  {
+    "label": "X Obsolete Locations",
+    "code": "zobsolete$zzzX",
+    "aeon_location": false,
+    "recap_electronic_delivery_location": false,
+    "open": true,
+    "requestable": true,
+    "always_requestable": false,
+    "circulates": true,
+    "remote_storage": "",
+    "fulfillment_unit": "Closed",
+    "url": "https://bibdata.princeton.edu/locations/holding_locations/zobsolete$zzzX.json",
+    "library": {
+      "label": "Obsolete Locations",
+      "code": "zobsolete",
+      "order": 0
+    },
+    "holding_library": null,
+    "hours_location": null
+  }
 ]

--- a/spec/helpers/advanced_helper_spec.rb
+++ b/spec/helpers/advanced_helper_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 
 RSpec.describe AdvancedHelper do
   let(:architecture) { Blacklight::Solr::Response::Facets::FacetItem.new(hits: '792', value: 'Architecture Library') }
-  let(:rcppw) { Blacklight::Solr::Response::Facets::FacetItem.new(hits: '792', value: 'rcppw') }
-  let(:ues) { Blacklight::Solr::Response::Facets::FacetItem.new(hits: '792', value: 'ues') }
-  let(:uesla) { Blacklight::Solr::Response::Facets::FacetItem.new(hits: '792', value: 'uesla') }
-  let(:uesrf) { Blacklight::Solr::Response::Facets::FacetItem.new(hits: '792', value: 'uesrf') }
+  let(:rcppw) { Blacklight::Solr::Response::Facets::FacetItem.new(hits: '792', value: 'arch$pw') }
+  let(:ues) { Blacklight::Solr::Response::Facets::FacetItem.new(hits: '792', value: 'arch$circ') }
+  let(:uesla) { Blacklight::Solr::Response::Facets::FacetItem.new(hits: '792', value: 'arch$la') }
+  let(:uesrf) { Blacklight::Solr::Response::Facets::FacetItem.new(hits: '792', value: 'arch$ref') }
   let(:location_items) { [architecture, rcppw, ues, uesla, uesrf] }
 
   before { stub_holding_locations }
@@ -22,7 +22,10 @@ RSpec.describe AdvancedHelper do
       let(:architecture_hash) { subject['Architecture Library'] }
 
       it 'includes holding location code facet items' do
-        expect(architecture_hash['codes']).to match_array([ues, uesla, uesrf])
+        # In Voyager the `architecture_hash['codes']` did not include the ReCAP library (rcppw)
+        # since ReCAP items were assigned to their own library (ReCAP). That is not the case
+        # in Alma and now the ReCAP library (rcppw) is included.
+        expect(architecture_hash['codes']).to match_array([ues, uesla, uesrf, rcppw])
       end
       it 'includes recap location code facet items' do
         expect(architecture_hash['recap_codes']).to include(rcppw)

--- a/spec/helpers/holding_block_spec.rb
+++ b/spec/helpers/holding_block_spec.rb
@@ -397,7 +397,7 @@ RSpec.describe ApplicationHelper do
         expect(show_result.last).to include call_number
         expect(show_result.last).to include library
         expect(show_result.last).to include 'Remote Storage (ReCAP)'
-        expect(show_result.last).to include 'Mendel Music Library: Reserve'
+        expect(show_result.last).to include 'Mendel Music Library - Reserve'
       end
 
       it 'link to call number browse' do

--- a/spec/helpers/locations_spec.rb
+++ b/spec/helpers/locations_spec.rb
@@ -4,9 +4,9 @@ require 'rails_helper'
 
 RSpec.describe ApplicationHelper do
   describe '#locate_url helper method' do
-    let(:stackmap_location) { 'mus' }
-    let(:locator_location) { 'f' }
-    let(:stackmap_ineligible_location) { 'annexa' }
+    let(:stackmap_location) { 'mendel$stacks' }
+    let(:locator_location) { 'firestone$stacks' }
+    let(:stackmap_ineligible_location) { 'annex$noncirc' }
     let(:bib) { { id: '123456' } }
     let(:call_number) { 'RCPXR-6136516' }
     let(:locator_library) { 'Firestone Library' }
@@ -46,7 +46,7 @@ RSpec.describe ApplicationHelper do
     end
 
     it 'renders full location when value is a valid location code' do
-      expect(render_location_code('clas')).to eq('clas: Firestone Library - Classics Collection (Clas)')
+      expect(render_location_code('firestone$clas')).to eq('firestone$clas: Firestone Library - Classics Collection')
     end
   end
 
@@ -54,12 +54,12 @@ RSpec.describe ApplicationHelper do
     let(:fallback) { 'Fallback' }
     let(:without_code) { { 'library' => 'Library Name', 'location' => fallback } }
     let(:invalid_code) { { 'library' => 'Library Name', 'location' => fallback, 'location_code' => 'invalid' } }
-    let(:valid_code) { { 'library' => 'Library Name', 'location' => fallback, 'location_code' => 'aas' } }
-    let(:code_location_blank) { { 'library' => 'Library Name', 'location' => '', 'location_code' => 'aas' } }
+    let(:valid_code) { { 'library' => 'Library Name', 'location' => fallback, 'location_code' => 'firestone$aas' } }
+    let(:code_location_blank) { { 'library' => 'Library Name', 'location' => '', 'location_code' => 'firestone$aas' } }
 
     it 'returns holding location label when location code lookup successful' do
       stub_holding_locations
-      expect(holding_location_label(valid_code)).to eq('Firestone Library - African American Studies Reading Room (AAS). B-7-B')
+      expect(holding_location_label(valid_code)).to eq('Firestone Library - African American Studies Reading Room')
     end
     context 'when location code lookup fails' do
       before do

--- a/spec/services/stackmap_service_spec.rb
+++ b/spec/services/stackmap_service_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe StackmapService::Url do
       end
     end
     describe 'missing doc' do
-      let(:location) { 'f' }
+      let(:location) { 'firestone$stacks' }
       let(:document) { nil }
 
       it 'resolves to catalog homepage' do

--- a/spec/services/stackmap_service_spec.rb
+++ b/spec/services/stackmap_service_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe StackmapService::Url do
 
   describe '#url with valid params' do
     describe 'firestone, call number provided' do
-      let(:location) { 'f' }
+      let(:location) { 'firestone$stacks' }
       let(:call_number) { 'Q43.2' }
 
       it 'resolves to embeded firestone locator with loc and bibid' do
@@ -29,7 +29,7 @@ RSpec.describe StackmapService::Url do
       end
     end
     describe 'firestone, no call number provided' do
-      let(:location) { 'f' }
+      let(:location) { 'firestone$stacks' }
 
       it 'resolves to embeded firestone locator with loc and bibid' do
         expect(url).to eq("https://locator-prod.princeton.edu/index.php?loc=#{location}&id=#{properties[:id]}&embed=true")
@@ -37,7 +37,7 @@ RSpec.describe StackmapService::Url do
     end
 
     describe 'firestone, doc has no call number' do
-      let(:location) { 'f' }
+      let(:location) { 'firestone$stacks' }
       let(:doc_cn) { nil }
 
       it 'resolves to embeded firestone locator with loc and bibid' do
@@ -50,20 +50,17 @@ RSpec.describe StackmapService::Url do
     end
 
     describe 'mendel, call number provided' do
-      let(:location) { 'mus' }
+      let(:location) { 'mendel$stacks' }
       let(:call_number) { 'Q43.2' }
 
       it 'resolves to stackmap with provided call number' do
         expect(url).to include('princeton.stackmap')
         expect(url).to include(call_number)
       end
-
-      it 'the library is the location label when the holding location has no label' do
-        expect(url_service.location_label).to eq('Mendel Music Library')
-      end
     end
+
     describe 'mendel, no call number provided' do
-      let(:location) { 'mus' }
+      let(:location) { 'mendel$stacks' }
 
       it 'resolves to stackmap with document call number' do
         expect(url).to include('princeton.stackmap')
@@ -71,8 +68,17 @@ RSpec.describe StackmapService::Url do
       end
     end
 
+    describe 'no location label' do
+      let(:location) { 'annex$UNASSIGNED' }
+      let(:call_number) { 'Q43.2' }
+
+      it 'the library is the location label when the holding location has no label' do
+        expect(url_service.location_label).to eq('Forrestal Annex')
+      end
+    end
+
     describe 'by title location' do
-      let(:location) { 'sprps' }
+      let(:location) { 'stokes$sprps' }
 
       it 'uses title as the call number value' do
         expect(url).to include({ callno: properties[:title_display] }.to_query)
@@ -81,11 +87,11 @@ RSpec.describe StackmapService::Url do
         expect(url_service.preferred_callno).to eq(properties[:title_display])
       end
       it 'location label is used instead of library when present' do
-        expect(url_service.location_label).to eq('Periodicals')
+        expect(url_service.location_label).to eq('Periodicals. Wallace Hall')
       end
     end
     describe 'by title location with provided call number' do
-      let(:location) { 'sprps' }
+      let(:location) { 'stokes$sprps' }
       let(:call_number) { 'Q43.2' }
 
       it 'uses title as the call number value' do
@@ -93,7 +99,7 @@ RSpec.describe StackmapService::Url do
       end
     end
     describe 'non-stackmap location' do
-      let(:location) { 'pplr' }
+      let(:location) { 'plasma$res' }
 
       it 'resolves to branch library page' do
         expect(url).to eq('https://library.princeton.edu/plasma-physics')


### PR DESCRIPTION
Fixes #2608 

This is an example of a book in the Architecture Library now displaying the stack map

![arch_stacks](https://user-images.githubusercontent.com/568286/134250218-c8f117fe-94e5-48b6-b9d5-3528a0da9325.png)

