### PR TITLE
Rescue and redirect from all BadRequest errors

### DIFF
--- a/lib/orangelight/middleware/invalid_parameter_handler.rb
+++ b/lib/orangelight/middleware/invalid_parameter_handler.rb
@@ -72,10 +72,15 @@ module Orangelight
           end
         end
 
-        def raise_error?(message)
-          valid_message_patterns.each do |pattern|
-            return false if message.match?(pattern)
-          end
+        ##
+        # Previously, we were rescuing only from exceptions we recognized.
+        # The problem with that is that there will be exceptions we don't recognize and
+        # haven't been able to diagnose (see, e.g., https://github.com/pulibrary/orangelight/issues/1455)
+        # and when those happen we want to provide the user with a graceful way forward,
+        # not just an error screen. Therefore, we should rescue all errors, log the problem,
+        # and redirect the user somewhere helpful.
+        def raise_error?(_message)
+          false
         end
 
         def request_content_type(env)

--- a/spec/requests/catalog_spec.rb
+++ b/spec/requests/catalog_spec.rb
@@ -13,4 +13,17 @@ describe 'search requests for the catalog' do
 
     expect(response.status).to eq(200)
   end
+
+  context "BadRequest when clicking back to search" do
+    # This url produces ActionController::BadRequest
+    let(:url) do
+      '/catalog?utf8=%E2%9C&f1=all_fields'
+    end
+
+    it 'redirects the user to start over' do
+      get url
+      expect(response.status).to eq(400)
+      expect(response.body).to match(/start over/)
+    end
+  end
 end


### PR DESCRIPTION
Previously we were only rescuing and redirecting for a sub-set of
BadRequest errors. This meant that when there was a BadRequest that we
didn't anticipate, the user was getting an unhelpful error screen.
Better to always rescue, until we come up with some flavor of error that
we want to do something different for.

Fixes #1455 

Before:
![Screen Shot 2021-09-21 at 10 12 15 AM](https://user-images.githubusercontent.com/65608/134190313-dd29b320-1eb6-4da6-9554-3c2192494126.png)

After:
![Screen Shot 2021-09-21 at 10 12 48 AM](https://user-images.githubusercontent.com/65608/134190347-b76aecf8-6491-44fe-a59f-c90b3f130dc5.png)
