### PR TITLE
Availability label in Search Results

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -236,10 +236,7 @@ module ApplicationHelper
     if scsb_multiple == true
       block << content_tag(:li, link_to('View Record for Full Availability', solr_document_path(document['id']), class: 'availability-icon badge badge-secondary more-info', title: 'Click on the record for full availability info', 'data-toggle' => 'tooltip').html_safe)
     elsif holdings_hash.length > 2
-      block << content_tag(:li, link_to('View Record for Full Availability', solr_document_path(document['id']),
-                                        class: 'availability-icon badge badge-secondary more-info', title: 'Click on the record for full availability info',
-                                        'data-toggle' => 'tooltip').html_safe)
-
+      block << content_tag(:span, "View record for information on additional holdings", "style" => "font-size: small; font-style: italic;")
     elsif !holdings_hash.empty?
       block << content_tag(:li, link_to('', solr_document_path(document['id']),
                                         class: 'availability-icon more-info', title: 'Click on the record for full availability info',

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -138,7 +138,7 @@ export default class AvailabilityUpdater {
         // In this case we set all of them to "Check record" because we can get this
         // information in the Show page.
         const badges = $(`*[data-availability-record='true'][data-record-id='${record_id}'] span.availability-icon`);
-        badges.text("View record for availability")
+        badges.text("View record for Full Availability")
         return true;
       }
 
@@ -163,7 +163,7 @@ export default class AvailabilityUpdater {
     // information for holdings coming from the host record. For those holdings we ask the user
     // to check the record since in `process_single()` we do the extra work to get that information.
     const boundWithBadges = $(`*[data-availability-record='true'][data-record-id='${record_id}'][data-bound-with='true'] span.availability-icon`);
-    boundWithBadges.text("View record for availability")
+    boundWithBadges.text("View record for Full Availability")
 
     return true;
   }

--- a/spec/helpers/holding_block_spec.rb
+++ b/spec/helpers/holding_block_spec.rb
@@ -176,10 +176,7 @@ RSpec.describe ApplicationHelper do
       before { stub_holding_locations }
 
       it 'displays View Record for Availability' do
-        expect(search_result).to include 'View Record for Full Availability'
-      end
-      it 'has an availability icon' do
-        expect(search_result).to have_selector ".availability-icon[title='Click on the record for full availability info']"
+        expect(search_result).to include 'View record for information on additional holdings'
       end
     end
     context '#holding_block_search' do

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -132,7 +132,7 @@ describe('AvailabilityUpdater', function() {
     u.process_result(bibId, holdingData)
 
     const badgesAfter = document.getElementsByClassName('availability-icon')
-    expect(badgesAfter[0].textContent).toEqual('View record for availability')
+    expect(badgesAfter[0].textContent).toEqual('View record for Full Availability')
   })
 
   test('record show page with an available holding displays the status label in green', () => {
@@ -340,7 +340,7 @@ describe('AvailabilityUpdater', function() {
     let u = new updater
     u.process_result("9929455793506421", holding_records)
 
-    expect(holding_badge.textContent).toContain('View record for availability');
+    expect(holding_badge.textContent).toContain('View record for Full Availability');
   })
 
   test('extra Online availability added for CDL records that are reported as unavailable', () => {

--- a/spec/requests/request_spec.rb
+++ b/spec/requests/request_spec.rb
@@ -52,10 +52,7 @@ describe 'blacklight tests' do
       r = JSON.parse(response.body)
       expect(r['location'].length).to be > 2
       get '/catalog?&search_field=all_fields&q=857469'
-      expect(response.body).to include '<a class="availability-icon badge badge-secondary more-info" '\
-                                       'title="Click on the record for full availability info" '\
-                                       'data-toggle="tooltip" href="/catalog/857469">View Record '\
-                                       'for Full Availability</a>'
+      expect(response.body).to include '<span style="font-size: small; font-style: italic;">View record for information on additional holdings</span>'
     end
     it 'displays the location name for an item with a single location' do
       get '/catalog/321/raw'


### PR DESCRIPTION
Use the same text to let the user that they can view complete availability in the record page regardless of what kind of holding the availability is for. 

With this PR we display "View record for Full Availability" rather than sometimes "View record for Full Availability" and other times "View record for availability"

The following screenshots show before and after. 

## Before
![old_display](https://user-images.githubusercontent.com/568286/135507191-844c65a7-0d0d-4e19-9326-541ff050edb6.png)

## After
![av_display_new](https://user-images.githubusercontent.com/568286/135670162-0bfb4ecf-aa42-42a0-a950-a827209b059f.png)

Fixes #2671 
