### PR TITLE
Add beginning harmful content feedback bar

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -49,6 +49,7 @@
 @import 'components/header--secondary';
 @import 'components/lists';
 @import 'components/nav--accounts';
+@import 'components/nav--harmful-content';
 @import 'components/overrides';
 @import 'components/pagination';
 @import 'components/record';

--- a/app/assets/stylesheets/components/nav--harmful-content.scss
+++ b/app/assets/stylesheets/components/nav--harmful-content.scss
@@ -1,0 +1,16 @@
+
+.harmful-content-feedback {
+  background-color: #e4e4e4;
+  color: #23578B;
+  justify-content: space-around;
+  position: sticky;
+  bottom: 0;
+  @media (max-width: $bp-small) {
+    align-items: flex-start;
+    flex-direction: column;
+    flex-wrap: nowrap;
+  }
+  .navbar-brand {
+    font-size: 1rem;
+  }
+}

--- a/app/views/catalog/_show_harmful_content_feedback.html.erb
+++ b/app/views/catalog/_show_harmful_content_feedback.html.erb
@@ -1,0 +1,5 @@
+<nav class="navbar navbar-expand-lg harmful-content-feedback">
+  <a class="navbar-brand" href="#">Ask A Question</a>
+  <a class="navbar-brand" href="#">Suggest A Correction</a>
+  <a class="navbar-brand" href="#">Report Harmful Language</a>
+</nav>

--- a/app/views/catalog/_show_harmful_content_feedback.html.erb
+++ b/app/views/catalog/_show_harmful_content_feedback.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg harmful-content-feedback">
+<nav class="navbar navbar-expand-lg harmful-content-feedback" aria-label="feedback">
   <a class="navbar-brand" href="#">Ask A Question</a>
   <a class="navbar-brand" href="#">Suggest A Correction</a>
   <a class="navbar-brand" href="#">Report Harmful Language</a>

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -21,6 +21,9 @@
         </dd>
       </dl>
     <% end %>
+    <% if Flipflop.harmful_content_feedback? %>
+      <%= render partial: 'show_harmful_content_feedback' %>
+    <% end %>
   </div>
   <div id="aside" class="<%= render_document_class %>">
     <h2 class="sr-only">Supplementary Information</h2>

--- a/config/features.rb
+++ b/config/features.rb
@@ -30,4 +30,8 @@ Flipflop.configure do
   feature :firestone_locator,
     default: true,
     description: "When on / true, uses the old locator service for Firestone. When off / false uses the new Stackmap service for Firestone."
+
+  feature :harmful_content_feedback,
+    default: false,
+    description: "When on / true, displays the Harmful Content Feedback bar."
 end

--- a/docs/features.md
+++ b/docs/features.md
@@ -7,5 +7,11 @@ Unless the feature impacts a controller or initializer (probably better not to u
 
 In order to update the application administrators, update the `ORANGELIGHT_ADMIN_NETIDS` value in princeton_ansible, run the Orangelight playbook and restart the application server.
 
+#### In development
+In order to use the dashboard in development, run the rails server with the `ORANGELIGHT_ADMIN_NETIDS` environment variable set, e.g.
+```zsh
+ORANGELIGHT_ADMIN_NETIDS="mk8066" bundle exec rails s
+```
+
 ### Ansible-managed
 Currently, `read_only_mode` is managed via Ansible. In order to set this value, change the value of `OL_READ_ONLY_MODE` in princeton_ansible and run the Orangelight playbook on the relevant environment. Because this value is set in an initializer, the application server must be restarted before this will take effect (deploying the application will do this as well).

--- a/spec/system/catalog_show_spec.rb
+++ b/spec/system/catalog_show_spec.rb
@@ -84,4 +84,15 @@ describe 'Viewing Catalog Documents', type: :system, js: true do
       expect(page).to have_selector('dd.blacklight-isbn_display ul li', count: 4)
     end
   end
+
+  describe 'giving feedback' do
+    let(:document_id) { '9946093213506421' }
+    before { allow(Flipflop).to receive(:harmful_content_feedback?).and_return(true) }
+
+    it 'shows a feedback bar' do
+      visit "catalog/#{document_id}"
+      expect(page).to have_selector('.harmful-content-feedback')
+      expect(page).to have_content('Report Harmful Language')
+    end
+  end
 end


### PR DESCRIPTION
- Put behind feature flipper so we can have control of rollout and incrementally introduce feature - go to /features to turn on and test
- Right now links just go to top and are placeholders for future tickets

Closes #3328

At bottom of page:
![image](https://user-images.githubusercontent.com/45948126/210841851-164b6d7a-7e54-4595-b972-4a8fbe25ca04.png)

Sticky!:
![image](https://user-images.githubusercontent.com/45948126/210841956-9f476d4f-4436-4e9f-966e-799488885c4d.png)

Mobile:
![image](https://user-images.githubusercontent.com/45948126/210842076-2f9fd22d-3aca-40dd-8ca1-5e05f5e9a69b.png)
