### PR TITLE
Redirect to login, do not use partial for requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,9 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  def after_sign_in_path_for(_resource)
+  def after_sign_in_path_for(resource)
+    stored_location = stored_location_for(resource)
+
     if referrer.present? && (!referrer.include?("sign_in") && !origin&.include?("redirect-to-alma"))
       referrer
     elsif origin.present?
@@ -23,6 +25,8 @@ class ApplicationController < ActionController::Base
     elsif !request.env['omniauth.origin'].nil? &&
           /request|borrow-direct|email|bookmarks|search_history|redirect-to-alma/.match(request.env['omniauth.origin'])
       request.env['omniauth.origin']
+    elsif stored_location.present?
+      stored_location
     else
       account_path
     end

--- a/app/controllers/requests/request_controller.rb
+++ b/app/controllers/requests/request_controller.rb
@@ -5,6 +5,8 @@ include Requests::ApplicationHelper
 
 module Requests
   class RequestController < ApplicationController
+    before_action :authenticate_user!, except: [:index]
+
     def index
       redirect_to('/')
     end

--- a/app/views/requests/request/_form.html.erb
+++ b/app/views/requests/request/_form.html.erb
@@ -1,8 +1,4 @@
-<% if @user.guest && @patron.blank? && !suppress_login(@request)%>
-  <%= simple_form_for(:request, { url: login_url(@request), method: :post, html: { id: 'logins'}} ) do |l| %>
-    <%= render partial: 'user_login_options', locals: { l: l } %>
-  <% end %>
-<% elsif !@user.guest && @patron.blank? %>
+<% if !@user.guest && @patron.blank? %>
   <%= render partial: 'auth_user_lookup_fail' %>
 <% else %>
   <%= render partial: 'request_form' %>

--- a/app/views/requests/request/_user_login_options.html.erb
+++ b/app/views/requests/request/_user_login_options.html.erb
@@ -1,5 +1,0 @@
-<div class="row">
-  <div id="punetid-form" role="menu" aria-hidden="false" style="display: block; text-align:center; width: 100%; margin: 0 auto; ">
-    <%= render  partial: 'shared/login' %>
-  </div>
-</div>

--- a/spec/controllers/requests/request_controller_spec.rb
+++ b/spec/controllers/requests/request_controller_spec.rb
@@ -9,6 +9,9 @@ describe Requests::RequestController, type: :controller, vcr: { cassette_name: '
   let(:user) { FactoryBot.create(:user) }
 
   describe 'POST #generate' do
+    before do
+      sign_in(user)
+    end
     it 'handles access patron params when the user form is posted' do
       post :generate, params: { request: { username: 'foobar', email: 'foo@bar.com' },
                                 source: 'pulsearch',

--- a/spec/features/request_options_spec.rb
+++ b/spec/features/request_options_spec.rb
@@ -17,13 +17,22 @@ describe 'Request Options' do
         .to_return(status: 200, body: {}.to_json, headers: {})
       visit '/catalog/99113436223506421'
     end
-
-    it 'clicking the request button loads the request page' do
-      using_wait_time 5 do
-        click_link 'Request'
-        expect(current_path).to eq "/requests/99113436223506421"
+    # rubocop:disable RSpec/AnyInstance
+    context 'as a logged in user' do
+      let(:user) { FactoryBot.create(:user) }
+      before do
+        allow_any_instance_of(Devise::Controllers::StoreLocation).to receive(:stored_location_for)
+          .and_return('/catalog/99113436223506421')
+        sign_in(user)
+      end
+      it 'clicking the request button loads the request page' do
+        using_wait_time 5 do
+          click_link 'Request'
+          expect(current_path).to eq "/requests/99113436223506421"
+        end
       end
     end
+    # rubocop:enable RSpec/AnyInstance
   end
 
   describe 'On site access status in non-circulate location', js: true do

--- a/spec/fixtures/bibdata/scsbcul_holding_locations.json
+++ b/spec/fixtures/bibdata/scsbcul_holding_locations.json
@@ -1,0 +1,35 @@
+{
+  "label": "Remote Storage",
+  "code": "scsbcul",
+  "aeon_location": false,
+  "recap_electronic_delivery_location": true,
+  "open": false,
+  "requestable": true,
+  "always_requestable": false,
+  "circulates": true,
+  "remote_storage": "recap_rmt",
+  "fulfillment_unit": null,
+  "library": {
+    "label": "ReCAP",
+    "code": "recap",
+    "order": 0
+  },
+  "holding_library": null,
+  "delivery_locations": [
+    {
+      "label": "Firestone Circulation Desk",
+      "address": "One Washington Rd. Princeton, NJ 08544",
+      "phone_number": "609 258-2345",
+      "contact_email": "fstcirc@princton.edu",
+      "gfa_pickup": "QX",
+      "staff_only": false,
+      "pickup_location": false,
+      "digital_location": false,
+      "library": {
+        "label": "Firestone Library",
+        "code": "firestone",
+        "order": 0
+      }
+    }
+  ]
+}

--- a/spec/requests/application_spec.rb
+++ b/spec/requests/application_spec.rb
@@ -61,6 +61,30 @@ RSpec.describe ApplicationController, type: :request do
           expect(response).to redirect_to('/bookmarks')
         end
       end
+      # rubocop:disable RSpec/AnyInstance
+      context 'only with devise stored_location_for' do
+        before do
+          allow_any_instance_of(Devise::Controllers::StoreLocation).to receive(:stored_location_for)
+            .and_return('/requests/SCSB-2143785')
+        end
+        context 'with a CAS user' do
+          let(:user) { FactoryBot.create(:valid_princeton_patron) }
+
+          it 'redirects the user to the stored resource' do
+            get '/users/sign_in'
+            expect(response).to redirect_to('/requests/SCSB-2143785')
+          end
+        end
+        context 'with an Alma user' do
+          let(:user) { FactoryBot.create(:valid_alma_patron) }
+
+          it 'redirects the user to the stored resource' do
+            get '/users/sign_in'
+            expect(response).to redirect_to('/requests/SCSB-2143785')
+          end
+        end
+      end
+      # rubocop:enable RSpec/AnyInstance
     end
 
     context "as an unauthenticated user" do


### PR DESCRIPTION
Rather than using a partial when someone logs in to make a request, which causes some javascript collisions, redirect the user to the main login page, and then back to the requests page once they've authenticated.

Closes #3206 