### PR TITLE
Do not display detailed status on requests page

### DIFF
--- a/app/models/requests/requestable/item.rb
+++ b/app/models/requests/requestable/item.rb
@@ -213,11 +213,11 @@ class Requests::Requestable
       end
 
       def status_label
-        'Not Available'
+        ''
       end
 
       def status
-        ''
+        'Not Available'
       end
 
       def available?

--- a/app/models/requests/requestable_decorator.rb
+++ b/app/models/requests/requestable_decorator.rb
@@ -117,15 +117,7 @@ module Requests
     end
 
     def status_badge
-      content_tag(:span, status_for_badge, class: "availability--label badge #{css_class}")
-    end
-
-    def status_for_badge
-      if requestable.status_label.nil? || requestable.status == requestable.status_label || requestable.status_label == "Resource Sharing Request"
-        requestable.status
-      else
-        requestable.status + ' - ' + requestable.status_label
-      end
+      content_tag(:span, requestable.status, class: "availability--label badge #{css_class}")
     end
 
     def css_class

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -291,7 +291,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
           stub_scsb_availability(bib_id: "99114026863506421", institution_id: "PUL", barcode: nil, item_availability_status: nil, error_message: "Bib Id doesn't exist in SCSB database.")
           visit "/requests/#{recap_in_process_id}"
           expect(page).to have_content 'In Process'
-          expect(page.find(:css, ".request--availability").text).to eq("Not Available - Acquisitions and Cataloging")
+          expect(page.find(:css, ".request--availability").text).to eq("Not Available")
           select('Firestone Library, Resource Sharing (Staff Only)', from: 'requestable__pick_up_23753408600006421')
           select('Technical Services 693 (Staff Only)', from: 'requestable__pick_up_23753408600006421')
           select('Technical Services HMT (Staff Only)', from: 'requestable__pick_up_23753408600006421')
@@ -1056,7 +1056,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
         it 'Shows recap item that has not made it to recap yet as On Order' do
           stub_scsb_availability(bib_id: "99123340993506421", institution_id: "PUL", barcode: nil, item_availability_status: nil, error_message: "Bib Id doesn't exist in SCSB database.")
           visit '/requests/99123340993506421?mfhd=22569931350006421'
-          expect(page).to have_content 'Not Available - Acquisition'
+          expect(page).to have_content 'Not Available'
           select('Firestone Library', from: 'requestable__pick_up_23896622240006421')
           expect { click_button 'Request this Item' }.to change { ActionMailer::Base.deliveries.count }.by(2)
           expect(page).to have_content I18n.t("requests.submit.in_process_success")
@@ -1187,7 +1187,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
             expect(page).to have_content 'Physical Item Delivery'
             expect(page).to have_content 'Electronic Delivery'
             expect(page).to have_content "Architecture Library- Librarian's Office NA682.B7 S673 2017b"
-            expect(page).to have_content 'Available - Item in place'
+            expect(page).to have_content 'Available'
             expect(page).to have_content 'vol.1'
             check('requestable_selected_23514405150006421')
             choose('requestable__delivery_mode_23514405150006421_edd')
@@ -1202,7 +1202,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
             expect(page).to have_content 'Physical Item Delivery'
             expect(page).to have_content 'Electronic Delivery'
             expect(page).to have_content "Architecture Library- Librarian's Office NA682.B7 S673 2017b"
-            expect(page).to have_content 'Available - Item in place'
+            expect(page).to have_content 'Available'
             expect(page).to have_content 'vol.1'
             check('requestable_selected_23514405150006421')
             choose('requestable__delivery_mode_23514405150006421_print')
@@ -1226,7 +1226,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
             expect(page).to have_content 'Physical Item Delivery'
             expect(page).to have_content 'Electronic Delivery'
             expect(page).to have_content "Architecture Library- Librarian's Office NA682.B7 S673 2017b"
-            expect(page).to have_content 'Available - Item in place'
+            expect(page).to have_content 'Available'
             expect(page).to have_content 'vol.1'
             check('requestable_selected_23514405150006421')
             expect(page).to have_button('Request this Item', disabled: true)
@@ -1240,7 +1240,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
             expect(page).to have_content 'Physical Item Delivery'
             expect(page).to have_content 'Electronic Delivery'
             expect(page).to have_content "Architecture Library- Librarian's Office NA682.B7 S673 2017b"
-            expect(page).to have_content 'Available - Item in place'
+            expect(page).to have_content 'Available'
             expect(page).to have_content 'vol.1'
             check('requestable_selected_23514405150006421')
             expect(page).to have_button('Request this Item', disabled: true)
@@ -1266,7 +1266,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
             expect(page).to have_content 'New York Botanical Garden'
             expect(page).to have_content 'Lewis Library - Lewis Library - Serials (Off-Site) 8763.668'
             expect(page).to have_content 'Electronic Delivery'
-            expect(page).to have_content 'Available - Item in place'
+            expect(page).to have_content 'Available'
             expect(page).to have_button('Request Selected Items', disabled: true)
             check('requestable_selected_23641620980006421')
             expect(page).to have_button('Request Selected Items', disabled: false)
@@ -1774,7 +1774,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
 
       it 'is available and in process' do
         visit "requests/99122304923506421?mfhd=22511126440006421"
-        expect(page.find(:css, ".request--availability").text).to eq("Available - In Process")
+        expect(page.find(:css, ".request--availability").text).to eq("Available")
         expect(page).to have_content 'In Process materials are typically available in several business days'
         select('Firestone Library', from: 'requestable__pick_up_23511126430006421')
         expect { click_button 'Request this Item' }.to change { ActionMailer::Base.deliveries.count }.by(2)

--- a/spec/models/requests/requestable_decorator_spec.rb
+++ b/spec/models/requests/requestable_decorator_spec.rb
@@ -1462,7 +1462,7 @@ describe Requests::RequestableDecorator do
     let(:stubbed_questions) { default_stubbed_questions.merge(charged?: false, status_label: 'Item in place', status: 'Available') }
 
     it 'shows the status' do
-      expect(decorator.status_badge).to eq('<span class="availability--label badge badge-success">Available - Item in place</span>')
+      expect(decorator.status_badge).to eq('<span class="availability--label badge badge-success">Available</span>')
     end
 
     context 'Status label nil' do
@@ -1476,7 +1476,7 @@ describe Requests::RequestableDecorator do
     context 'Charged item' do
       let(:stubbed_questions) { default_stubbed_questions.merge(charged?: true, status_label: 'Technical - Migration', status: 'Not Available') }
       it 'shows the status' do
-        expect(decorator.status_badge).to eq('<span class="availability--label badge badge-danger">Not Available - Technical - Migration</span>')
+        expect(decorator.status_badge).to eq('<span class="availability--label badge badge-danger">Not Available</span>')
       end
     end
 
@@ -1490,7 +1490,7 @@ describe Requests::RequestableDecorator do
     context 'migration item that is available' do
       let(:stubbed_questions) { default_stubbed_questions.merge(status_label: 'Technical - Migration', status: 'Available') }
       it 'shows the status' do
-        expect(decorator.status_badge).to eq('<span class="availability--label badge badge-success">Available - Technical - Migration</span>')
+        expect(decorator.status_badge).to eq('<span class="availability--label badge badge-success">Available</span>')
       end
     end
   end


### PR DESCRIPTION
Closes #3230

Recent example: https://catalog-staging.princeton.edu/requests/99124444633506421?aeon=false&mfhd=22664759370006421

Before this branch is deployed:
![availability labels include detailed info](https://user-images.githubusercontent.com/45948126/227624710-4f8b5bcb-6acf-4be1-888a-3a4d7221491d.png)

After this branch is deployed:
![availability labels do not include detailed info](https://user-images.githubusercontent.com/45948126/227625426-1f8300cc-d549-4d70-9777-fc570073940a.png)


