### PR TITLE
Remove references to unused blacklight_advanced_search assets

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,7 +19,6 @@
 //= require chosen-jquery
 //
 //= require bootstrap/tab
-//= require 'blacklight_advanced_search'
 //
 // Required by Blacklight
 //= require blacklight/blacklight

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,7 +11,6 @@
  * file per style scope.
  *
  *= require  'blacklight_range_limit'
- *= require 'blacklight_advanced_search'
 *= require 'bootstrap-select'
  *= require chosen
  *= require_self


### PR DESCRIPTION
Cherry-picked from commit 24b3fc6a9985c00e0f218c7b17387b59259c7678

Trying to split #3391 into smaller chunks!

Part of #3412 