### PR TITLE
Address deprecations in atom display

### DIFF
--- a/app/views/catalog/_atom_index.html.erb
+++ b/app/views/catalog/_atom_index.html.erb
@@ -1,5 +1,7 @@
-<% index_fields(document).each do |solr_fname, field| -%>
-  <% if (should_render_index_field?(document, field)) %>
+<% doc_presenter = document_presenter(document) %>
+<% doc_presenter.fields_to_render.each do |solr_fname, field| -%>
+  <% field_presenter = Blacklight::FieldPresenter.new(doc_presenter.view_context, document, field) %>
+  <% if (field_presenter.render_field?) %>
     <% if !document[solr_fname].is_a?(Array) %>
       <%= document[solr_fname]%><br>
     <% else %>

--- a/app/views/catalog/_document_default.atom.builder
+++ b/app/views/catalog/_document_default.atom.builder
@@ -6,7 +6,7 @@ xml.entry do
   # updated is required, for now we'll just set it to now, sorry
   xml.updated document['cataloged_tdt']
 
-  xml.link    'rel' => 'alternate', 'type' => 'text/html', 'href' => polymorphic_url(url_for_document(document))
+  xml.link    'rel' => 'alternate', 'type' => 'text/html', 'href' => polymorphic_url(search_state.url_for_document(document))
   # add other doc-specific formats, atom only lets us have one per
   # content type, so the first one in the list wins.
   xml << document_presenter(document).link_rel_alternates(unique: true)


### PR DESCRIPTION
Closes #3503

There is a remaining deprecation that stems from Blacklight Advanced Search that I believe will be addressed in https://github.com/pulibrary/orangelight/issues/3412.