### PR TITLE
Add subject_facet to catalog controller (get subject browse working again)

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -156,6 +156,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'advanced_location_s', label: 'Holding location', include_in_request: false,
                                                   helper_method: :render_location_code
     config.add_facet_field 'name_title_browse_s', label: 'Author-title heading', include_in_request: false
+    config.add_facet_field 'subject_facet', show: false
 
     # Numismatics facets
     config.add_facet_field 'numismatic_collection_s', label: 'Numismatic Collection', include_in_request: false

--- a/spec/system/searching_spec.rb
+++ b/spec/system/searching_spec.rb
@@ -116,4 +116,9 @@ describe 'Searching', type: :system, js: false do
       expect(Rails.logger).to have_received(:error).with(/Invalid parameters passed in the request: Facet field author_s has a scalar value 汪精衛, 1883-1944/)
     end
   end
+
+  it 'filters using the subject_facet field' do
+    visit "/catalog?f[subject_facet][]=Japan%E2%80%94History"
+    expect(page).to have_content '1 entry found'
+  end
 end


### PR DESCRIPTION
Blacklight now needs facets to be defined in the catalog controller before it can display them. See https://github.com/projectblacklight/blacklight/issues/2401

This facet is linked from the subject browse and from show pages, so we also need to add it to the catalog controller.