### PR TITLE
Add honeybadger section to the bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,3 +17,8 @@ Include screenshots, or links and browser version if relevant
 
 **Impact of this bug**
 E.g. "I can't work until this is fixed" or "I have a workaround"
+
+**Honeybadger link and code snippet, if applicable**
+
+```
+```


### PR DESCRIPTION
Could be helpful for the runner when creating issues from honeybadger errors