### PR TITLE
Display local subject headings

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -265,6 +265,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'class_year_s', label: 'Class year', helper_method: :link_to_search_value
     # Linked fields pushed to top of supplemental info
     config.add_show_field 'lc_subject_display', label: 'Subject(s)', helper_method: :subjectify
+    config.add_show_field 'local_subject_display', label: 'Princeton University subject(s)', helper_method: :subjectify
     config.add_show_field 'siku_subject_display', label: 'Chinese traditional subject(s)', helper_method: :subjectify
     config.add_show_field 'related_name_json_1display', hash: true
     config.add_show_field 'lcgft_s', label: 'Library of Congress genre', helper_method: :subjectify


### PR DESCRIPTION
Displays the field added in https://github.com/pulibrary/bibdata/pull/1854

Don't merge yet -- we are waiting on final details of how to display these from the Reparitive Metadata group.

closes #2977