### PR TITLE
Add feature to switch between ReShare and Relais

### DIFF
--- a/app/helpers/requests/request_helper.rb
+++ b/app/helpers/requests/request_helper.rb
@@ -83,5 +83,36 @@ module Requests
         "/catalog/#{id}"
       end
     end
+
+    def zero_results_link(query_params, search_field)
+      if Flipflop.reshare_for_borrow_direct?
+        reshare_link(query_params, search_field)
+      else
+        borrow_direct_path(q: query_params)
+      end
+    end
+
+    def reshare_link(query_params, search_field)
+      if query_params
+        "https://borrowdirect.reshare.indexdata.com/Search/Results?lookfor=#{query_params}&type=#{reshare_type(search_field)}"
+      else
+        "https://borrowdirect.reshare.indexdata.com/Search/Results"
+      end
+    end
+
+    def reshare_type(search_field)
+      case search_field
+      when 'all_fields'
+        'AllFields'
+      when 'author'
+        'Author'
+      when 'subject'
+        'Subject'
+      when 'title'
+        'Title'
+      else
+        'AllFields'
+      end
+    end
   end
 end

--- a/app/views/catalog/_zero_results.html.erb
+++ b/app/views/catalog/_zero_results.html.erb
@@ -1,6 +1,6 @@
 <h2><%= t 'blacklight.search.zero_results.title' %></h2>
 <div id="documents" class="noresults">
-  <h3><%= link_to(t('blacklight.search.zero_results.try_borrow_direct'), borrow_direct_path(q: params[:q])) %></h3>
+  <h3><%= link_to(t('blacklight.search.zero_results.try_borrow_direct'), zero_results_link(params[:q], params[:search_field])) %></h3>
   <p>To learn more about this service, consult the Library <%= link_to('Borrow Direct', 'https://library.princeton.edu/services/borrowdirect') %> information page.</p>
   <ul>
 

--- a/app/views/shared/_announcement.html.erb
+++ b/app/views/shared/_announcement.html.erb
@@ -1,11 +1,5 @@
 <%# to remove messages altogether, set this to empty string %>
-<% 
-    if Flipflop.test_header? && !Rails.env.production?
-      message = 'Flipflop test_header feature is on!'
-    else
-      message = ''
-    end
-%>
+<% message = '' %>
 <% if Orangelight.read_only_mode %>
   <div class="col-12 alert alert-warning announcement">
     <div class="container">

--- a/config/features.rb
+++ b/config/features.rb
@@ -19,7 +19,11 @@ Flipflop.configure do
 
   # Declare your features, e.g:
   #
-  feature :test_header,
+  # feature :test_header,
+  #   default: false,
+  #   description: "Display a test header to show if flipflop is working."
+
+  feature :reshare_for_borrow_direct,
     default: false,
-    description: "Display a test header to show if flipflop is working."
+    description: "When on / true, uses the new ReShare provider for BorrowDirect. When off / false, uses the older Relais provider for BorrowDirect."
 end

--- a/spec/helpers/requests/request_helper_spec.rb
+++ b/spec/helpers/requests/request_helper_spec.rb
@@ -12,4 +12,67 @@ RSpec.describe Requests::RequestHelper, type: :helper do
       expect(helper.request_title).to eq(I18n.t('requests.default.form_title'))
     end
   end
+
+  describe '#zero_results_link' do
+    let(:test_strategy) { Flipflop::FeatureSet.current.test! }
+    let(:query_params) { 'asdf' }
+    let(:zero_results_link) { helper.zero_results_link(query_params, search_field) }
+
+    context 'with old borrow direct provider' do
+      before do
+        test_strategy.switch!(:reshare_for_borrow_direct, false)
+      end
+      context 'with a standard keyword query' do
+        let(:search_field) { 'all_fields' }
+
+        it 'returns the link to borrow direct' do
+          expect(zero_results_link).to eq('/borrow-direct?q=asdf')
+        end
+      end
+      context 'with a title keyword query' do
+        let(:search_field) { 'title' }
+
+        it 'returns the link to borrow direct' do
+          expect(zero_results_link).to eq('/borrow-direct?q=asdf')
+        end
+      end
+    end
+    context 'with new borrow direct provider' do
+      before do
+        test_strategy.switch!(:reshare_for_borrow_direct, true)
+      end
+      context 'with a standard keyword query' do
+        let(:expected_url) { 'https://borrowdirect.reshare.indexdata.com/Search/Results?lookfor=asdf&type=AllFields' }
+        let(:search_field) { 'all_fields' }
+
+        it 'returns the link to borrow direct' do
+          expect(zero_results_link).to eq(expected_url)
+        end
+      end
+      context 'with a title keyword query' do
+        let(:expected_url) { 'https://borrowdirect.reshare.indexdata.com/Search/Results?lookfor=asdf&type=Title' }
+        let(:search_field) { 'title' }
+
+        it 'returns the link to borrow direct' do
+          expect(zero_results_link).to eq(expected_url)
+        end
+      end
+      context 'with a subject keyword query' do
+        let(:expected_url) { 'https://borrowdirect.reshare.indexdata.com/Search/Results?lookfor=asdf&type=Subject' }
+        let(:search_field) { 'subject' }
+
+        it 'returns the link to borrow direct' do
+          expect(zero_results_link).to eq(expected_url)
+        end
+      end
+      context 'with an author keyword query' do
+        let(:expected_url) { 'https://borrowdirect.reshare.indexdata.com/Search/Results?lookfor=asdf&type=Author' }
+        let(:search_field) { 'author' }
+
+        it 'returns the link to borrow direct' do
+          expect(zero_results_link).to eq(expected_url)
+        end
+      end
+    end
+  end
 end

--- a/spec/system/searching_spec.rb
+++ b/spec/system/searching_spec.rb
@@ -88,10 +88,29 @@ describe 'Searching', type: :system, js: false do
     end
   end
   context 'with an invalid field list parameter in the advanced search' do
-    it 'will return results without an error' do
-      visit '/catalog?q1=NSF%20Series&search_field=advanced&f1=in_series2121121121212.1'
-      expect { page }.not_to raise_error
-      expect(page).to have_content 'No results found for your search'
+    let(:test_strategy) { Flipflop::FeatureSet.current.test! }
+
+    context 'with old borrow direct provider' do
+      before do
+        test_strategy.switch!(:reshare_for_borrow_direct, false)
+      end
+      it 'will return results without an error' do
+        visit '/catalog?q1=NSF%20Series&search_field=advanced&f1=in_series2121121121212.1'
+        expect { page }.not_to raise_error
+        expect(page).to have_content 'No results found for your search'
+        expect(page).to have_link('Try Borrow Direct', href: '/borrow-direct')
+      end
+    end
+    context 'with new borrow direct provider' do
+      before do
+        test_strategy.switch!(:reshare_for_borrow_direct, true)
+      end
+      it 'will return results without an error' do
+        visit '/catalog?q1=NSF%20Series&search_field=advanced&f1=in_series2121121121212.1'
+        expect { page }.not_to raise_error
+        expect(page).to have_content 'No results found for your search'
+        expect(page).to have_link('Try Borrow Direct', href: 'https://borrowdirect.reshare.indexdata.com/Search/Results')
+      end
     end
   end
   context 'when searching with an invalid facet parameter' do


### PR DESCRIPTION
- Right now just changes BorrowDirect url on zero_results page
- To test:
  - Go to catalog-staging and do a keyword search that has no results (e.g. `adsfga`)
  - This will take you to a page that has a blue link to "Try Borrow Direct"
  - Hover over this link and note the url
  - Go to https://catalog-staging.princeton.edu/features and toggle the "Reshare for borrow direct" feature
  - Refresh the previous page and hover over the link and note the url
  - One should be for the internal `/borrow-direct` path, the other should be for the external ReShare borrow direct link

Closes #3091