### PR TITLE
Concurrent Alma API calls (with smaller batches)

### DIFF
--- a/app/assets/javascripts/book_covers.js.coffee
+++ b/app/assets/javascripts/book_covers.js.coffee
@@ -33,7 +33,6 @@ class BookCoverManager
         type_matches = $("*[data-#{identifier_type}]")
         thumbnail_element = type_matches.filter( -> $(this).data(identifier_type).indexOf(identifier) != -1)[0]
         thumbnail_url = info.thumbnail_url.replace(/zoom=./,"zoom=1").replace("&edge=curl","")
-        console.log(thumbnail_url)
         new_thumbnail = $("<img alt='' src='#{thumbnail_url}'>")
         $(thumbnail_element).html('')
         $(thumbnail_element).append(new_thumbnail)

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -35,45 +35,23 @@ export default class AvailabilityUpdater {
     // a search results page or a call number browse page
     if ($(".documents-list").length > 0) {
       const bib_ids = this.record_ids();
-      if (bib_ids.length < 1) { return; }
-
-      // Default batch size to the largest page size in OL. The number of actual bib_ids
-      // is usually the same as the number of bibs on the page.
-      var batch_size = 100;
-      var urlParams = new URLSearchParams(window.location.search);
-      if (urlParams.has('alma_batch_size')) {
-        // Break down the bibdata/Alma API calls in batches if and only if we have our
-        // super secret query string parameter in the URL.
-        batch_size = parseInt(urlParams.get('alma_batch_size'), 10);
+      if (bib_ids.length < 1) {
+        return;
       }
 
+      const batch_size = 10;
       const batches = this.ids_to_batches(bib_ids, batch_size);
-      console.log(`Batches requested at ${new Date().toISOString()}`);
-      console.log(`size: ${batch_size}, batches: ${batches.length}, ids: ${bib_ids.length}`);
-      for(var i= 0; i < batches.length; i++) {
+      console.log(`Requested at ${new Date().toISOString()}, batch size: ${batch_size}, batches: ${batches.length}, ids: ${bib_ids.length}`);
 
+      for(var i= 0; i < batches.length; i++) {
         var batch_url = `${this.bibdata_base_url}/bibliographic/availability.json?bib_ids=${batches[i].join()}`;
         console.log(`batch: ${i}, url: ${batch_url}`);
-
         $.getJSON(batch_url, this.process_results_list)
-          .fail((jqXHR, textStatus, errorThrown) => {
-            // TODO: how do we report/retry the correct a given batch
-            if (jqXHR.status == 429) {
-              if (allowRetry) {
-                console.log(`Retrying availability for records ${bib_ids.join()}`);
-                window.setTimeout(() => {
-                  this.update_availability_retrying();
-                  this.request_availability(false);
-                }, 1500);
-              } else {
-                console.error(`Failed to retrieve availability data for bibs (retry). Records ${bib_ids.join()}: ${errorThrown}`);
-                this.update_availability_undetermined();
-              }
-              return;
-            }
-            return console.error(`Failed to retrieve availability data for bibs. Records ${bib_ids.join(", ")}: ${errorThrown}`);
+          .fail((jqXHR, _textStatus, errorThrown) => {
+            // Log that there were problems fetching a batch. Unfortunately we don't know exactly
+            // which batch so we cannot include that information.
+            console.error(`Failed to retrieve availability data for batch. HTTP status: ${jqXHR.status}: ${errorThrown}`);
           });
-
       }
 
     // a show page

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -7,7 +7,6 @@
  * DS207: Consider shorter variations of null checks
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/master/docs/suggestions.md
  */
-import { bigIntLiteral } from '@babel/types';
 import { insert_online_link } from 'orangelight/insert_online_link'
 
 export default class AvailabilityUpdater {
@@ -38,6 +37,8 @@ export default class AvailabilityUpdater {
       const bib_ids = this.record_ids();
       if (bib_ids.length < 1) { return; }
 
+      // Default batch size to the largest page size in OL. The number of actual bib_ids
+      // is usually the same as the number of bibs on the page.
       var batch_size = 100;
       var urlParams = new URLSearchParams(window.location.search);
       if (urlParams.has('alma_batch_size')) {
@@ -47,6 +48,7 @@ export default class AvailabilityUpdater {
       }
 
       const batches = this.ids_to_batches(bib_ids, batch_size);
+      console.log(`Batches requested at ${new Date().toISOString()}`);
       console.log(`size: ${batch_size}, batches: ${batches.length}, ids: ${bib_ids.length}`);
       for(var i= 0; i < batches.length; i++) {
 
@@ -73,25 +75,6 @@ export default class AvailabilityUpdater {
           });
 
       }
-
-      // url = `${this.bibdata_base_url}/bibliographic/availability.json?bib_ids=${bib_ids.join()}`;
-      // return $.getJSON(url, this.process_results_list)
-      //   .fail((jqXHR, textStatus, errorThrown) => {
-      //     if (jqXHR.status == 429) {
-      //       if (allowRetry) {
-      //         console.log(`Retrying availability for records ${bib_ids.join()}`);
-      //         window.setTimeout(() => {
-      //           this.update_availability_retrying();
-      //           this.request_availability(false);
-      //         }, 1500);
-      //       } else {
-      //         console.error(`Failed to retrieve availability data for bibs (retry). Records ${bib_ids.join()}: ${errorThrown}`);
-      //         this.update_availability_undetermined();
-      //       }
-      //       return;
-      //     }
-      //     return console.error(`Failed to retrieve availability data for bibs. Records ${bib_ids.join(", ")}: ${errorThrown}`);
-      //   });
 
     // a show page
     } else if ($("*[data-availability-record='true']").length > 0) {
@@ -159,6 +142,7 @@ export default class AvailabilityUpdater {
   }
 
   process_results_list(records) {
+    console.log(`Batch finished at ${new Date().toISOString()}`);
     let result = [];
     for (let record_id in records) {
       const holding_records = records[record_id];


### PR DESCRIPTION
Make calls to bibdata/Alma in batches of 10 MMS_IDs, instead of using the page size that defaults to 20 but than can be as large as 100. Large batches (50 or 100 MMS_IDs) results in extremely slow response times from Alma.

For the default page size of 20 in Search results the code in this PR will result in two concurrent calls to bibdata (and hence Alma) of 10 MMS_IDs each. It seems that we get better performance this way at the cost of increasing our number of API call to Alma, but since we are way under the limit this is something that ExLibris recommended that we try.

Another thing to watch for is our **concurrent** number of calls to Alma since we are limited to (I believe) 25 calls per second. But again, since our current concurrency is not high this should not be a problem, but we should keep an eye on it after deploying this to production.

Fixes #2780

This PR also takes care of the problem where we were requesting more than 100 MMS_IDs from Alma at once and Alma was rejecting the request (Alma has a hard limit of 100 MMS_IDs). This issue happens if user requests page size of 100 and there are more than 100 **holdings** in the results. Not a common occurrence but something that showed up in our logs a few times.