### PR TITLE
Address show_fields_for deprecation

### DIFF
--- a/app/views/catalog/_show_top_fields.html.erb
+++ b/app/views/catalog/_show_top_fields.html.erb
@@ -2,7 +2,7 @@
 <% doc_presenter = document_presenter(document) %>
 <%# default partial to display solr document fields in catalog show view -%>
 <dl class="dl-horizontal  dl-invert top-fields">
-  <% doc_presenter.configuration.show_fields_for(document['format']).each do |field_name, field| -%>
+  <% doc_presenter.configuration.show_fields_for(document['format'] || ['Unknown']).each do |field_name, field| -%>
     <% if render_top_field? document, field_name %>
       <% field_presenter = Blacklight::FieldPresenter.new(doc_presenter.view_context, document, field) %>
       <% if field_name == 'author_display' && document['marc_relator_display'] %>

--- a/spec/system/catalog_show_spec.rb
+++ b/spec/system/catalog_show_spec.rb
@@ -170,6 +170,17 @@ describe 'Viewing Catalog Documents', type: :system, js: true do
         end
       end
     end
+    context 'with a record without a format' do
+      let(:document_id) { 'SCSB-7935196' }
+      it 'does not raise a deprecation warning' do
+        allow(Deprecation).to receive(:default_deprecation_behavior).and_return(:raise)
+        visit "catalog/#{document_id}"
+        within('dl.top-fields') do
+          expect(page).to have_selector("dt.blacklight-pub_created_display")
+          expect(page).to have_selector("dt.blacklight-description_display")
+        end
+      end
+    end
   end
 
   describe 'action note display' do


### PR DESCRIPTION
- When a document does not have a format field, it will not raise a deprecation warning

Closes #3490