### PR TITLE
downcase netids from CAS

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,7 @@ class User < ApplicationRecord
   # @param access_token []
   # @return [User,nil]
   def self.from_cas(access_token)
+    access_token.uid = access_token.uid.downcase
     User.where(provider: access_token.provider, uid: access_token.uid).first_or_create do |user|
       user.uid = access_token.uid
       user.username = access_token.uid

--- a/app/services/db_migrate_uppercase_usernames.rb
+++ b/app/services/db_migrate_uppercase_usernames.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: false
 
 class DBMigrateUppercaseUsernames
+  def self.run
+    find_uppercase_users.map { |uppercase_user|
+      find_lowercase_user(uppercase_user).map { |lowercase_user|
+        merge_bookmarks(uppercase_user, lowercase_user)
+        merge_searches(uppercase_user, lowercase_user)
+        delete_uppercase_user(uppercase_user)
+      }
+    }
+  end
+
   # find all users with uppercase letters in their username
   def find_uppercase_users
     User.where("uid ~ ?", "[A-Z]").to_a

--- a/app/services/db_migrate_uppercase_usernames.rb
+++ b/app/services/db_migrate_uppercase_usernames.rb
@@ -29,7 +29,7 @@ class DBMigrateUppercaseUsernames
 
     # find lowercase version of the user with uppercase letters in their username
     def find_lowercase_user
-      User.find_by(username: uppercase_user.uid.downcase)
+      User.find_by(username: uppercase_user.uid.downcase) || User.create(uid: uppercase_user.uid.downcase, username: uppercase_user.uid.downcase)
     end
 
     # merge uppercase user's bookmarks into lowercase user's bookmarks

--- a/app/services/db_migrate_uppercase_usernames.rb
+++ b/app/services/db_migrate_uppercase_usernames.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: false
+
+class DBMigrateUppercaseUsernames
+  # find all users with uppercase letters in their username
+  def find_uppercase_users
+    User.where("uid ~ ?", "[A-Z]").to_a
+  end
+
+  # find lowercase version of the user with uppercase letters in their username
+  def find_lowercase_user(uppercase_user)
+    User.find_by(username: uppercase_user.uid.downcase)
+  end
+
+  # merge uppercase user's bookmarks into lowercase user's bookmarks
+  def merge_bookmarks(uppercase_user, lowercase_user)
+    uppercase_user_bookmarks = Bookmark.where(user_id: uppercase_user.id)
+    lowercase_user_bookmarks = Bookmark.where(user_id: lowercase_user.id)
+    lowercase_user.bookmarks = uppercase_user_bookmarks | lowercase_user_bookmarks
+  end
+
+  # merge uppercase user's searches into lowercase user's searches
+  def merge_searches(uppercase_user, lowercase_user)
+    uppercase_user_searches = Search.where(user_id: uppercase_user.id)
+    lowercase_user_searches = Search.where(user_id: lowercase_user.id)
+    lowercase_user.searches = uppercase_user_searches | lowercase_user_searches
+  end
+
+  # delete the duplicate account
+  def delete_uppercase_user(uppercase_user)
+    uppercase_user.destroy
+  end
+end

--- a/app/services/db_migrate_uppercase_usernames.rb
+++ b/app/services/db_migrate_uppercase_usernames.rb
@@ -2,13 +2,11 @@
 
 class DBMigrateUppercaseUsernames
   def self.run
-    find_uppercase_users.map { |uppercase_user|
-      find_lowercase_user(uppercase_user).map { |lowercase_user|
-        merge_bookmarks(uppercase_user, lowercase_user)
-        merge_searches(uppercase_user, lowercase_user)
-        delete_uppercase_user(uppercase_user)
-      }
-    }
+    new.run
+  end
+
+  def run
+    find_uppercase_users.map { |uppercase_user| UserLowercaser.new(uppercase_user).convert }
   end
 
   # find all users with uppercase letters in their username
@@ -16,27 +14,36 @@ class DBMigrateUppercaseUsernames
     User.where("uid ~ ?", "[A-Z]").to_a
   end
 
-  # find lowercase version of the user with uppercase letters in their username
-  def find_lowercase_user(uppercase_user)
-    User.find_by(username: uppercase_user.uid.downcase)
-  end
+  class UserLowercaser
+    attr_reader :uppercase_user
 
-  # merge uppercase user's bookmarks into lowercase user's bookmarks
-  def merge_bookmarks(uppercase_user, lowercase_user)
-    uppercase_user_bookmarks = Bookmark.where(user_id: uppercase_user.id)
-    lowercase_user_bookmarks = Bookmark.where(user_id: lowercase_user.id)
-    lowercase_user.bookmarks = uppercase_user_bookmarks | lowercase_user_bookmarks
-  end
+    def initialize(uppercase_user)
+      @uppercase_user = uppercase_user
+    end
 
-  # merge uppercase user's searches into lowercase user's searches
-  def merge_searches(uppercase_user, lowercase_user)
-    uppercase_user_searches = Search.where(user_id: uppercase_user.id)
-    lowercase_user_searches = Search.where(user_id: lowercase_user.id)
-    lowercase_user.searches = uppercase_user_searches | lowercase_user_searches
-  end
+    def convert
+      lowercase_user = find_lowercase_user
+      merge_bookmarks(lowercase_user)
+      merge_searches(lowercase_user)
+    end
 
-  # delete the duplicate account
-  def delete_uppercase_user(uppercase_user)
-    uppercase_user.destroy
+    # find lowercase version of the user with uppercase letters in their username
+    def find_lowercase_user
+      User.find_by(username: uppercase_user.uid.downcase)
+    end
+
+    # merge uppercase user's bookmarks into lowercase user's bookmarks
+    def merge_bookmarks(lowercase_user)
+      uppercase_user_bookmarks = Bookmark.where(user_id: uppercase_user.id)
+      lowercase_user_bookmarks = Bookmark.where(user_id: lowercase_user.id)
+      lowercase_user.bookmarks = uppercase_user_bookmarks | lowercase_user_bookmarks
+    end
+
+    # merge uppercase user's searches into lowercase user's searches
+    def merge_searches(lowercase_user)
+      uppercase_user_searches = Search.where(user_id: uppercase_user.id)
+      lowercase_user_searches = Search.where(user_id: lowercase_user.id)
+      lowercase_user.searches = uppercase_user_searches | lowercase_user_searches
+    end
   end
 end

--- a/app/services/db_migrate_uppercase_usernames.rb
+++ b/app/services/db_migrate_uppercase_usernames.rb
@@ -36,24 +36,16 @@ class DBMigrateUppercaseUsernames
     def merge_bookmarks(lowercase_user)
       uppercase_user_bookmarks = Bookmark.where(user_id: uppercase_user.id)
       lowercase_user_bookmarks = Bookmark.where(user_id: lowercase_user.id).to_a
-      lowercase_bookmarks_doc_ids = []
-      lowercase_user_bookmarks.each { |lowercase_bookmark| lowercase_bookmarks_doc_ids.push(lowercase_bookmark.document_id) }
-      uppercase_user_bookmarks.each do |uppercase_bookmark|
-        lowercase_user_bookmarks = lowercase_user_bookmarks.push(uppercase_bookmark) unless lowercase_bookmarks_doc_ids.include? uppercase_bookmark.document_id
-      end
-      lowercase_user.bookmarks = lowercase_user_bookmarks
+      lowercase_bookmarks_doc_ids = lowercase_user_bookmarks.map(&:document_id)
+      lowercase_user.bookmarks = lowercase_user_bookmarks + uppercase_user_bookmarks.reject { |bookmark| lowercase_bookmarks_doc_ids.include? bookmark.document_id }
     end
 
     # merge uppercase user's searches into lowercase user's searches
     def merge_searches(lowercase_user)
       uppercase_user_searches = Search.where(user_id: uppercase_user.id)
       lowercase_user_searches = Search.where(user_id: lowercase_user.id).to_a
-      lowercase_searches_queries = []
-      lowercase_user_searches.each { |lowercase_search| lowercase_searches_queries.push(lowercase_search.query_params) }
-      uppercase_user_searches.each do |uppercase_search|
-        lowercase_user_searches = lowercase_user_searches.push(uppercase_search) unless lowercase_searches_queries.include? uppercase_search.query_params
-      end
-      lowercase_user.searches = lowercase_user_searches
+      lowercase_searches_queries = lowercase_user_searches.map(&:query_params)
+      lowercase_user.searches = lowercase_user_searches + uppercase_user_searches.reject { |search| lowercase_searches_queries.include? search.query_params }
     end
   end
 end

--- a/app/services/db_migrate_uppercase_usernames.rb
+++ b/app/services/db_migrate_uppercase_usernames.rb
@@ -35,15 +35,25 @@ class DBMigrateUppercaseUsernames
     # merge uppercase user's bookmarks into lowercase user's bookmarks
     def merge_bookmarks(lowercase_user)
       uppercase_user_bookmarks = Bookmark.where(user_id: uppercase_user.id)
-      lowercase_user_bookmarks = Bookmark.where(user_id: lowercase_user.id)
-      lowercase_user.bookmarks = uppercase_user_bookmarks | lowercase_user_bookmarks
+      lowercase_user_bookmarks = Bookmark.where(user_id: lowercase_user.id).to_a
+      lowercase_bookmarks_doc_ids = []
+      lowercase_user_bookmarks.each { |lowercase_bookmark| lowercase_bookmarks_doc_ids.push(lowercase_bookmark.document_id) }
+      uppercase_user_bookmarks.each do |uppercase_bookmark|
+        lowercase_user_bookmarks = lowercase_user_bookmarks.push(uppercase_bookmark) unless lowercase_bookmarks_doc_ids.include? uppercase_bookmark.document_id
+      end
+      lowercase_user.bookmarks = lowercase_user_bookmarks
     end
 
     # merge uppercase user's searches into lowercase user's searches
     def merge_searches(lowercase_user)
       uppercase_user_searches = Search.where(user_id: uppercase_user.id)
-      lowercase_user_searches = Search.where(user_id: lowercase_user.id)
-      lowercase_user.searches = uppercase_user_searches | lowercase_user_searches
+      lowercase_user_searches = Search.where(user_id: lowercase_user.id).to_a
+      lowercase_searches_queries = []
+      lowercase_user_searches.each { |lowercase_search| lowercase_searches_queries.push(lowercase_search.query_params) }
+      uppercase_user_searches.each do |uppercase_search|
+        lowercase_user_searches = lowercase_user_searches.push(uppercase_search) unless lowercase_searches_queries.include? uppercase_search.query_params
+      end
+      lowercase_user.searches = lowercase_user_searches
     end
   end
 end

--- a/lib/tasks/maintenance.rake
+++ b/lib/tasks/maintenance.rake
@@ -7,4 +7,11 @@ namespace :orangelight do
       User.expire_guest_accounts
     end
   end
+
+  namespace :migration do
+    desc 'Downcase netids from CAS'
+    task netids: :environment do
+      DBMigrateUppercaseUsernames.run
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,11 +25,15 @@ RSpec.describe User do
   end
 
   describe ".from_cas" do
-    it "finds the user in the database" do
-      access_token = OmniAuth::AuthHash.new(provider: "provider", uid: "1234")
+    let(:access_token) { access_token = OmniAuth::AuthHash.new(provider: "provider", uid: "testUSER123") }
+
+    it "finds or creates user in the database" do
+      expect{ described_class.from_cas(access_token) }.to change(User, :count).by(1)
+    end
+
+    it "downcases User.username" do
       described_class.from_cas(access_token)
-      expect(User.last.provider).to eq("provider")
-      expect(User.last.uid).to eq("1234")
+      expect(User.last.username).to eq("testuser123")
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,13 +25,13 @@ RSpec.describe User do
   end
 
   describe ".from_cas" do
-    let(:access_token) { access_token = OmniAuth::AuthHash.new(provider: "provider", uid: "testUSER123") }
+    let(:access_token) { OmniAuth::AuthHash.new(provider: "provider", uid: "testUSER123") }
 
     it "finds or creates user in the database" do
-      expect{ described_class.from_cas(access_token) }.to change(described_class, :count).by(1)
+      expect { described_class.from_cas(access_token) }.to change(described_class, :count).by(1)
     end
 
-    it "downcases User.username" do
+    it "downcases username" do
       described_class.from_cas(access_token)
       expect(described_class.last.username).to eq("testuser123")
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -23,4 +23,13 @@ RSpec.describe User do
       expect { described_class.expire_guest_accounts }.to change { described_class.count }.by(-100)
     end
   end
+
+  describe ".from_cas" do
+    it "finds the user in the database" do
+      access_token = OmniAuth::AuthHash.new(provider: "provider", uid: "1234")
+      described_class.from_cas(access_token)
+      expect(User.last.provider).to eq("provider")
+      expect(User.last.uid).to eq("1234")
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -28,12 +28,12 @@ RSpec.describe User do
     let(:access_token) { access_token = OmniAuth::AuthHash.new(provider: "provider", uid: "testUSER123") }
 
     it "finds or creates user in the database" do
-      expect{ described_class.from_cas(access_token) }.to change(User, :count).by(1)
+      expect{ described_class.from_cas(access_token) }.to change(described_class, :count).by(1)
     end
 
     it "downcases User.username" do
       described_class.from_cas(access_token)
-      expect(User.last.username).to eq("testuser123")
+      expect(described_class.last.username).to eq("testuser123")
     end
   end
 end

--- a/spec/services/db_migrate_uppercase_usernames_spec.rb
+++ b/spec/services/db_migrate_uppercase_usernames_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe DBMigrateUppercaseUsernames do
         uppercase_user.searches.create([{ query_params: 'history' }])
         expect { described_class.run }.to change(lowercase_user.searches, :count).by(1)
       end
+
+      it "doesn't merge search into existing user if they already have it" do
+        uppercase_user.searches.create([{ query_params: 'history' }])
+        lowercase_user.searches.create([{ query_params: 'history' }])
+        expect { described_class.run }.to change(lowercase_user.searches, :count).by(0)
+      end
     end
 
     context "when there is not an equivalent lowercase user" do

--- a/spec/services/db_migrate_uppercase_usernames_spec.rb
+++ b/spec/services/db_migrate_uppercase_usernames_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DBMigrateUppercaseUsernames do
+  let(:username) { "testUSER123" }
+  let!(:uppercase_user) { FactoryBot.create(:user, username: username) }
+  let!(:lowercase_user) { FactoryBot.create(:user, username: username.downcase) }
+  let(:migrator) { described_class.new }
+
+  describe ".find_uppercase_users" do
+    it "finds users with uppercase letters in their usernames" do
+      expect(migrator.find_uppercase_users).to eq([uppercase_user])
+    end
+  end
+
+  describe ".find_lowercase_user" do
+    it "finds user with lowercase equivalent of uppercase username" do
+      expect(migrator.find_lowercase_user(uppercase_user)).to eq(lowercase_user)
+    end
+  end
+
+  describe ".merge_bookmarks" do
+    it "transfer bookmarks to user with lowercase username" do
+      uppercase_user.bookmarks.create!([{ document_id: '9741216', document_type: 'SolrDocument' }])
+      expect { migrator.merge_bookmarks(uppercase_user, lowercase_user) }.to change(lowercase_user.bookmarks, :count).by(1)
+    end
+  end
+
+  describe ".merge_searches" do
+    it "merge searches" do
+      uppercase_user.searches.create!([{ query_params: 'history' }])
+      expect { migrator.merge_searches(uppercase_user, lowercase_user) }.to change(lowercase_user.searches, :count).by(1)
+    end
+  end
+
+  describe ".delete_uppercase_user" do
+    it "deletes users with uppercase letters in their usernames" do
+      expect { migrator.delete_uppercase_user(uppercase_user) }.to change(User, :count).by(-1)
+    end
+  end
+end

--- a/spec/services/db_migrate_uppercase_usernames_spec.rb
+++ b/spec/services/db_migrate_uppercase_usernames_spec.rb
@@ -5,38 +5,39 @@ require 'rails_helper'
 RSpec.describe DBMigrateUppercaseUsernames do
   let(:username) { "testUSER123" }
   let!(:uppercase_user) { FactoryBot.create(:user, username: username) }
-  let!(:lowercase_user) { FactoryBot.create(:user, username: username.downcase) }
-  let(:migrator) { described_class.new }
+  let(:lowercase_user) { FactoryBot.create(:user, username: username.downcase) }
 
-  describe ".find_uppercase_users" do
-    it "finds users with uppercase letters in their usernames" do
-      expect(migrator.find_uppercase_users).to eq([uppercase_user])
+  describe "self.run" do
+    context "when there is an equivalent lowercase user" do
+      it "merges bookmarks into existing user" do
+        lowercase_user
+        uppercase_user.bookmarks.create([{ document_id: '9741216', document_type: 'SolrDocument' }])
+        expect { described_class.run }.to change(lowercase_user.bookmarks, :count).by(1)
+      end
+
+      it "merges searches into existing user" do
+        lowercase_user
+        uppercase_user.searches.create([{ query_params: 'history' }])
+        expect { described_class.run }.to change(lowercase_user.searches, :count).by(1)
+      end
     end
-  end
 
-  describe ".find_lowercase_user" do
-    it "finds user with lowercase equivalent of uppercase username" do
-      expect(migrator.find_lowercase_user(uppercase_user)).to eq(lowercase_user)
-    end
-  end
+    context "when there is not an equivalent lowercase user" do
+      it "creates a new lowercase user" do
+        expect { described_class.run }.to change(User, :count).by(1)
+      end
 
-  describe ".merge_bookmarks" do
-    it "transfer bookmarks to user with lowercase username" do
-      uppercase_user.bookmarks.create!([{ document_id: '9741216', document_type: 'SolrDocument' }])
-      expect { migrator.merge_bookmarks(uppercase_user, lowercase_user) }.to change(lowercase_user.bookmarks, :count).by(1)
-    end
-  end
+      it "merges bookmarks into new user" do
+        uppercase_user.bookmarks.create([{ document_id: '9741216', document_type: 'SolrDocument' }])
+        described_class.run
+        expect(User.last.bookmarks.count).to eq(1)
+      end
 
-  describe ".merge_searches" do
-    it "merge searches" do
-      uppercase_user.searches.create!([{ query_params: 'history' }])
-      expect { migrator.merge_searches(uppercase_user, lowercase_user) }.to change(lowercase_user.searches, :count).by(1)
-    end
-  end
-
-  describe ".delete_uppercase_user" do
-    it "deletes users with uppercase letters in their usernames" do
-      expect { migrator.delete_uppercase_user(uppercase_user) }.to change(User, :count).by(-1)
+      it "merges searches into new user" do
+        uppercase_user.searches.create([{ query_params: 'history' }])
+        described_class.run
+        expect(User.last.searches.count).to eq(1)
+      end
     end
   end
 end


### PR DESCRIPTION
closes #2371

This PR shouldn't be merged until a scheduled migration time. Migration process:

- [ ] Turn on read only mode for orangelight https://github.com/pulibrary/princeton_ansible/blob/6554ff7ef44c38cbe11e5caee15ce9a6279af417/playbooks/orangelight_toggle_readonly.yml
- [ ] Merge and deploy this PR
- [ ] Run the migration task
- [ ] Turn off read only mode