### PR TITLE
Leave default wait time alone

### DIFF
--- a/spec/support/capybara_selenium.rb
+++ b/spec/support/capybara_selenium.rb
@@ -64,4 +64,3 @@ end
 
 Capybara.server = :webrick
 Capybara.javascript_driver = :selenium_headless
-Capybara.default_max_wait_time = 60

--- a/spec/views/catalog/show.html.erb_spec.rb
+++ b/spec/views/catalog/show.html.erb_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'catalog/show' do
   context 'when entries describe resources published using multiple ARKs', js: true do
     it 'renders multiple viewers' do
       visit '/catalog/9970446223506421'
-      expect(page).to have_selector('div#viewer-container')
+      expect(page).to have_selector('div#viewer-container', wait: 60)
       expect(page).to have_selector('div#viewer-container_1')
     end
   end


### PR DESCRIPTION
Saves about a minute overall, and only one tests seems to need the 60 seconds.  I wonder if others will get flaky....