### PR TITLE
Use omniauth-rails_csrf_protection gem to resolve CVE-2015-9284

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'faraday', '~> 0.17'
 gem 'faraday-cookie_jar'
 gem 'global'
 gem 'omniauth-cas'
+gem "omniauth-rails_csrf_protection"
 gem 'yajl-ruby', '>= 1.3.1', require: 'yajl'
 
 gem 'babel-transpiler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -356,6 +356,9 @@ GEM
       addressable (~> 2.3)
       nokogiri (~> 1.5)
       omniauth (~> 1.2)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     openurl (1.0.0)
       marc
       scrub_rb (~> 1.0)
@@ -654,6 +657,7 @@ DEPENDENCIES
   modernizr-rails
   net-ldap
   omniauth-cas
+  omniauth-rails_csrf_protection
   openurl (~> 1.0)
   pg
   pry-byebug

--- a/app/views/shared/_login.html.erb
+++ b/app/views/shared/_login.html.erb
@@ -1,7 +1,7 @@
  <% do_not_show_barcode ||= false %>
  <div class='card border-0'>
     <div class='card-body text-center'>
-      <%= link_to t('blacklight.login.netid_login_msg'), main_app.user_cas_omniauth_authorize_path, :class => 'btn btn-primary' %>
+      <%= link_to t('blacklight.login.netid_login_msg'), main_app.user_cas_omniauth_authorize_path, method: :post, :class => 'btn btn-primary' %>
       <hr>
       <p class="or-divider">
       or

--- a/spec/features/email_authentication_spec.rb
+++ b/spec/features/email_authentication_spec.rb
@@ -24,7 +24,7 @@ describe 'email form' do
     valid_patron_record_uri = "#{ENV['voyager_api_base']}/vxws/MyAccountService?patronId=#{valid_voyager_patron[:patron_id]}&patronHomeUbId=1@DB"
     stub_request(:get, valid_patron_record_uri)
       .to_return(status: 200, body: voyager_account_response, headers: {})
-    sign_in user
+    login_as user
     visit "/catalog/#{bibid}/email"
     expect(page).to have_button('Send')
   end

--- a/spec/support/features/session_helpers.rb
+++ b/spec/support/features/session_helpers.rb
@@ -25,18 +25,5 @@ module Features
       fill_in 'Password confirmation', with: password
       click_button 'Sign up'
     end
-
-    # Poltergeist-friendly sign-in
-    # Use this in feature tests
-    def sign_in(who = :user)
-      user = if who.instance_of?(User)
-               who.username
-             else
-               FactoryBot.create(:valid_princeton_patron).username
-             end
-      OmniAuth.config.test_mode = true
-      OmniAuth.config.add_mock(:cas, uid: user)
-      visit user_cas_omniauth_authorize_path
-    end
   end
 end

--- a/spec/views/feedback/feedback_spec.rb
+++ b/spec/views/feedback/feedback_spec.rb
@@ -48,7 +48,7 @@ describe 'Feedback Form', type: :feature do
     it 'Populates Email Field' do
       stub_request(:get, "#{Requests.config['bibdata_base']}/patron/#{user.uid}")
         .to_return(status: 200, body: valid_patron_response, headers: {})
-      sign_in user
+      login_as user
       visit('/catalog/4747577')
       click_link('Feedback')
       expect(page).to have_field('feedback_form_email', with: "#{user.uid}@princeton.edu")


### PR DESCRIPTION
- Remove test helper that does not work with csrf_protection gem (and does not seem to be needed)

Closes #3084