### PR TITLE
Remove no longer accepts string warning

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -214,8 +214,13 @@ module BlacklightHelper
 
   # pulls some logic from blacklight's `link_to_document` helper
   # then adds truncation of link text
-  def truncated_link(doc, field, opts = { counter: nil }, length = 200)
-    label = index_presenter(doc).label(field, opts).truncate(length).html_safe
+  def truncated_link(doc, field_or_string, opts = { counter: nil }, length = 200)
+    label_value = if field_or_string.class == String
+                    field_or_string
+                  else
+                    index_presenter(doc).label(field_or_string, opts)
+                  end
+    label = label_value.truncate(length).html_safe
     link_to label, url_for_document(doc), document_link_params(doc, opts)
   end
 


### PR DESCRIPTION
This removes the deprication warning that label on IndexPresenter no longer accepts strings
```
DEPRECATION WARNING: calling IndexPresenter.label with a String is deprecated. First argument must be a symbol. This will be removed in Blacklight 8. (called from truncated_link at /Users/colec/projects/orangelight/app/helpers/blacklight_helper.rb:218) 
```