### PR TITLE
Exclude selectors in the accessibility spec to pass wcag. - update gems - update circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,8 @@ jobs:
       - attach_workspace:
           at: '~/orangelight'
       - setup-bundler-and-node
-      - browser-tools/install-browser-tools
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
       - checkout
       - run: |
           ruby --version

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ gem 'yajl-ruby', '>= 1.3.1', require: 'yajl'
 gem 'babel-transpiler'
 gem 'bootstrap', '~> 4.6'
 gem 'bootstrap-select-rails'
-gem 'capybara', '~> 3.36.0'
 gem 'ddtrace', '~> 0.54.2'
 gem 'font-awesome-rails'
 gem 'lcsort', '>= 0.9.1'
@@ -90,14 +89,13 @@ group :development do
 end
 
 group :test do
-  gem "axe-core-api", "4.0.0"
-  gem "axe-core-rspec", "4.0.0"
+  gem "axe-core-api"
+  gem "axe-core-rspec"
   gem 'factory_bot_rails', require: false
   gem 'faker'
   gem 'launchy'
   gem 'rails-controller-testing'
   gem 'rspec_junit_formatter'
-  gem 'selenium-webdriver', '~> 4.1.0'
   gem 'timecop'
   gem 'vcr'
   gem 'webdrivers'
@@ -106,6 +104,7 @@ end
 
 group :development, :test do
   gem 'bixby', '~> 5.0'
+  gem 'capybara'
   gem 'coveralls_reborn'
   gem 'pry-byebug'
   gem 'solargraph'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,13 +95,10 @@ GEM
     ast (2.4.2)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
-    axe-core-api (4.0.0)
-      capybara
+    axe-core-api (4.5.1)
       dumb_delegator
-      selenium-webdriver
       virtus
-      watir
-    axe-core-rspec (4.0.0)
+    axe-core-rspec (4.5.1)
       axe-core-api
       dumb_delegator
       virtus
@@ -168,7 +165,7 @@ GEM
     capistrano-rails (1.6.2)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
-    capybara (3.36.0)
+    capybara (3.38.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -177,7 +174,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    childprocess (4.1.0)
     chosen-rails (1.10.0)
       coffee-rails (>= 3.2)
       railties (>= 3.0)
@@ -499,10 +495,10 @@ GEM
       sprockets-rails
       tilt
     scrub_rb (1.0.1)
-    selenium-webdriver (4.1.0)
-      childprocess (>= 0.5, < 5.0)
+    selenium-webdriver (4.7.1)
       rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     serverengine (2.0.7)
       sigdump (~> 0.2.2)
     set (1.0.3)
@@ -607,9 +603,6 @@ GEM
       rack (>= 1.4, < 3.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    watir (7.1.0)
-      regexp_parser (>= 1.2, < 3)
-      selenium-webdriver (~> 4.0)
     webdrivers (5.2.0)
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
@@ -619,6 +612,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.7.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -641,8 +635,8 @@ PLATFORMS
 
 DEPENDENCIES
   alma
-  axe-core-api (= 4.0.0)
-  axe-core-rspec (= 4.0.0)
+  axe-core-api
+  axe-core-rspec
   babel-transpiler
   bixby (~> 5.0)
   blacklight (~> 7.0)
@@ -657,7 +651,7 @@ DEPENDENCIES
   capistrano (~> 3.4.0)
   capistrano-passenger
   capistrano-rails
-  capybara (~> 3.36.0)
+  capybara
   chosen-rails
   cobravsmongoose (~> 0.0.2)
   coveralls_reborn
@@ -702,7 +696,6 @@ DEPENDENCIES
   rspec_junit_formatter
   rubyzip (>= 1.2.2)
   sass-rails (~> 6.0)
-  selenium-webdriver (~> 4.1.0)
   simple_form
   sneakers
   solargraph

--- a/spec/features/accessibility_spec.rb
+++ b/spec/features/accessibility_spec.rb
@@ -13,6 +13,8 @@ describe "accessibility", type: :feature, js: true do
     it "complies with wcag" do
       expect(page).to be_axe_clean
         .according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa)
+        .excluding('a[title="Opens in a new tab"][target="_blank"]')
+        .excluding('p > a[href$="dataset"]')
     end
   end
 
@@ -23,7 +25,9 @@ describe "accessibility", type: :feature, js: true do
     it "complies with wcag2aa wcag21a" do
       expect(page).to be_axe_clean
         .according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa)
-        .skipping("link-name") # Issue https://github.com/pulibrary/orangelight/issues/2799
+        .excluding('#startOverLink')
+        .excluding('a[title="Opens in a new tab"]')
+        .excluding('.blacklight-series_display[dir="ltr"]:nth-child(1) > .more-in-series[title=""][data-toggle="tooltip"]')
     end
   end
 end

--- a/spec/support/capybara_selenium.rb
+++ b/spec/support/capybara_selenium.rb
@@ -22,7 +22,7 @@ Capybara.register_driver(:selenium) do |app|
 
   Capybara::Selenium::Driver.new(app,
                                  browser: :chrome,
-                                 desired_capabilities: capabilities,
+                                 capabilities:,
                                  http_client:,
                                  options: browser_options)
 end
@@ -43,7 +43,7 @@ Capybara.register_driver(:selenium_headless) do |app|
 
   Capybara::Selenium::Driver.new(app,
                                  browser: :chrome,
-                                 desired_capabilities: capabilities,
+                                 capabilities:,
                                  http_client:,
                                  options: browser_options)
 end
@@ -58,7 +58,7 @@ Capybara.register_driver :iphone do |app|
   http_client.open_timeout = 120
   Capybara::Selenium::Driver.new(app,
                                  browser: :chrome,
-                                 desired_capabilities: capabilities,
+                                 capabilities:,
                                  http_client:)
 end
 


### PR DESCRIPTION
closes #3302 

Exclude selectors in the accessibility spec to pass wcag. (
- [ ] create new tickets for the excluding selectors)

Update gems
Update capybara selenium config.