### PR TITLE
Update login button wording, closes #2983

### DIFF
--- a/app/helpers/requests/request_helper.rb
+++ b/app/helpers/requests/request_helper.rb
@@ -13,7 +13,7 @@ module Requests
         end
       elsif current_user.guest?
         content_tag(:div) do
-          concat link_to I18n.t('requests.account.netid_login_msg'), '/users/auth/cas', role: 'menuitem', class: 'btn btn-primary', id: 'cas-login' # , current_user_name: current_user.uid)
+          concat link_to I18n.t('blacklight.login.netid_login_msg'), '/users/auth/cas', role: 'menuitem', class: 'btn btn-primary', id: 'cas-login' # , current_user_name: current_user.uid)
           # concat content_tag(:hr)
           # concat content_tag(:p, "or", class: "or-divider")
           # concat link_to I18n.t('requests.account.barcode_login_msg'), '/users/auth/barcode', role: 'menuitem', class: 'btn btn-outline-secondary', id: 'barcode-login'

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -71,10 +71,10 @@ en:
       search_history: 'Search History'
       account_page: 'Your Account'
     login:
-      netid_login_msg: "Princeton faculty, staff, and students log in with NetID"
+      netid_login_msg: 'Log in with netID'
       netid_button: 'Log in with netID'
       redirect_text: 'You will be redirected to the secure Princeton University Central Authentication Service (CAS) login.'
-      alma_login_msg: 'Log in with an Alma Account (affiliates)'
+      alma_login_msg: 'Log in with Alma Account (affiliates)'
       barcode_login_msg: 'Log in with a barcode (retirees, family members, guest borrowers, etc)'
       barcode_netid: 'Please log in with netID.'
       barcode_header: ''

--- a/config/locales/requests.en.yml
+++ b/config/locales/requests.en.yml
@@ -265,7 +265,6 @@ en:
     account:
       pul_auth: "You are logged as %{current_user_name}"
       unauthenticated: "Please sign in to see all requests"
-      netid_login_msg: "Princeton faculty, staff, and students log in with NetID"
       barcode_login_msg: "Log in with a barcode (affiliates, family members, guest borrowers, etc)"
       unauthenticated: "Please sign in to see all requests"
       logged_in: "Logged in as:"

--- a/spec/features/bookmarks_spec.rb
+++ b/spec/features/bookmarks_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'bookmarks' do
     it 'logging in brings user back to bookmarks page' do
       visit '/bookmarks'
       click_link "log in"
-      click_link "Princeton faculty, staff, and students log in with NetID"
+      click_link I18n.t('blacklight.login.netid_login_msg')
       expect(current_path).to eq bookmarks_path
     end
   end

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -46,7 +46,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
         it "displays three authentication options" do
           stub_scsb_availability(bib_id: "9999443553506421", institution_id: "PUL", barcode: '32101098722844')
           visit '/requests/9999443553506421?mfhd=22743365320006421'
-          expect(page).to have_content(I18n.t('requests.account.netid_login_msg'))
+          expect(page).to have_content(I18n.t('blacklight.login.netid_login_msg'))
           expect(page).not_to have_content(I18n.t('requests.account.barcode_login_msg'))
           expect(page).not_to have_content(I18n.t('requests.account.other_user_login_msg'))
         end

--- a/spec/features/search_history_spec.rb
+++ b/spec/features/search_history_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'search history' do
       it 'logging in brings user back to search history page' do
         visit '/search_history'
         click_link "log in"
-        click_link "Princeton faculty, staff, and students log in with NetID"
+        click_link I18n.t('blacklight.login.netid_login_msg')
         expect(current_path).to eq blacklight.search_history_path
       end
     end


### PR DESCRIPTION
Also consolidates to use a single translation key for both occurrences of the NetID login string