### PR TITLE
Increase cpu and ram in docker container - update capybara selenium configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,12 +21,14 @@ executors:
           POSTGRES_DB: orangelight_test
       - image: pulibrary/ci-solr:8.4-v1.0.0
         command: server/scripts/ci-start.sh
+    resource_class: large
     working_directory: ~/orangelight
   basic-executor:
     docker:
       - image: cimg/ruby:3.1.0-browsers
         environment:
           RAILS_ENV: test
+    resource_class: large
     working_directory: ~/orangelight
 
 commands:

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ source 'https://rubygems.org'
 gem 'rails', '~> 6.1.7'
 # Use postgresql as the database for Active Record
 gem 'pg'
+gem 'puma', '~> 6.0'
 # Blacklight
 gem 'blacklight', '~> 7.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -392,6 +392,8 @@ GEM
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
     public_suffix (5.0.1)
+    puma (6.0.1)
+      nio4r (~> 2.0)
     racc (1.6.1)
     rack (2.2.4)
     rack-proxy (0.7.4)
@@ -688,6 +690,7 @@ DEPENDENCIES
   openurl (~> 1.0)
   pg
   pry-byebug
+  puma (~> 6.0)
   rails (~> 6.1.7)
   rails-controller-testing
   rake

--- a/spec/support/capybara_selenium.rb
+++ b/spec/support/capybara_selenium.rb
@@ -4,31 +4,11 @@ require 'capybara/rails'
 require 'capybara/rspec'
 require "selenium-webdriver"
 
-Capybara.register_driver :chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome)
-end
+# Capybara.register_driver :chrome do |app|
+#   Capybara::Selenium::Driver.new(app, browser: :chrome)
+# end
 
 Capybara.register_driver(:selenium) do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    'goog:chromeOptions': { args: %w[disable-gpu disable-setuid-sandbox window-size=7680,4320] }
-  )
-
-  browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << "--disable-gpu"
-
-  http_client = Selenium::WebDriver::Remote::Http::Default.new
-  http_client.read_timeout = 120
-  http_client.open_timeout = 120
-
-  Capybara::Selenium::Driver.new(app,
-                                 browser: :chrome,
-                                 capabilities:,
-                                 http_client:,
-                                 options: browser_options)
-end
-
-# This was needed for my local workstation, perhaps :selenium is overridden elsewhere?
-Capybara.register_driver(:selenium_headless) do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     'goog:chromeOptions': { args: %w[headless disable-gpu disable-setuid-sandbox window-size=7680,4320] }
   )
@@ -63,5 +43,5 @@ Capybara.register_driver :iphone do |app|
 end
 
 Capybara.server = :webrick
-Capybara.javascript_driver = :selenium_headless
+Capybara.javascript_driver = :selenium
 Capybara.default_max_wait_time = 15

--- a/spec/support/capybara_selenium.rb
+++ b/spec/support/capybara_selenium.rb
@@ -4,10 +4,6 @@ require 'capybara/rails'
 require 'capybara/rspec'
 require "selenium-webdriver"
 
-# Capybara.register_driver :chrome do |app|
-#   Capybara::Selenium::Driver.new(app, browser: :chrome)
-# end
-
 Capybara.register_driver(:selenium) do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     'goog:chromeOptions': { args: %w[headless disable-gpu disable-setuid-sandbox window-size=7680,4320] }
@@ -42,6 +38,5 @@ Capybara.register_driver :iphone do |app|
                                  http_client:)
 end
 
-Capybara.server = :webrick
 Capybara.javascript_driver = :selenium
 Capybara.default_max_wait_time = 15


### PR DESCRIPTION
part of #3302 

Use resource_class to increase cpu and ram in docker container.
Update capybara/selenium configuration. 
Use default capybara driver.
Include puma in Gemfile