### PR TITLE
Disable Metrics/AbcSize on individual methods

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,23 +20,6 @@ AllCops:
     - 'spec/views/catalog/_show_availability_sidebar.html.erb_spec.rb'
     - 'node_modules/**/*'
 
-Metrics/AbcSize:
-  Exclude:
-    - 'app/models/concerns/blacklight/solr/document/marc.rb'
-    - 'app/controllers/account_controller.rb'
-    - 'app/controllers/orangelight/browsables_controller.rb'
-    - 'app/controllers/users/omniauth_callbacks_controller.rb'
-    - 'app/controllers/account_controller.rb:'
-    - 'app/controllers/concerns/orangelight/catalog.rb'
-    - 'app/helpers/advanced_helper.rb'
-    - 'app/helpers/blacklight_helper.rb'
-    - 'app/helpers/application_helper.rb'
-    - 'app/services/physical_holdings_markup_builder.rb'
-    - 'lib/orangelight/browse_lists/call_number_csv.rb'
-    - 'app/models/requests/illiad_metadata/article_express.rb'
-    - 'app/models/concerns/blacklight/document/json_ld.rb'
-    - 'app/models/requests/solr_open_url_context.rb'
-
 Metrics/BlockLength:
   Exclude:
     - 'app/controllers/catalog_controller.rb'

--- a/app/controllers/orangelight/browsables_controller.rb
+++ b/app/controllers/orangelight/browsables_controller.rb
@@ -3,6 +3,7 @@
 class Orangelight::BrowsablesController < ApplicationController
   # GET /orangelight/names
   # GET /orangelight/names.json
+  # rubocop:disable Metrics/AbcSize
   def index
     # if rpp isn't specified default is 50
     # if rpp has values other than 10, 25, 50, 100 then set it to 50
@@ -80,6 +81,7 @@ class Orangelight::BrowsablesController < ApplicationController
       format.json { render json: @orangelight_browsables }
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   private
 

--- a/app/helpers/advanced_helper.rb
+++ b/app/helpers/advanced_helper.rb
@@ -110,6 +110,7 @@ module BlacklightAdvancedSearch
       @keyword_op
     end
 
+    # rubocop:disable Metrics/AbcSize
     def keyword_queries
       unless @keyword_queries
         @keyword_queries = {}
@@ -146,6 +147,7 @@ module BlacklightAdvancedSearch
       end
       @keyword_queries
     end
+    # rubocop:enable Metrics/AbcSize
 
     private
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -151,6 +151,7 @@ module ApplicationHelper
   # Generate the markup block for individual search result items containing holding information
   # @param document [SolrDocument] the Solr Document retrieved in the search result set
   # @return [String] the markup
+  # rubocop:disable Metrics/AbcSize
   def holding_block_search(document)
     block = ''
     portfolio_links = electronic_portfolio_links(document)
@@ -231,6 +232,7 @@ module ApplicationHelper
       content_tag(:ul, block.html_safe)
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   # Location display in the search results page
   def search_location_display(holding, document)
@@ -246,6 +248,7 @@ module ApplicationHelper
 
   SEPARATOR = '—'.freeze
   QUERYSEP = '—'.freeze
+  # rubocop:disable Metrics/AbcSize
   def subjectify(args)
     all_subjects = []
     sub_array = []
@@ -278,6 +281,7 @@ module ApplicationHelper
       subject_list.each { |subject| concat(content_tag(:li, subject, dir: subject.dir)) }
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   def title_hierarchy(args)
     titles = JSON.parse(args[:document][args[:field]])

--- a/app/models/concerns/blacklight/document/json_ld.rb
+++ b/app/models/concerns/blacklight/document/json_ld.rb
@@ -14,6 +14,7 @@ module Blacklight::Document::JsonLd
     data.to_json
   end
 
+  # rubocop:disable Metrics/AbcSize
   def data
     metadata = {}
     metadata["@context"] = "#{default_host}/context.json"
@@ -37,6 +38,7 @@ module Blacklight::Document::JsonLd
 
     metadata
   end
+  # rubocop:enable Metrics/AbcSize
 
   # rubocop:disable Metrics/MethodLength
   def metadata_map

--- a/app/models/concerns/blacklight/solr/document/marc.rb
+++ b/app/models/concerns/blacklight/solr/document/marc.rb
@@ -128,6 +128,7 @@ module Blacklight
 
         protected
 
+          # rubocop:disable Metrics/AbcSize
           def build_ctx(format = nil)
             format ||= first('format')&.downcase
             ctx = ContextObject.new
@@ -186,6 +187,7 @@ module Blacklight
             ctx.referent.add_identifier("info:lccn/#{self['lccn_s'].first}") unless self['lccn_s'].nil?
             ctx
           end
+          # rubocop:enable Metrics/AbcSize
 
           # Retrieves the bib. ID from the Solr Document
           # @return [String]

--- a/app/models/requests/illiad_metadata/article_express.rb
+++ b/app/models/requests/illiad_metadata/article_express.rb
@@ -17,6 +17,7 @@ module Requests
 
       private
 
+        # rubocop:disable Metrics/AbcSize
         def map_metdata
           {
             "Username" => patron.netid, "TransactionStatus" => illiad_transaction_status,
@@ -32,6 +33,7 @@ module Requests
             "PhotoArticleTitle" => item["edd_art_title"]&.truncate(250)
           }
         end
+        # rubocop:enable Metrics/AbcSize
 
         def pages
           "#{item['edd_start_page']}-#{item['edd_end_page']}"

--- a/app/models/requests/solr_open_url_context.rb
+++ b/app/models/requests/solr_open_url_context.rb
@@ -47,6 +47,7 @@ module Requests
         ctx
       end
 
+      # rubocop:disable Metrics/AbcSize
       def build_metadata(solr_doc:)
         metadata = {}
         metadata[:id] = solr_doc['id']
@@ -63,6 +64,7 @@ module Requests
         metadata[:lccn] = solr_doc['lccn_s'].first unless solr_doc['lccn_s'].nil?
         metadata
       end
+      # rubocop:enable Metrics/AbcSize
 
       def copy_metadata(format:, metadata:)
         ctx = ContextObject.new

--- a/app/services/bibdata.rb
+++ b/app/services/bibdata.rb
@@ -90,6 +90,5 @@ class Bibdata
         sorted.to_h.with_indifferent_access
       end
     # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/app/services/physical_holdings_markup_builder.rb
+++ b/app/services/physical_holdings_markup_builder.rb
@@ -462,6 +462,7 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
     # @param holding [Hash] holding information from a Solr Document
     # @param holding_id [String] the ID for the holding record
     # @return [String] the markup
+    # rubocop:disable Metrics/AbcSize
     def process_physical_holding(holding, holding_id)
       markup = ''
       doc_id = doc_id(holding)
@@ -513,6 +514,7 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
       markup = self.class.holding_block(markup) unless markup.empty?
       markup
     end
+    # rubocop:enable Metrics/AbcSize
 
     # Generate the markup for physical holdings
     # @return [String] the markup


### PR DESCRIPTION
- Scope the exclusion to a single method, rather than an entire file. This reduces the likelihood of accidentally introducing even more complexity.