### PR TITLE
Right-align rtl titles on browse

### DIFF
--- a/app/assets/stylesheets/components/overrides.scss
+++ b/app/assets/stylesheets/components/overrides.scss
@@ -72,6 +72,17 @@ dd.rtl {
   text-align: right;
 }
 
+td.rtl {
+  direction: rtl;
+  text-align: right;
+}
+
+td.rtl::before {
+  direction: ltr;
+  text-align: left;
+  float: left;
+}
+
 rtl {
   display: inline;
   float: right;

--- a/app/assets/stylesheets/components/overrides.scss
+++ b/app/assets/stylesheets/components/overrides.scss
@@ -77,7 +77,7 @@ td.rtl {
   text-align: right;
 }
 
-td.rtl::before {
+td[dir="rtl"]::before {
   text-align: left;
 }
 

--- a/app/assets/stylesheets/components/overrides.scss
+++ b/app/assets/stylesheets/components/overrides.scss
@@ -78,14 +78,7 @@ td.rtl {
 }
 
 td.rtl::before {
-  direction: ltr;
   text-align: left;
-  float: left;
-}
-
-rtl {
-  display: inline;
-  float: right;
 }
 
 // .dl-horizontal dt {
@@ -162,9 +155,6 @@ address {
 
 [dir="rtl"] {
   font-family: verdana, arial;
-}
-
-li[dir="rtl"] {
   text-align: right;
 }
 

--- a/app/assets/stylesheets/components/tables.scss
+++ b/app/assets/stylesheets/components/tables.scss
@@ -95,8 +95,8 @@ td {
       /* Top/left values mimic padding */
       top: 6px;
 
-      // left: 6px;
-      width: 45%;
+      left: 6px;
+      width: 100%;
       white-space: nowrap;
       font-weight: 700;
       font-family: Arial, sans-serif;

--- a/app/views/orangelight/browsables/index.html.erb
+++ b/app/views/orangelight/browsables/index.html.erb
@@ -84,9 +84,9 @@
             <% end %>
           </td>
 
-          <td class="<%=orangelight_name.dir%>"><%= orangelight_name.title %></td>
-          <td><%= orangelight_name.author %></td>
-          <td><%= orangelight_name.date %></td>
+          <td dir="<%=orangelight_name.title.dir%>"><%= orangelight_name.title %></td>
+          <td dir="<%=orangelight_name&.author&.dir%>"><%= orangelight_name.author %></td>
+          <td dir="<%=orangelight_name&.date&.dir%>"><%= orangelight_name.date %></td>
         <% if orangelight_name.id == @match && @exact_match %>
             </strong>
           </tr>


### PR DESCRIPTION
Closes #1824 

Call number browse - narrow:
![image](https://user-images.githubusercontent.com/45948126/193636999-54fd73d8-c892-46a4-9424-59abcaedb55f.png)

Call number browse - wide:
![image](https://user-images.githubusercontent.com/45948126/193642674-024a56d6-ee0b-4eee-ab3a-0b59ba20153b.png)

Show page title:
![image](https://user-images.githubusercontent.com/45948126/193637126-9e4a8b31-8c0c-4b17-a76d-396424c2b1bf.png)

Index page title:
![image](https://user-images.githubusercontent.com/45948126/193644118-d060b2d2-f06d-417b-9fd4-ca3ed90266b6.png)
