### PR TITLE
Render component/partial names as HTML comments in development environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,4 +49,5 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   config.middleware.use Orangelight::Middleware::InvalidParameterHandler
+  config.action_view.annotate_rendered_view_with_filenames = true
 end


### PR DESCRIPTION
closes https://github.com/pulibrary/orangelight/pull/3486

See https://blog.saeloun.com/2020/05/11/rails-support-annotates-html-output-with-template-file-names