### PR TITLE
Proxy Library Account through CAS

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -5,9 +5,9 @@ require './lib/orangelight/illiad_account.rb'
 class AccountController < ApplicationController
   include ApplicationHelper
 
-  before_action :read_only_redirect
-  before_action :require_user_authentication_provider
-  before_action :verify_user, except: [:borrow_direct_redirect]
+  before_action :read_only_redirect, except: [:redirect_to_alma]
+  before_action :require_user_authentication_provider, except: [:redirect_to_alma]
+  before_action :verify_user, except: [:borrow_direct_redirect, :redirect_to_alma]
 
   def index
     redirect_to digitization_requests_path
@@ -34,6 +34,10 @@ class AccountController < ApplicationController
         format.js { flash.now[:error] = I18n.t('blacklight.account.cancel_fail') }
       end
     end
+  end
+
+  def redirect_to_alma
+    render "redirect_to_alma"
   end
 
   protected

--- a/app/views/account/redirect_to_alma.html.erb
+++ b/app/views/account/redirect_to_alma.html.erb
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <!-- TODO: enable this to automatically redirect -->
+  <!-- meta http-equiv="Refresh" content="0; URL=https://princeton.alma.exlibrisgroup.com/discovery/account?vid=01PRI_INST:Services&lang=EN&section=overview" -->
+</head>
+<body>
+  <div class="col-md-12">
+    <p>Redirecting to Library Account in Alma,
+    click <%= link_to("here", "https://princeton.alma.exlibrisgroup.com/discovery/account?vid=01PRI_INST:Services&lang=EN&section=overview") %>
+    if you are not automatically redirected.</p>
+  </div>
+</body>
+</html>

--- a/app/views/shared/_account.html.erb
+++ b/app/views/shared/_account.html.erb
@@ -6,7 +6,7 @@
       </button>
       <ul class="dropdown-menu dropdown-menu-right" role="menu">
         <li role="menuitem">
-          <%= link_to("https://princeton.alma.exlibrisgroup.com/discovery/account?vid=01PRI_INST:Services&lang=EN&section=overview", target: "_blank") do %>
+          <%= link_to(main_app.new_user_session_path(origin: "/account/redirect-to-alma"), target: "_blank") do %>
             Library Account <i class="fa fa-external-link" aria-hidden="true"></i>
           <% end %>
         </li>
@@ -25,7 +25,7 @@
       </button>
       <ul class="dropdown-menu dropdown-menu-right" role="menu">
         <li role="menuitem">
-          <%= link_to("https://princeton.alma.exlibrisgroup.com/discovery/account?vid=01PRI_INST:Services&lang=EN&section=overview", target: "_blank") do %>
+          <%= link_to(main_app.new_user_session_path(origin: "/account/redirect-to-alma"), target: "_blank") do %>
             Library Account <i class="fa fa-external-link" aria-hidden="true"></i>
           <% end %>
         </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,7 @@ Rails.application.routes.draw do
   get '/account', to: 'account#index'
   get '/account/digitization_requests', to: 'account#digitization_requests', as: "digitization_requests"
   post '/account/cancel_ill_requests', to: 'account#cancel_ill_requests'
+  get '/account/redirect-to-alma', to: 'account#redirect_to_alma'
   get '/borrow-direct', to: 'account#borrow_direct_redirect'
 
   ### For feedback Form


### PR DESCRIPTION
First pass at routing the (Alma) Library Account login through CAS to get users to be authenticated in the Catalog and Alma at the same time.

Fixes #2709 