### PR TITLE
keep jest in version 26 until we are ready to upgrade to 27 and then 28

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@webpack-cli/serve": "^1.6.1",
     "babel-jest": "26.6.3",
-    "jest": "^26.6.3",
+    "jest": "26.6.3",
     "jquery": "3.5.1",
     "webpack": "^4.29.6",
     "webpack-cli": "^4.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6209,7 +6209,7 @@ jest-worker@^26.5.0, jest-worker@^26.6.2:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jest@^26.6.3:
+jest@26.6.3:
   version "26.6.3"
   resolved "https://registry.yarnpkg.com/jest/-/jest-26.6.3.tgz#40e8fdbe48f00dfa1f0ce8121ca74b88ac9148ef"
   integrity sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==


### PR DESCRIPTION
there are breaking changes that we would need to take care off before upgrading jest to 27 and 28
https://jestjs.io/blog/2021/05/25/jest-27