### PR TITLE
Remove trailing characters from borrowdirect banner

### DIFF
--- a/app/views/shared/_announcement.html.erb
+++ b/app/views/shared/_announcement.html.erb
@@ -1,5 +1,5 @@
 <%# to remove messages altogether, set this to empty string %>
-<% message = 'New BorrowDirect platform to launch 12/13/2022.' %>
+<% message = 'New BorrowDirect platform to launch 12/13/2022' %>
 <% if Orangelight.read_only_mode %>
   <div class="col-12 alert alert-warning announcement">
     <div class="container">
@@ -13,7 +13,7 @@
   <div class="col-12 alert alert-warning announcement">
     <div class="container">
       <p>
-      <%= link_to message, "https://library.princeton.edu/news/general/2022-12-02/borrowdirect-new-platform-launch-december-13-2022" %>·
+      <%= link_to message, "https://library.princeton.edu/news/general/2022-12-02/borrowdirect-new-platform-launch-december-13-2022" %>
       </p>
     </div>
   </div>


### PR DESCRIPTION
Based on this comment: https://pulibrary.slack.com/archives/C9ZM9RX4J/p1670284300977759?thread_ts=1670271848.187479&cid=C9ZM9RX4J