### PR TITLE
i1227: add a title to universal viewer iframe

### DIFF
--- a/app/javascript/orangelight/figgy_manifest_manager.js
+++ b/app/javascript/orangelight/figgy_manifest_manager.js
@@ -55,6 +55,7 @@ class FiggyViewer {
   constructIFrame() {
     const iframeElement = document.createElement("iframe")
     iframeElement.setAttribute("allowFullScreen", "true")
+    iframeElement.setAttribute("title", "Digital content viewer")
     iframeElement.id = `iframe-${this.idx + 1}`
 
     // This needs to be retrieved using Global
@@ -265,4 +266,8 @@ class FiggyManifestManager {
   }
 }
 
-export default FiggyManifestManager
+export default FiggyManifestManager;
+
+export const exportedForTesting = {
+  FiggyViewer
+};

--- a/spec/javascript/orangelight/figgy_manifest_manager.spec.js
+++ b/spec/javascript/orangelight/figgy_manifest_manager.spec.js
@@ -1,0 +1,16 @@
+import { exportedForTesting } from 'orangelight/figgy_manifest_manager';
+const { FiggyViewer } = exportedForTesting;
+
+describe('RelatedRecords', function() {
+    afterEach(jest.clearAllMocks);
+
+    test('viewer iframe has a title', async() => {
+        document.body.innerHTML = '<div id="container"></div>';
+        const element = document.getElementById('container');
+        const viewer = new FiggyViewer(0, element, 'https://example.com', []);
+        viewer.render().then(() => {
+            const element = document.getElementById('iframe-1');
+            expect(element.getAttribute('title')).toBe('Digital content viewer');
+        });
+    });
+});


### PR DESCRIPTION
closes #1227 

To test this out with voiceover:

1. Go to https://catalog.princeton.edu/catalog/9946093213506421
1. Turn on voiceover
2. Tab until focus is on the viewer
3. Note that voiceover just starts reading a humongous URL.
4. Repeat steps 1-3 in an environment with this branch deployed.
5. Note that voiceover is much more concise: "Entering digital content viewer scroll area"

If you aren't able to complete the steps above, here is a video comparing the two: https://drive.google.com/file/d/15G2F4icya77CjBviY_ecA4S1CcVETjbt/view?usp=sharing