### PR TITLE
Remove rack-mini-profiler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -117,4 +117,3 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'solargraph'
 end
-gem 'rack-mini-profiler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,8 +389,6 @@ GEM
     public_suffix (4.0.6)
     racc (1.6.0)
     rack (2.2.3)
-    rack-mini-profiler (3.0.0)
-      rack (>= 1.2.0)
     rack-proxy (0.7.2)
       rack
     rack-test (1.1.0)
@@ -674,7 +672,6 @@ DEPENDENCIES
   openurl (~> 1.0)
   pg
   pry-byebug
-  rack-mini-profiler
   rails (~> 5.2.4)
   rails-controller-testing
   requests!


### PR DESCRIPTION
I accidentally added this gem in a previous PR.  This PR removes it again.