### PR TITLE
Add the solr artifacts to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ node_modules
 # https://vitejs.dev/guide/env-and-mode.html#env-files
 *.local
 
+solr/conf/CJKFoldingFilter.jar
+solr/conf/lucene-umich-solr-filters-6.0.0-SNAPSHOT.jar


### PR DESCRIPTION
These files are re-added each time I re-create my orangelight application locally, and it just adds mental overhead to remember not to commit them.