### PR TITLE
Allow the user to put in an additional slash and still get the availability

### DIFF
--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -56,7 +56,7 @@ export default class AvailabilityUpdater {
 
     // a show page
     } else if ($("*[data-availability-record='true']").length > 0) {
-      this.id = window.location.pathname.split('/')[2];
+      this.id = window.location.pathname.split('/').pop();
       this.host_id = $("#main-content").data("host-id") || "";
       if (this.id.match(/^SCSB-\d+/)) {
         url = `${this.availability_url}?scsb_id=${this.id.replace(/^SCSB-/, '')}`;


### PR DESCRIPTION
https://catalog.princeton.edu/catalog/9920096813506421 - Availability loads
https://catalog.princeton.edu//catalog/9920096813506421 - Availability will never load.

Note the second slash before catalog in the last url.  This causes the id to be "catalog" vs "9920096813506421".  Pop will always take the last item, which should be the id.

I realize the users are unlikely to see this error, but I get it relatively often when cutting and pasting urls between servers.