### PR TITLE
Avoid constraint display error when facets applied in certain order

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -389,12 +389,11 @@ module ApplicationHelper
   end
 
   def render_location_code(value)
-    if value.is_a?(Array)
-      value.map { |v| render_location_code(v) }
-    else
-      location = Bibdata.holding_locations[value.to_sym]
-      location.nil? ? value : "#{value}: #{location_full_display(location)}"
+    values = Array(value).map do |loc|
+      location = Bibdata.holding_locations[loc.to_sym]
+      location.nil? ? loc : "#{loc}: #{location_full_display(location)}"
     end
+    values.count == 1 ? values.first : values
   end
 
   def holding_location_label(holding)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -389,8 +389,12 @@ module ApplicationHelper
   end
 
   def render_location_code(value)
-    location = Bibdata.holding_locations[value.to_sym]
-    location.nil? ? value : "#{value}: #{location_full_display(location)}"
+    if value.is_a?(Array)
+      value.map { |v| render_location_code(v) }
+    else
+      location = Bibdata.holding_locations[value.to_sym]
+      location.nil? ? value : "#{value}: #{location_full_display(location)}"
+    end
   end
 
   def holding_location_label(holding)

--- a/spec/helpers/locations_spec.rb
+++ b/spec/helpers/locations_spec.rb
@@ -48,6 +48,11 @@ RSpec.describe ApplicationHelper do
     it 'renders full location when value is a valid location code' do
       expect(render_location_code('firestone$clas')).to eq('firestone$clas: Firestone Library - Classics Collection')
     end
+
+    it 'can handle an array' do
+      expect(render_location_code(['firestone$clas'])).to eq('firestone$clas: Firestone Library - Classics Collection')
+      expect(render_location_code(['firestone$clas', 'blah'])).to eq(['firestone$clas: Firestone Library - Classics Collection', 'blah'])
+    end
   end
 
   describe '#holding_location_label' do

--- a/spec/system/searching_spec.rb
+++ b/spec/system/searching_spec.rb
@@ -121,4 +121,9 @@ describe 'Searching', type: :system, js: false do
     visit "/catalog?f[subject_facet][]=Japan%E2%80%94History"
     expect(page).to have_content '1 entry found'
   end
+
+  it 'allows user to successfully edit facet-only searches' do
+    visit "/catalog?f[format][]=Book&f_inclusive[advanced_location_s][]=Firestone+Library&search_field=advanced"
+    expect(page).to have_content "1 - 20 of 60"
+  end
 end


### PR DESCRIPTION
closes #2874 

Here is an easy way to trigger this issue on production:
1. Go to [the production catalog](https://catalog.princeton.edu/)
2. Select a Format Facet
3. Push Edit Search button
4. Select one or many holding locations
5. Push search button

Without the fix, you will get "We're sorry, but there was a problem processing the page you requested."  With the fix, you will at least get results, just with goofy-looking duplicative constraints view.