### PR TITLE
Refactorama: Incremental move toward system specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -81,7 +81,7 @@ Metrics/LineLength:
     - 'app/models/concerns/blacklight/solr/document/marc.rb'
     - 'app/helpers/advanced_helper.rb'
     - 'app/helpers/application_helper.rb'
-    - 'spec/features/searching_spec.rb'
+    - 'spec/system/searching_spec.rb'
     - 'spec/models/solr_document_spec.rb'
     - 'spec/controllers/bookmarks_controller_spec.rb'
     - 'spec/features/availability_spec.rb'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -74,6 +74,16 @@ RSpec.configure do |config|
     Warden.test_reset!
   end
 
+  ## Start to migrate to system specs.
+  # See https://medium.com/table-xi/a-quick-guide-to-rails-system-tests-in-rspec-b6e9e8a8b5f6
+  config.before(:each, type: :system) do
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by :selenium_chrome_headless
+  end
+
   config.before(:suite) { Rails.cache.clear }
   config.after { Rails.cache.clear }
 end

--- a/spec/system/searching_spec.rb
+++ b/spec/system/searching_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'searching' do
+describe 'Searching', type: :system, js: false do
   before do
     stub_holding_locations
   end


### PR DESCRIPTION
System specs have replaced feature specs. When we have time, we should
migrate all of the feature specs. This refactor adds configuration for
system specs and moves one test from feature to system.

Co-authored-by: Carolyn Cole <cac9@princeton.edu>
Co-authored-by: Anna Headley <anna.headley@gmail.com>
Co-authored-by: Alicia Cozine <879121+acozine@users.noreply.github.com>
Co-authored-by: Thanya Begum <tbegum@princeton.edu>