### PR TITLE
Allow old ids to be update individually

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -51,17 +51,18 @@ class BookmarksController < CatalogController
 
     def bookmark_ids
       bookmarks = token_or_current_or_guest_user.bookmarks
-      bookmark_ids = bookmarks.collect { |b| b.document_id.to_s }
-      bookmark_ids + alma_ids(bookmark_ids)
+      bookmarks.collect { |b| convert_to_alma_id(b.document_id.to_s) }
     end
 
     def fetch_bookmarked_documents
       _, @documents = search_service.fetch(bookmark_ids, rows: bookmark_ids.length, fl: '*')
     end
 
-    def alma_ids(bookmark_ids)
-      bookmark_ids.map do |id|
+    def convert_to_alma_id(id)
+      if (id.length < 13) && (id =~ /^\d+$/)
         "99#{id}3506421"
+      else
+        id
       end
     end
 


### PR DESCRIPTION
Currently an entire set of new ids gets added to the old ids and the query is getting too large.
This change only updates the ids that need to be updated, so if a user has 100 bookmarks 100 ids get sent not 200

refs #2860