### PR TITLE
Use rails helpers for labels

### DIFF
--- a/app/views/shared/_login.html.erb
+++ b/app/views/shared/_login.html.erb
@@ -15,7 +15,7 @@
     <div class='card-body'>
       <%= simple_form_for(@user, url:  main_app.user_alma_omniauth_callback_path, class: 'form-horizontal', data: { toggle: 'validator' }, :method => :post)  do |f| %>
         <div class='field form-group col-md-12 row'>
-          <%= f.label 'Alma user name', class: 'control-label col-md-2 col-form-label' %>
+          <%= label_tag 'username', 'Alma user name', class: 'control-label col-md-2 col-form-label' %>
           <div class='col-md-5 <%= 'has-error' if flash[:username] %>'>
             <%= text_field_tag 'username', '', class: 'form-control', autocomplete: 'off' %>
             <% if flash[:username] %>
@@ -26,7 +26,7 @@
         </div>
 
         <div class='field form-group col-md-12 row'>
-          <%= f.label 'Password', class: 'control-label col-md-2 col-form-label' %>
+          <%= label_tag 'password', 'Password', class: 'control-label col-md-2 col-form-label' %>
           <div class='col-md-5 <%= 'has-error' if flash[:password] %>'>
             <%= password_field_tag 'password', '', class: 'form-control', autocomplete: 'off' %>
             <% if flash[:password] %>

--- a/spec/features/login_account_spec.rb
+++ b/spec/features/login_account_spec.rb
@@ -55,6 +55,21 @@ describe 'Account login' do
           expect(page.current_url).to include("https://princeton.alma.exlibrisgroup.com/discovery/")
         end
       end
+
+      it 'has accessible labels for Alma login inputs' do
+        visit '/users/sign_in'
+        click_link("Log in with Alma Account (affiliates)")
+        # Username
+        expect(page).to have_selector('#username')
+        username_label_element = page.find('label', text: 'Alma user name')
+        expect(username_label_element['for']).to eq("username")
+        expect(username_label_element.text).to eq('Alma user name')
+        # Password
+        expect(page).to have_selector('#password')
+        password_label_element = page.find('label', text: 'Password')
+        expect(password_label_element['for']).to eq('password')
+        expect(password_label_element.text).to eq('Password')
+      end
     end
     context "as an authenticated user" do
       before do


### PR DESCRIPTION
- This form mixes simple_form and Rails helpers, switching to all Rails helpers made keeping the look consistent easier

Look, it looks the same!
![image](https://user-images.githubusercontent.com/45948126/194405556-5a3c404b-cb04-49fc-bd4d-7deeb26898c8.png)


Closes #3216 