### PR TITLE
Only have dependabot do security fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,14 @@ updates:
       - "npm"
       - "dependencies"
       - "maintenance"
+    # Only create PRs for security updates
+    open-pull-requests-limit: 0
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
       interval: "daily"
+    # Only create PRs for security updates
+    open-pull-requests-limit: 0
     labels:
       - "ruby"
       - "dependencies"


### PR DESCRIPTION
According to the documentation here: https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file