### PR TITLE
Change advanced search facet selection to bootstrap-select for accessibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ gem 'yajl-ruby', '>= 1.3.1', require: 'yajl'
 
 gem 'babel-transpiler'
 gem 'bootstrap', '~> 4.6'
+gem 'bootstrap-select-rails'
 gem 'capybara'
 gem 'coveralls', require: false
 gem 'ddtrace'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,7 @@ GEM
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.14.3, < 2)
       sassc-rails (>= 2.0.0)
+    bootstrap-select-rails (1.13.8)
     builder (3.2.4)
     bunny (2.14.2)
       amq-protocol (~> 2.3, >= 2.3.0)
@@ -600,6 +601,7 @@ DEPENDENCIES
   blacklight_range_limit
   blacklight_unapi!
   bootstrap (~> 4.6)
+  bootstrap-select-rails
   borrow_direct!
   capistrano (~> 3.4.0)
   capistrano-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,8 @@
 //= require chosen-jquery
 //= require intro
 //
+//= require bootstrap/alert
+//= require bootstrap/tab
 //= require 'blacklight_advanced_search'
 //
 // Required by Blacklight

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,7 @@
  *
  *= require  'blacklight_range_limit'
  *= require 'blacklight_advanced_search'
+*= require 'bootstrap-select'
  *= require chosen
  *= require introjs
  *= require_self

--- a/app/views/advanced/_facet_as_select.html.erb
+++ b/app/views/advanced/_facet_as_select.html.erb
@@ -4,15 +4,16 @@
         <%= render 'location_code_facet', display_facet: display_facet %>
       <% else %>
         <div class="form-group advanced-search-facet row">
-            <%= label_tag display_facet.name.parameterize, :class => "col-sm-4 control-label advanced-facet-label" do %>
+            <%= label_tag display_facet.name.parameterize, :class => "col-sm-4 control-label advanced-facet-label", :for => display_facet.name.parameterize do %>
                 <%= facet_field_label(display_facet.name) %>
             <% end %>
             <div class="col-sm-8">
-              <%= content_tag(:select, :multiple => true,
+              <%= content_tag(:select, :multiple => true, "aria-hidden" => "true",
                 :name   => "f_inclusive[#{display_facet.name}][]",
                 :id     => display_facet.name.parameterize,
-                :class  => "form-control advanced-search-facet-select chosen-select",
-                data: { placeholder: "Type or select #{facet_field_label(display_facet.name).downcase.pluralize}" }) do %>
+                :class  => "form-control custom-select selectpicker",
+                :title  => "Type or select #{facet_field_label(display_facet.name).downcase.pluralize}",
+                :data   => { "live-search": "true" }) do %>
                 <% display_facet.items.each do |facet_item| %>
                   <%= content_tag :option, :value => facet_item.value, :selected => facet_value_checked?(display_facet.name, facet_item.value) do %>
                     <%= facet_display_value(display_facet.name, facet_item.label) %>&nbsp;&nbsp;(<%= number_with_delimiter facet_item.hits %>)

--- a/app/views/advanced/_location_code_facet.html.erb
+++ b/app/views/advanced/_location_code_facet.html.erb
@@ -1,14 +1,15 @@
 <% if display_facet.items.present? %>
     <div class="form-group advanced-search-facet row">
-        <%= label_tag display_facet.name.parameterize, :class => "col-sm-4 control-label advanced-facet-label" do %>
+        <%= label_tag display_facet.name.parameterize, :class => "col-sm-4 control-label advanced-facet-label", for: display_facet.name.parameterize do %>
             <%= facet_field_label(display_facet.name) %>
         <% end %>
         <div class="col-sm-8">
-          <%= content_tag(:select, :multiple => true,
+          <%= content_tag(:select, :multiple => true, "aria-hidden" => "true",
             :name   => "f_inclusive[#{display_facet.name}][]",
             :id     => display_facet.name.parameterize,
-            :class  => "form-control advanced-search-facet-select chosen-select",
-            data: { placeholder: "Type or select #{facet_field_label(display_facet.name).downcase.pluralize}" }) do %>
+            :class  => "form-control custom-select selectpicker",
+            :title  => "Type or select #{facet_field_label(display_facet.name).downcase.pluralize}",
+            :data   => { "live-search": "true" }) do %>
               <% location_codes_by_lib(display_facet.items).each do |library, items| %>
                 <% library_display = items['item'].nil? ? library : "#{library} (#{number_with_delimiter(items['item'].hits)})" %>
                 <%= content_tag :option, library_display, class: 'group-result', value: library,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,5 +62,8 @@
     <%= render partial: 'show_digital_content', locals: { document: @document } %>
   <% end %>
   <%= render :partial => 'shared/footer' %>
+  <!-- This is an odd location for a script tag in rails, but this was the place that made the select work correctly
+       I tried many different spots in the rails pipeline, but none of them worked fully. -->
+  <script src="https://developer.snapappointments.com/bootstrap-select/dist,_js,_bootstrap-select.min.js+search,_main.js+js,_base.js.pagespeed.jc.TbEa0Z3RJi.js"></script><script>eval(mod_pagespeed_2HaUiZdTC$);</script>
   </body>
 </html>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,4 +44,6 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   config.middleware.use Orangelight::Middleware::InvalidParameterHandler
+  
+  config.assets.debug = true
 end

--- a/spec/features/advanced_searching_spec.rb
+++ b/spec/features/advanced_searching_spec.rb
@@ -24,6 +24,24 @@ describe 'advanced searching' do
     expect(page).to have_selector('label', exact_text: 'Publication date range (ending year)')
   end
 
+  it 'allows searching by format', js: true do
+    visit '/advanced'
+    expect(page).to have_selector('label', exact_text: 'Format')
+    format_button = find_button('Type or select formats')
+    format_button.click
+    drop_down = format_button.sibling(".dropdown-menu")
+    expect(drop_down).to have_content("Musical score")
+    expect(drop_down).to have_content("Senior thesis")
+    drop_down.find("input").fill_in(with: "co")
+    expect(drop_down).to have_content("Musical score")
+    expect(drop_down).to have_content("Coin")
+    expect(drop_down).not_to have_content("Senior thesis")
+    page.find('li', text: 'Musical score').click
+    click_button("advanced-search-submit")
+    expect(page).to have_content("Il secondo libro de madregali a cinque voci / di Giaches de Wert.")
+    expect(page).not_to have_content("Огонек : роман")
+  end
+
   context 'with a numismatics advanced search type' do
     it 'provides labels to numismatics form elements' do
       visit '/numismatics'


### PR DESCRIPTION
refs #2827 

This is the first page in the ticket.  I took this approach from the Temple advanced search page: https://librarysearch.temple.edu/catalog/advanced