### PR TITLE
These will cause issues with the next rails upgrade

### DIFF
--- a/config/alma.yml
+++ b/config/alma.yml
@@ -11,5 +11,8 @@ test:
 alma_qa:
   <<: *default
 
+staging:
+  <<: *default
+
 production:
   <<: *default

--- a/spec/models/requests/request_decorator_spec.rb
+++ b/spec/models/requests/request_decorator_spec.rb
@@ -2,7 +2,9 @@
 require 'rails_helper'
 
 describe Requests::RequestDecorator do
-  subject(:decorator) { described_class.new(request, view_context) }
+  include ActionView::TestCase::Behavior
+
+  subject(:decorator) { described_class.new(request, view) }
   let(:user) { FactoryBot.build(:user) }
   let(:valid_patron) do
     { "netid" => "foo", "first_name" => "Foo", "last_name" => "Request",
@@ -20,7 +22,6 @@ describe Requests::RequestDecorator do
   let(:solr_context) { instance_double(Requests::SolrOpenUrlContext) }
   let(:stubbed_questions) { { etas?: false } }
   let(:ldap) { {} }
-  let(:view_context) { ActionView::Base.new }
 
   describe "#bib_id" do
     it 'is the system id' do
@@ -206,7 +207,7 @@ describe Requests::RequestDecorator do
       request2 = instance_double(Requests::RequestableDecorator, aeon?: true)
       request = instance_double(Requests::Request, system_id: '123abc', mfhd: '112233', ctx: solr_context, requestable: [request1, request2], patron: patron, first_filtered_requestable: requestable,
                                                    display_metadata: { title: 'title', author: 'author', isbn: 'isbn' }, language: 'en')
-      decorator = described_class.new(request, view_context)
+      decorator = described_class.new(request, view)
       expect(decorator.only_aeon?).to be_truthy
     end
 
@@ -215,7 +216,7 @@ describe Requests::RequestDecorator do
       request2 = instance_double(Requests::RequestableDecorator, aeon?: false)
       request = instance_double(Requests::Request, system_id: '123abc', mfhd: '112233', ctx: solr_context, requestable: [request1, request2], patron: patron, first_filtered_requestable: requestable,
                                                    display_metadata: { title: 'title', author: 'author', isbn: 'isbn' }, language: 'en')
-      decorator = described_class.new(request, view_context)
+      decorator = described_class.new(request, view)
       expect(decorator.only_aeon?).to be_falsey
     end
   end
@@ -224,21 +225,21 @@ describe Requests::RequestDecorator do
     it "shows the library name" do
       request = instance_double(Requests::Request, system_id: '123abc', mfhd: '112233', ctx: solr_context, requestable: [], patron: patron, first_filtered_requestable: requestable,
                                                    display_metadata: { title: 'title', author: 'author', isbn: 'isbn' }, language: 'en', holdings: { '112233' => { "library" => 'abc' } })
-      decorator = described_class.new(request, view_context)
+      decorator = described_class.new(request, view)
       expect(decorator.location_label).to eq('abc')
     end
 
     it "shows the library name and location" do
       request = instance_double(Requests::Request, system_id: '123abc', mfhd: '112233', ctx: solr_context, requestable: [], patron: patron, first_filtered_requestable: requestable,
                                                    display_metadata: { title: 'title', author: 'author', isbn: 'isbn' }, language: 'en', holdings: { '112233' => { "library" => 'abc', "location" => "123" } })
-      decorator = described_class.new(request, view_context)
+      decorator = described_class.new(request, view)
       expect(decorator.location_label).to eq('abc - 123')
     end
 
     it "shows the nothing if the holding is empty" do
       request = instance_double(Requests::Request, system_id: '123abc', mfhd: '112233', ctx: solr_context, requestable: [], patron: patron, first_filtered_requestable: requestable,
                                                    display_metadata: { title: 'title', author: 'author', isbn: 'isbn' }, language: 'en', holdings: {})
-      decorator = described_class.new(request, view_context)
+      decorator = described_class.new(request, view)
       expect(decorator.location_label).to eq('')
     end
   end

--- a/spec/models/requests/requestable_decorator_spec.rb
+++ b/spec/models/requests/requestable_decorator_spec.rb
@@ -3,7 +3,9 @@ require 'rails_helper'
 
 # rubocop:disable Metrics/BlockLength
 describe Requests::RequestableDecorator do
-  subject(:decorator) { described_class.new(requestable, view_context) }
+  include ActionView::TestCase::Behavior
+
+  subject(:decorator) { described_class.new(requestable, view) }
   let(:user) { FactoryBot.build(:user) }
   let(:valid_patron) do
     { "netid" => "foo", "first_name" => "Foo", "last_name" => "Request",
@@ -16,7 +18,6 @@ describe Requests::RequestableDecorator do
   let(:requestable) { instance_double(Requests::Requestable, stubbed_questions) }
   let(:default_stubbed_questions) { { patron: patron, etas?: false, item_data?: true, circulates?: true, eligible_to_pickup?: true, on_shelf?: false, recap?: false, annex?: false, holding_library_in_library_only?: false, scsb_in_library_use?: false, on_order?: false, in_process?: false, traceable?: false, aeon?: false, borrow_direct?: false, ill_eligible?: false, clancy?: false, held_at_marquand_library?: false, item_at_clancy?: false, cul_avery?: false, resource_shared?: false, eligible_for_library_services?: true } }
   let(:stubbed_questions) { default_stubbed_questions.merge(etas?: false) }
-  let(:view_context) { ActionView::Base.new }
   let(:ldap) { {} }
 
   describe "#digitize?" do


### PR DESCRIPTION
- Fixing them now while they're still fresh
- Explicitly give staging environment for alma (I believe it was falling back to the default, which it will no longer do in rails 6.1)
- Use built-in helper fixtures for tests