### PR TITLE
Updating requests to get the enumeration for books in the pickup email

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GIT
 
 GIT
   remote: https://github.com/pulibrary/requests.git
-  revision: ef5f3881755f3ceb86745e9b3cec1956025ab3cf
+  revision: eec504b061ed4ded71f453ca65540ce6ea189aac
   branch: main
   specs:
     requests (0.0.2)
@@ -258,7 +258,7 @@ GEM
       domain_name (~> 0.5)
     http-form_data (2.1.1)
     http_parser.rb (0.6.0)
-    httparty (0.19.0)
+    httparty (0.20.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)


### PR DESCRIPTION
Here is an example of the email with the enumeration for : https://catalog-qa.princeton.edu//requests/9973397793506421?mfhd=22541187250006421
![Screen Shot 2021-10-04 at 10 20 39 AM](https://user-images.githubusercontent.com/1599081/135868276-17a521a0-6f4d-44bb-a8ab-616caaf33633.png)
