### PR TITLE
In the beginning only invoke function to deactivate the request button

### DIFF
--- a/app/assets/javascripts/requests/requests.js
+++ b/app/assets/javascripts/requests/requests.js
@@ -54,8 +54,6 @@ $(document).ready(function() {
         $('#request-submit-button').prop('disabled', false);
     }
 
-    activateRequestButton();
-
     function deactivateRequestButton () {
         $('#request-submit-button').prop('disabled', true);
     }


### PR DESCRIPTION
This is a cleanup of a function I didnt have to invoke when loading the page. I missed it in the previous commit.