### PR TITLE
Don't filter out viewers if it's a MVW

### DIFF
--- a/app/javascript/orangelight/figgy_manifest_manager.js
+++ b/app/javascript/orangelight/figgy_manifest_manager.js
@@ -114,21 +114,7 @@ class FiggyViewerSet {
       return []
     }
 
-    // Filter only for resources with child resources (i. e. non-FileSets) as members
-    // This is not performant, and should require a separate GraphQL query
-    const filteredResources = resources.filter((resource) => {
-      if (!resource['members'])
-        return true
-      return resource.members.filter((member) => {
-        return member.__typename != "FileSet"
-      }).length > 0
-    })
-    if (resources.length > 0 && filteredResources.length < 1)
-      return resources.map((resource) => {
-        return resource.manifestUrl
-      })
-
-    return filteredResources.map((resource) => {
+    return resources.map((resource) => {
       return resource.manifestUrl
     })
   }

--- a/app/javascript/orangelight/load-resources-by-orangelight-id.js
+++ b/app/javascript/orangelight/load-resources-by-orangelight-id.js
@@ -13,9 +13,6 @@ async function loadResourcesByOrangelightId(id) {
          },
          label,
          url,
-         members {
-           id
-         },
          embed {
            type,
            content,

--- a/app/javascript/orangelight/load-resources-by-orangelight-ids.js
+++ b/app/javascript/orangelight/load-resources-by-orangelight-ids.js
@@ -13,9 +13,6 @@ async function loadResourcesByOrangelightIds(ids) {
            thumbnailUrl
          },
          url,
-         members {
-           id
-         },
          ... on ScannedResource {
            manifestUrl,
            orangelightId


### PR DESCRIPTION
Closes #3285

This should also SIGNIFICANTLY improve the render time for large MVWs.

The priority for this is pretty high - it's breaking https://catalog.princeton.edu/catalog/9950403683506421 which is going to be used for a class on Thursday.