### PR TITLE
3450 mapset multiple viewers

### DIFF
--- a/app/javascript/orangelight/figgy_manifest_manager.js
+++ b/app/javascript/orangelight/figgy_manifest_manager.js
@@ -1,279 +1,279 @@
-import loadResourcesByFiggyIds from './load-resources-by-figgy-ids'
-import loadResourcesByOrangelightId from './load-resources-by-orangelight-id'
-import loadResourcesByOrangelightIds from './load-resources-by-orangelight-ids'
-import { insert_online_link } from './insert_online_link.es6'
+import loadResourcesByFiggyIds from './load-resources-by-figgy-ids';
+import loadResourcesByOrangelightId from './load-resources-by-orangelight-id';
+import loadResourcesByOrangelightIds from './load-resources-by-orangelight-ids';
+import { insert_online_link } from './insert_online_link.es6';
 
 class FiggyViewer {
-  // There may be more than one ARK minted which resolves to the same manifested resource
-  constructor(idx, element, manifestUrl) {
-    this.idx = idx
-    this.element = element
-    this.manifestUrl = manifestUrl
-  }
-
-  getAvailabilityElement() {
-    let elements = document.querySelectorAll('#availability > div.location--panel.location--online > div > div.panel-body > div')
-    if (elements.length < 1) {
-      elements = document.querySelectorAll('#availability > div.location--panel.location--online > div > div.panel-body > div > ul > div.electronic-access')
-    }
-    // This assumes that the first element is the link
-    const element = elements[0]
-    return element
-  }
-
-  buildViewerId() {
-    return this.idx == 0 ? 'viewer-container' : `viewer-container_${this.idx}`
-  }
-
-  constructIFrame() {
-    const iframeElement = document.createElement("iframe")
-    iframeElement.setAttribute("allowFullScreen", "true")
-    iframeElement.setAttribute("title", "Digital content viewer")
-    iframeElement.id = `iframe-${this.idx + 1}`
-
-    // This needs to be retrieved using Global
-    const figgyUrl = window.Global.figgy.url
-    const src = `${figgyUrl}/viewer#?manifest=${this.manifestUrl}&config=${figgyUrl}/uv/uv_config.json`
-    iframeElement.src = src
-
-    return iframeElement
-  }
-
-  constructViewerElement() {
-    const viewerElement = document.createElement("div")
-    viewerElement.setAttribute("class", "intrinsic-container intrinsic-container-16x9")
-    viewerElement.id = this.buildViewerId()
-
-    const iFrameElement = this.constructIFrame()
-    viewerElement.appendChild(iFrameElement)
-
-    return viewerElement
-  }
-
-  async render() {
-    const viewerElement = this.constructViewerElement()
-    if (!viewerElement) {
-      return null
+    // There may be more than one ARK minted which resolves to the same manifested resource
+    constructor(idx, element, manifestUrl) {
+        this.idx = idx;
+        this.element = element;
+        this.manifestUrl = manifestUrl;
     }
 
-    this.element.appendChild(viewerElement)
-  }
+    getAvailabilityElement() {
+        let elements = document.querySelectorAll('#availability > div.location--panel.location--online > div > div.panel-body > div');
+        if (elements.length < 1) {
+            elements = document.querySelectorAll('#availability > div.location--panel.location--online > div > div.panel-body > div > ul > div.electronic-access');
+        }
+        // This assumes that the first element is the link
+        const element = elements[0];
+        return element;
+    }
+
+    buildViewerId() {
+        return this.idx == 0 ? 'viewer-container' : `viewer-container_${this.idx}`;
+    }
+
+    constructIFrame() {
+        const iframeElement = document.createElement("iframe");
+        iframeElement.setAttribute("allowFullScreen", "true");
+        iframeElement.setAttribute("title", "Digital content viewer");
+        iframeElement.id = `iframe-${this.idx + 1}`;
+
+        // This needs to be retrieved using Global
+        const figgyUrl = window.Global.figgy.url;
+        const src = `${figgyUrl}/viewer#?manifest=${this.manifestUrl}&config=${figgyUrl}/uv/uv_config.json`;
+        iframeElement.src = src;
+
+        return iframeElement;
+    }
+
+    constructViewerElement() {
+        const viewerElement = document.createElement("div");
+        viewerElement.setAttribute("class", "intrinsic-container intrinsic-container-16x9");
+        viewerElement.id = this.buildViewerId();
+
+        const iFrameElement = this.constructIFrame();
+        viewerElement.appendChild(iFrameElement);
+
+        return viewerElement;
+    }
+
+    async render() {
+        const viewerElement = this.constructViewerElement();
+        if (!viewerElement) {
+            return null;
+        }
+
+        this.element.appendChild(viewerElement);
+    }
 }
 class FiggyViewerSet {
-  constructor(element, query, variables, jQuery) {
-    this.element = element
-    this.query = query
-    this.variables = variables
-    this.jQuery = jQuery
-  }
-
-  async fetchResources() {
-    const data = await this.query.call(this, this.variables)
-    if (!data) {
-      return null;
-    }
-    const resources = data.resourcesByOrangelightId
-    return resources
-  }
-
-  getMemberIds(resources) {
-    const ids = resources.map((resource) => {
-      return resource.members.map((member) => {
-        return member.id
-      })
-    })
-
-    return ids.flat()
-  }
-
-  getManifestUrls(resources) {
-    if (!resources) {
-      return []
+    constructor(element, query, variables, jQuery) {
+        this.element = element;
+        this.query = query;
+        this.variables = variables;
+        this.jQuery = jQuery;
     }
 
-    // If there is a resource whose ID is included as a member_id of another resource,
-    // filter it out
-    const filterDuplicatedResources = resources.filter((resource) => {
-      if (!resource['members'])
-        return true
-      const member_ids = this.getMemberIds(resources)
-      const resource_is_unique =  member_ids.map((member_id) => {
-        if (member_ids.includes(resource.id))
-          return false
-      })
-
-      return !resource_is_unique.includes(false)
-    })
-
-    if (resources.length > 0 && filterDuplicatedResources.length < 1)
-      return resources.map((resource) => {
-        return resource.manifestUrl
-      })
-
-    return filterDuplicatedResources.map((resource) => {
-      return resource.manifestUrl
-    })
-  }
-
-  isUnauthorizedSeniorThesis(resource) {
-    if(resource.notice !== undefined) {
-      if(resource.notice){
-        const isSeniorThesis = resource.notice.heading.search("Senior Thesis");
-        return resource.embed.status == 'unauthorized' && isSeniorThesis
-      }
-    }
-    return false;
-  }
-
-  // function for adding thesis request link
-  addThesisRequestLinks(resources) {
-    let iteration = 0;
-    const link = 'https://library.princeton.edu/special-collections/senior-thesis-order-form';
-    const target = '_blank';
-    resources.forEach((resource) => {
-      if(this.isUnauthorizedSeniorThesis(resource)) {
-        const content = (link, target) => {
-          return `<a href="${link}" target="${target}">Request a copy of ${resource.label}</a><p>Princeton community has access to this thesis on campus or VPN.</p>`
+    async fetchResources() {
+        const data = await this.query.call(this, this.variables);
+        if (!data) {
+            return null;
         }
-        insert_online_link(link, `thesis_request_link_${iteration}`, content);
-        iteration++;
-      }
-    })
-  }
+        const resources = data.resourcesByOrangelightId;
+        return resources;
+    }
 
-  async render() {
-    let resources = await this.fetchResources()
-    this.addThesisRequestLinks(resources)
-    const filteredResources = resources.filter((resource) => {
-      return !this.isUnauthorizedSeniorThesis(resource)
-    })
-    const manifestUrls = await this.getManifestUrls(filteredResources)
-    manifestUrls.forEach((manifestUrl, idx) => {
-      const viewer = new FiggyViewer(idx, this.element, manifestUrl)
-      viewer.render()
-    })
-  }
+    getMemberIds(resources) {
+        const ids = resources.map((resource) => {
+            return resource.members.map((member) => {
+                return member.id;
+            });
+        });
+
+        return ids.flat();
+    }
+
+    getManifestUrls(resources) {
+        if (!resources) {
+            return [];
+        }
+
+        // If there is a resource whose ID is included as a member_id of another resource,
+        // filter it out
+        const filterDuplicatedResources = resources.filter((resource) => {
+            if (!resource['members'])
+                return true;
+            const member_ids = this.getMemberIds(resources);
+            const resource_is_unique = member_ids.map(() => {
+                if (member_ids.includes(resource.id))
+                    return false;
+            });
+
+            return !resource_is_unique.includes(false);
+        });
+
+        if (resources.length > 0 && filterDuplicatedResources.length < 1)
+            return resources.map((resource) => {
+                return resource.manifestUrl;
+            });
+
+        return filterDuplicatedResources.map((resource) => {
+            return resource.manifestUrl;
+        });
+    }
+
+    isUnauthorizedSeniorThesis(resource) {
+        if(resource.notice !== undefined) {
+            if(resource.notice){
+                const isSeniorThesis = resource.notice.heading.search("Senior Thesis");
+                return resource.embed.status == 'unauthorized' && isSeniorThesis;
+            }
+        }
+        return false;
+    }
+
+    // function for adding thesis request link
+    addThesisRequestLinks(resources) {
+        let iteration = 0;
+        const link = 'https://library.princeton.edu/special-collections/senior-thesis-order-form';
+        const target = '_blank';
+        resources.forEach((resource) => {
+            if(this.isUnauthorizedSeniorThesis(resource)) {
+                const content = (link, target) => {
+                    return `<a href="${link}" target="${target}">Request a copy of ${resource.label}</a><p>Princeton community has access to this thesis on campus or VPN.</p>`;
+                };
+                insert_online_link(link, `thesis_request_link_${iteration}`, content);
+                iteration++;
+            }
+        });
+    }
+
+    async render() {
+        const resources = await this.fetchResources();
+        this.addThesisRequestLinks(resources);
+        const filteredResources = resources.filter((resource) => {
+            return !this.isUnauthorizedSeniorThesis(resource);
+        });
+        const manifestUrls = await this.getManifestUrls(filteredResources);
+        manifestUrls.forEach((manifestUrl, idx) => {
+            const viewer = new FiggyViewer(idx, this.element, manifestUrl);
+            viewer.render();
+        });
+    }
 }
 
 // Queries for resources using multiple bib. IDs
 class FiggyThumbnailSet {
 
-  constructor(elements, query, jQuery) {
-    this.elements = elements
-    this.$elements = jQuery(elements)
-    this.query = query
-    this.jQuery = jQuery
-  }
-
-  async fetchResources() {
-    this.bibIds = this.$elements.map((idx, element) => this.jQuery(element).data('bib-id').toString())
-
-    const variables = { bibIds: this.bibIds.toArray() }
-    this.thumbnails = {}
-    const data = await this.query.call(this, variables.bibIds)
-    if (!data) {
-      return null;
+    constructor(elements, query, jQuery) {
+        this.elements = elements;
+        this.$elements = jQuery(elements);
+        this.query = query;
+        this.jQuery = jQuery;
     }
 
-    const resources = data.resourcesByOrangelightIds
-    this.resources = resources
+    async fetchResources() {
+        this.bibIds = this.$elements.map((idx, element) => this.jQuery(element).data('bib-id').toString());
 
-    // Cache the thumbnail URLs
-    for (let resource of this.resources) {
-      const orangelightId = resource.orangelightId
-      this.thumbnails[orangelightId] = resource.thumbnail
-    }
-    return this.resources
-  }
+        const variables = { bibIds: this.bibIds.toArray() };
+        this.thumbnails = {};
+        const data = await this.query.call(this, variables.bibIds);
+        if (!data) {
+            return null;
+        }
 
-  async fetchMonogramResources() {
-    this.ids = this.$elements.map((idx, element) => this.jQuery(element).data('monogram-id').toString())
-    const variables = { ids: this.ids.toArray() }
-    this.thumbnails = {}
-    const data = await this.query.call(this, variables.ids)
-    if (!data) {
-      return null;
-    }
+        const resources = data.resourcesByOrangelightIds;
+        this.resources = resources;
 
-    const resources = data.resourcesByFiggyIds
-    this.resources = resources
-
-    // Cache the thumbnail URLs
-    for (let resource of this.resources) {
-      const id = resource.id
-      this.thumbnails[id] = resource.thumbnail
-    }
-    return this.resources
-  }
-
-  constructThumbnailElement(bibId) {
-    const thumbnail = this.thumbnails[bibId]
-
-    if (!thumbnail) {
-      return null
+        // Cache the thumbnail URLs
+        for (const resource of this.resources) {
+            const orangelightId = resource.orangelightId;
+            this.thumbnails[orangelightId] = resource.thumbnail;
+        }
+        return this.resources;
     }
 
-    const $element = this.jQuery(`<img alt="" src="${thumbnail.iiifServiceUrl}/square/225,/0/default.jpg">`)
-    return $element
-  }
+    async fetchMonogramResources() {
+        this.ids = this.$elements.map((idx, element) => this.jQuery(element).data('monogram-id').toString());
+        const variables = { ids: this.ids.toArray() };
+        this.thumbnails = {};
+        const data = await this.query.call(this, variables.ids);
+        if (!data) {
+            return null;
+        }
 
-  constructMonogramThumbnailElement(figgyId) {
-    const thumbnail = this.thumbnails[figgyId]
-    if (!thumbnail) {
-      return null
+        const resources = data.resourcesByFiggyIds;
+        this.resources = resources;
+
+        // Cache the thumbnail URLs
+        for (const resource of this.resources) {
+            const id = resource.id;
+            this.thumbnails[id] = resource.thumbnail;
+        }
+        return this.resources;
     }
 
-    const $element = this.jQuery(`<img alt="" src="${thumbnail.iiifServiceUrl}/full/225,/0/default.jpg">`)
-    return $element
-  }
+    constructThumbnailElement(bibId) {
+        const thumbnail = this.thumbnails[bibId];
 
-  async render() {
-    await this.fetchResources()
-    this.$elements.map((idx, element) => {
-      const $element = this.jQuery(element)
-      const bibId = $element.data('bib-id')
-      const $thumbnailElement = this.constructThumbnailElement(bibId)
+        if (!thumbnail) {
+            return null;
+        }
 
-      if (!$thumbnailElement) {
-        return
-      }
-      $element.empty()
-      $element.addClass('has-viewer-link')
-      $element.wrap('<a href="#viewer-container"></a>').append('<span class="sr-only">Go to viewer</span>')
-      $element.append($thumbnailElement)
-    })
-  }
+        const $element = this.jQuery(`<img alt="" src="${thumbnail.iiifServiceUrl}/square/225,/0/default.jpg">`);
+        return $element;
+    }
 
-  async renderMonogram() {
-    await this.fetchMonogramResources()
-    this.$elements.map((idx, element) => {
-      const $element = this.jQuery(element)
-      const monogramId = $element.data('monogram-id')
-      const $thumbnailElement = this.constructMonogramThumbnailElement(monogramId)
-      if (!$thumbnailElement) {
-        return
-      }
-      $element.after($thumbnailElement)
-    })
-  }
+    constructMonogramThumbnailElement(figgyId) {
+        const thumbnail = this.thumbnails[figgyId];
+        if (!thumbnail) {
+            return null;
+        }
+
+        const $element = this.jQuery(`<img alt="" src="${thumbnail.iiifServiceUrl}/full/225,/0/default.jpg">`);
+        return $element;
+    }
+
+    async render() {
+        await this.fetchResources();
+        this.$elements.map((idx, element) => {
+            const $element = this.jQuery(element);
+            const bibId = $element.data('bib-id');
+            const $thumbnailElement = this.constructThumbnailElement(bibId);
+
+            if (!$thumbnailElement) {
+                return;
+            }
+            $element.empty();
+            $element.addClass('has-viewer-link');
+            $element.wrap('<a href="#viewer-container"></a>').append('<span class="sr-only">Go to viewer</span>');
+            $element.append($thumbnailElement);
+        });
+    }
+
+    async renderMonogram() {
+        await this.fetchMonogramResources();
+        this.$elements.map((idx, element) => {
+            const $element = this.jQuery(element);
+            const monogramId = $element.data('monogram-id');
+            const $thumbnailElement = this.constructMonogramThumbnailElement(monogramId);
+            if (!$thumbnailElement) {
+                return;
+            }
+            $element.after($thumbnailElement);
+        });
+    }
 }
 
 class FiggyManifestManager {
 
-  static buildThumbnailSet($elements) {
-    return new FiggyThumbnailSet($elements, loadResourcesByOrangelightIds, window.jQuery)
-  }
-  // See: https://github.com/pulibrary/orangelight/issues/2967
-  static buildMonogramThumbnails($monogramIds) {
-    return new FiggyThumbnailSet($monogramIds, loadResourcesByFiggyIds, window.jQuery)
-  }
+    static buildThumbnailSet($elements) {
+        return new FiggyThumbnailSet($elements, loadResourcesByOrangelightIds, window.jQuery);
+    }
+    // See: https://github.com/pulibrary/orangelight/issues/2967
+    static buildMonogramThumbnails($monogramIds) {
+        return new FiggyThumbnailSet($monogramIds, loadResourcesByFiggyIds, window.jQuery);
+    }
 
-  // Build multiple viewers
-  static buildViewers(element) {
-    const $element = window.jQuery(element)
-    const bibId = $element.data('bib-id')
-    return new FiggyViewerSet(element, loadResourcesByOrangelightId, bibId.toString(), window.jQuery)
-  }
+    // Build multiple viewers
+    static buildViewers(element) {
+        const $element = window.jQuery(element);
+        const bibId = $element.data('bib-id');
+        return new FiggyViewerSet(element, loadResourcesByOrangelightId, bibId.toString(), window.jQuery);
+    }
 }
 
 export {FiggyManifestManager, FiggyViewer, FiggyViewerSet};

--- a/app/javascript/orangelight/figgy_manifest_manager.js
+++ b/app/javascript/orangelight/figgy_manifest_manager.js
@@ -5,11 +5,10 @@ import { insert_online_link } from './insert_online_link.es6'
 
 class FiggyViewer {
   // There may be more than one ARK minted which resolves to the same manifested resource
-  constructor(idx, element, manifestUrl, arks) {
+  constructor(idx, element, manifestUrl) {
     this.idx = idx
     this.element = element
     this.manifestUrl = manifestUrl
-    this.arks = arks
   }
 
   getAvailabilityElement() {
@@ -22,35 +21,8 @@ class FiggyViewer {
     return element
   }
 
-  getArkLinkElement() {
-    // If there is only one electronic access link, it's structure using a <div> rather than <ul>
-    const availabilityElement = this.getAvailabilityElement()
-
-    if (!availabilityElement) {
-      return null
-    }
-
-    let elements = availabilityElement.querySelectorAll('div > a')
-    if (elements.length < 1) {
-      elements = availabilityElement.querySelectorAll('li > a')
-    }
-
-    // This assumes that there is a one-to-one mapping between the ARK electronic resource links in the DOM and the UniversalViewer instances
-    return elements[this.idx]
-  }
-
   buildViewerId() {
     return this.idx == 0 ? 'viewer-container' : `viewer-container_${this.idx}`
-  }
-
-  updateArkLinkElement() {
-    const arkLinkElement = this.getArkLinkElement()
-    if (!arkLinkElement) {
-      return
-    }
-
-    arkLinkElement.href = '#' + this.buildViewerId()
-    arkLinkElement.removeAttribute("target")
   }
 
   constructIFrame() {
@@ -84,19 +56,14 @@ class FiggyViewer {
       return null
     }
 
-    if (this.arks.length > 0) {
-      this.updateArkLinkElement()
-    }
-
     this.element.appendChild(viewerElement)
   }
 }
 class FiggyViewerSet {
-  constructor(element, query, variables, arks, jQuery) {
+  constructor(element, query, variables, jQuery) {
     this.element = element
     this.query = query
     this.variables = variables
-    this.arks = arks
     this.jQuery = jQuery
   }
 
@@ -153,7 +120,7 @@ class FiggyViewerSet {
     })
     const manifestUrls = await this.getManifestUrls(filteredResources)
     manifestUrls.forEach((manifestUrl, idx) => {
-      const viewer = new FiggyViewer(idx, this.element, manifestUrl, this.arks)
+      const viewer = new FiggyViewer(idx, this.element, manifestUrl)
       viewer.render()
     })
   }
@@ -276,8 +243,7 @@ class FiggyManifestManager {
   static buildViewers(element) {
     const $element = window.jQuery(element)
     const bibId = $element.data('bib-id')
-    const arks = $element.data('arks') || []
-    return new FiggyViewerSet(element, loadResourcesByOrangelightId, bibId.toString(), arks, window.jQuery)
+    return new FiggyViewerSet(element, loadResourcesByOrangelightId, bibId.toString(), window.jQuery)
   }
 }
 

--- a/app/javascript/orangelight/figgy_manifest_manager.js
+++ b/app/javascript/orangelight/figgy_manifest_manager.js
@@ -78,11 +78,8 @@ class FiggyViewerSet {
 
     getMemberIds(resources) {
         const ids = resources.map((resource) => {
-            return resource.members.map((member) => {
-                return member.id;
-            });
+            return resource.memberIds;
         });
-
         return ids.flat();
     }
 
@@ -94,7 +91,7 @@ class FiggyViewerSet {
         // If there is a resource whose ID is included as a member_id of another resource,
         // filter it out
         const filterDuplicatedResources = resources.filter((resource) => {
-            if (!resource['members'])
+            if (!resource['memberIds'])
                 return true;
             const member_ids = this.getMemberIds(resources);
             const resource_is_unique = member_ids.map(() => {

--- a/app/javascript/orangelight/figgy_manifest_manager.js
+++ b/app/javascript/orangelight/figgy_manifest_manager.js
@@ -76,12 +76,41 @@ class FiggyViewerSet {
     return resources
   }
 
+  getMemberIds(resources) {
+    const ids = resources.map((resource) => {
+      return resource.members.map((member) => {
+        return member.id
+      })
+    })
+
+    return ids.flat()
+  }
+
   getManifestUrls(resources) {
     if (!resources) {
       return []
     }
 
-    return resources.map((resource) => {
+    // If there is a resource whose ID is included as a member_id of another resource,
+    // filter it out
+    const filterDuplicatedResources = resources.filter((resource) => {
+      if (!resource['members'])
+        return true
+      const member_ids = this.getMemberIds(resources)
+      const resource_is_unique =  member_ids.map((member_id) => {
+        if (member_ids.includes(resource.id))
+          return false
+      })
+
+      return !resource_is_unique.includes(false)
+    })
+
+    if (resources.length > 0 && filterDuplicatedResources.length < 1)
+      return resources.map((resource) => {
+        return resource.manifestUrl
+      })
+
+    return filterDuplicatedResources.map((resource) => {
       return resource.manifestUrl
     })
   }

--- a/app/javascript/orangelight/load-resources-by-orangelight-id.js
+++ b/app/javascript/orangelight/load-resources-by-orangelight-id.js
@@ -13,9 +13,7 @@ async function loadResourcesByOrangelightId(id) {
          },
          label,
          url,
-         members {
-           id
-         },
+         memberIds,
          embed {
            type,
            content,

--- a/app/javascript/orangelight/load-resources-by-orangelight-id.js
+++ b/app/javascript/orangelight/load-resources-by-orangelight-id.js
@@ -13,6 +13,9 @@ async function loadResourcesByOrangelightId(id) {
          },
          label,
          url,
+         members {
+           id
+         },
          embed {
            type,
            content,

--- a/app/javascript/orangelight/load-resources-by-orangelight-ids.js
+++ b/app/javascript/orangelight/load-resources-by-orangelight-ids.js
@@ -13,6 +13,9 @@ async function loadResourcesByOrangelightIds(ids) {
            thumbnailUrl
          },
          url,
+         members {
+           id
+         },
          ... on ScannedResource {
            manifestUrl,
            orangelightId

--- a/app/javascript/orangelight/load-resources-by-orangelight-ids.js
+++ b/app/javascript/orangelight/load-resources-by-orangelight-ids.js
@@ -13,9 +13,7 @@ async function loadResourcesByOrangelightIds(ids) {
            thumbnailUrl
          },
          url,
-         members {
-           id
-         },
+         memberIds,
          ... on ScannedResource {
            manifestUrl,
            orangelightId

--- a/spec/fixtures/alma/current_fixtures.json
+++ b/spec/fixtures/alma/current_fixtures.json
@@ -32612,5 +32612,145 @@
   "access_facet": [
     "In the Library"
   ]
+},
+{
+  "id": "9950403683506421",
+  "numeric_id_b": true,
+  "author_display": [
+    "Massachusetts. Council"
+  ],
+  "author_citation_display": [
+    "Massachusetts",
+    "Foster, John",
+    "Rawson, Edward",
+    "Green, Samuel",
+    "Stan. V. Henkels (Firm)"
+  ],
+  "author_roles_1display": "{\"secondary_authors\":[\"Foster, John\",\"Rawson, Edward\",\"Green, Samuel\",\"Massachusetts\",\"Stan. V. Henkels (Firm)\"],\"translators\":[],\"editors\":[],\"compilers\":[],\"primary_author\":\"Massachusetts\"}",
+  "author_s": [
+    "Massachusetts. Council",
+    "Foster, John, 1648-1681",
+    "Rawson, Edward, 1615-1693",
+    "Green, Samuel, 1615-1702",
+    "Massachusetts. Governor (1679-1686 : Bradstreet)",
+    "Stan. V. Henkels (Firm)"
+  ],
+  "marc_relator_display": [
+    "Author"
+  ],
+  "title_display": "At a Council held at Boston March 8. 1679,80. : The governour and Council, upon mature consideration of the many loud calls of Providence ... Do therefore appoint and order, that the fifteenth day of April next, be set apart for a day of humiliation and prayer ...",
+  "title_t": [
+    "At a Council held at Boston March 8. 1679,80. : The governour and Council, upon mature consideration of the many loud calls of Providence ... Do therefore appoint and order, that the fifteenth day of April next, be set apart for a day of humiliation and prayer ..."
+  ],
+  "title_citation_display": [
+    "At a Council held at Boston March 8. 1679,80. : The governour and Council, upon mature consideration of the many loud calls of Providence ... Do therefore appoint and order, that the fifteenth day of April next, be set apart for a day of humiliation and prayer ..."
+  ],
+  "compiled_created_t": [
+    "At a Council held at Boston March 8. 1679,80. : The governour and Council, upon mature consideration of the many loud calls of Providence ... Do therefore appoint and order, that the fifteenth day of April next, be set apart for a day of humiliation and prayer ..."
+  ],
+  "pub_created_display": [
+    "[Boston : Printed by John Foster, 1680]"
+  ],
+  "pub_created_s": [
+    "[Boston : Printed by John Foster, 1680]"
+  ],
+  "pub_citation_display": [
+    "Boston: Printed by John Foster"
+  ],
+  "pub_date_display": [
+    "1680"
+  ],
+  "pub_date_start_sort": 1680,
+  "cataloged_tdt": "2021-07-20T23:53:10Z",
+  "format": [
+    "Book"
+  ],
+  "description_display": [
+    "1 sheet ([1] p.) : ill. (relief cut) ; 32 x 22 cm."
+  ],
+  "description_t": [
+    "1 sheet ([1] p.) : ill. (relief cut) ; 32 x 22 cm."
+  ],
+  "number_of_pages_citation_display": [
+    "1 sheet ([1] p.)"
+  ],
+  "series_display": [
+    "Early American imprints. First series ; no. 287.",
+    "Early American imprints. First series ; no. 39214."
+  ],
+  "more_in_this_series_t": [
+    "Early American imprints. First series"
+  ],
+  "geo_related_record_display": [
+    "Multi-title collection including The Monitor, or, British freeholder ... number CCCLVII, Saturday, May the 22nd, 1762 and 37 other(s)."
+  ],
+  "contained_in_s": [
+    "99125086303506421"
+  ],
+  "notes_display": [
+    "This catalogue record is derived in large part from a record for an electronic reproduction.",
+    "Signed: Edward Rawson secr.",
+    "Imprint determined from colony seal used. Cf. Jones, Matt B. The early Massachusetts-Bay Colony seals, Proceedings of the American Antiquarian Society, new series, v. 44, 1934, p. 13-44.",
+    "WHS shelf-list has imprint: [Cambridge, Samuel Green, 1679/80].",
+    "WHS shelf-list has note: Unidentified ms. notes, probably for a sermon on the occasion, written on the margins and at the bottom of a proclamation of the Governor and Council of Massachusetts Bay proclaiming 15 April 1679-80 as a day of humiliation and prayer."
+  ],
+  "language_name_display": [
+    "English"
+  ],
+  "language_facet": [
+    "English"
+  ],
+  "language_code_s": [
+    "eng"
+  ],
+  "language_iana_s": [
+    "en"
+  ],
+  "provenance_display": [
+    "WHS copy acquired 11/18/24 from Henkels; inv. 517."
+  ],
+  "references_display": [
+    "Evans 287",
+    "Bristol B53",
+    "Shipton & Mooney 39214",
+    "Wing (2nd ed.) M966AB",
+    "Wing (2nd ed.) M1011",
+    "Ford, W.C. Broadsides, 76",
+    "Cushing, J.D. Mass. laws, 80"
+  ],
+  "references_url_display": [
+    "Evans 287",
+    "Bristol B53",
+    "Shipton & Mooney 39214",
+    "Wing (2nd ed.) M966AB",
+    "Wing (2nd ed.) M1011",
+    "Ford, W.C. Broadsides, 76",
+    "Cushing, J.D. Mass. laws, 80"
+  ],
+  "subject_facet": [
+    "Fast day proclamations—1680 Apr. 15.",
+    "Broadsides"
+  ],
+  "rbgenr_s": [
+    "Fast day proclamations—1680 Apr. 15.",
+    "Broadsides"
+  ],
+  "related_name_json_1display": "{\"Printer\":[\"Foster, John, 1648-1681\",\"Green, Samuel, 1615-1702\"],\"Related name\":[\"Rawson, Edward, 1615-1693\",\"Massachusetts. Governor (1679-1686 : Bradstreet)\"],\"Bookseller\":[\"Stan. V. Henkels (Firm)\"]}",
+  "in_display": [
+    "Multi-title collection including The Monitor, or, British freeholder ... number CCCLVII, Saturday, May the 22nd, 1762 and 37 other(s)."
+  ],
+  "oclc_s": [
+    "85773401"
+  ],
+  "other_version_s": [
+    "ocm85773401"
+  ],
+  "name_title_browse_s": [
+    "Massachusetts. Council. At a Council held at Boston March 8. 1679,80."
+  ],
+  "electronic_portfolio_s": [
+    "{\"desc\":null,\"title\":\"Newsbank America's Historical Imprints\",\"url\":\"https://na05.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&portfolio_pid=53848371460006421&Force_direct=true\",\"start\":null,\"end\":\"latest\",\"notes\":[]}",
+    "{\"desc\":null,\"title\":\"Newsbank America's Historical Imprints\",\"url\":\"https://na05.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true&portfolio_pid=53848371480006421&Force_direct=true\",\"start\":null,\"end\":\"latest\",\"notes\":[]}"
+  ]
 }
 ]

--- a/spec/javascript/orangelight/figgy_manifest_manager.spec.js
+++ b/spec/javascript/orangelight/figgy_manifest_manager.spec.js
@@ -7,7 +7,7 @@ describe('RelatedRecords', function() {
     test('viewer iframe has a title', async() => {
         document.body.innerHTML = '<div id="container"></div>';
         const element = document.getElementById('container');
-        const viewer = new FiggyViewer(0, element, 'https://example.com', []);
+        const viewer = new FiggyViewer(0, element, 'https://example.com');
         viewer.render().then(() => {
             const element = document.getElementById('iframe-1');
             expect(element.getAttribute('title')).toBe('Digital content viewer');
@@ -41,7 +41,7 @@ describe('RelatedRecords', function() {
 
       const availableOnlineElement = document.getElementsByClassName('availability--online');
       const viewerWrapperElement = document.getElementById('view');
-      const viewerSet = new FiggyViewerSet(viewerWrapperElement, queryFunction, 'dsp01wd3760321', [], null)
+      const viewerSet = new FiggyViewerSet(viewerWrapperElement, queryFunction, 'dsp01wd3760321', null)
       await viewerSet.render()
       expect(queryFunction).toHaveBeenCalledTimes(1);
       expect(availableOnlineElement[0].getElementsByTagName('li')).toHaveLength(2);
@@ -72,7 +72,7 @@ describe('RelatedRecords', function() {
 
       const availableOnlineElement = document.getElementsByClassName('availability--online');
       const viewerWrapperElement = document.getElementById('view');
-      const viewerSet = new FiggyViewerSet(viewerWrapperElement, queryFunction2, 'dsp01wd3760321', [], null)
+      const viewerSet = new FiggyViewerSet(viewerWrapperElement, queryFunction2, 'dsp01wd3760321', null)
       await viewerSet.render()
       expect(queryFunction2).toHaveBeenCalledTimes(1);
       expect(availableOnlineElement[0].getElementsByTagName('li')).toHaveLength(1);

--- a/spec/javascript/orangelight/figgy_manifest_manager.spec.js
+++ b/spec/javascript/orangelight/figgy_manifest_manager.spec.js
@@ -14,6 +14,178 @@ describe('RelatedRecords', function() {
         });
     });
 
+    test('displays one viewer for ScannedMaps', async() => {
+      const graphqlResponse = {
+                                "resourcesByOrangelightId": [
+                                  {
+                                    "id": "26b01ff3-eb40-40b0-821c-42fade1cf349",
+                                    "thumbnail": {
+                                      "iiifServiceUrl": "https://iiif-cloud.princeton.edu/iiif/2/84%2Fda%2Ff9%2F84daf940542e425a8c97fbfe53858b57%2Fintermediate_file",
+                                      "thumbnailUrl": "https://iiif-cloud.princeton.edu/iiif/2/84%2Fda%2Ff9%2F84daf940542e425a8c97fbfe53858b57%2Fintermediate_file/full/!200,150/0/default.jpg",
+                                      "__typename": "Thumbnail"
+                                    },
+                                    "label": "Pennsylvania: Troy Quadrangle.",
+                                    "url": "https://figgy.princeton.edu/catalog/26b01ff3-eb40-40b0-821c-42fade1cf349",
+                                    "members": [
+                                      {
+                                        "id": "85773d63-8a3a-4cea-b1c3-d9d0196bac3f",
+                                        "__typename": "FileSet"
+                                      }
+                                    ],
+                                    "embed": {
+                                      "type": "html",
+                                      "content": "\u003ciframe allowfullscreen=\"true\" id=\"uv_iframe\" src=\"https://figgy.princeton.edu/viewer#?manifest=https://figgy.princeton.edu/concern/scanned_maps/26b01ff3-eb40-40b0-821c-42fade1cf349/manifest\"\u003e\u003c/iframe\u003e",
+                                      "status": "authorized",
+                                      "__typename": "Embed"
+                                    },
+                                    "notice": null,
+                                    "manifestUrl": "https://figgy.princeton.edu/concern/scanned_maps/26b01ff3-eb40-40b0-821c-42fade1cf349/manifest",
+                                    "__typename": "ScannedMap"
+                                  },
+                                  {
+                                    "id": "a65bd135-5356-4613-8089-d90fc445cfda",
+                                    "thumbnail": {
+                                      "iiifServiceUrl": "https://iiif-cloud.princeton.edu/iiif/2/0f%2F6a%2F0d%2F0f6a0dcac6054d19987c6048854f505d%2Fintermediate_file",
+                                      "thumbnailUrl": "https://iiif-cloud.princeton.edu/iiif/2/0f%2F6a%2F0d%2F0f6a0dcac6054d19987c6048854f505d%2Fintermediate_file/full/!200,150/0/default.jpg",
+                                      "__typename": "Thumbnail"
+                                    },
+                                    "label": "Pennsylvania: (Lycoming) Trout Run Quadrangle",
+                                    "url": "https://figgy.princeton.edu/catalog/a65bd135-5356-4613-8089-d90fc445cfda",
+                                    "members": [
+                                      {
+                                        "id": "595ee476-d247-4339-83e2-bddb90a7d069",
+                                        "__typename": "ScannedMap"
+                                      },
+                                      {
+                                        "id": "26b01ff3-eb40-40b0-821c-42fade1cf349",
+                                        "__typename": "ScannedMap"
+                                      }
+                                    ],
+                                    "embed": {
+                                      "type": "html",
+                                      "content": "\u003ciframe allowfullscreen=\"true\" id=\"uv_iframe\" src=\"https://figgy.princeton.edu/viewer#?manifest=https://figgy.princeton.edu/concern/scanned_maps/a65bd135-5356-4613-8089-d90fc445cfda/manifest\"\u003e\u003c/iframe\u003e",
+                                      "status": "authorized",
+                                      "__typename": "Embed"
+                                    },
+                                    "notice": null,
+                                    "manifestUrl": "https://figgy.princeton.edu/concern/scanned_maps/a65bd135-5356-4613-8089-d90fc445cfda/manifest",
+                                    "__typename": "ScannedMap"
+                                  },
+                                  {
+                                    "id": "595ee476-d247-4339-83e2-bddb90a7d069",
+                                    "thumbnail": {
+                                      "iiifServiceUrl": "https://iiif-cloud.princeton.edu/iiif/2/0f%2F6a%2F0d%2F0f6a0dcac6054d19987c6048854f505d%2Fintermediate_file",
+                                      "thumbnailUrl": "https://iiif-cloud.princeton.edu/iiif/2/0f%2F6a%2F0d%2F0f6a0dcac6054d19987c6048854f505d%2Fintermediate_file/full/!200,150/0/default.jpg",
+                                      "__typename": "Thumbnail"
+                                    },
+                                    "label": "Pennsylvania: (Lycoming) Trout Run Quadrangle (Lycoming)",
+                                    "url": "https://figgy.princeton.edu/catalog/595ee476-d247-4339-83e2-bddb90a7d069",
+                                    "members": [
+                                      {
+                                        "id": "8fa8bc9b-b0e9-456c-a1ee-a913b2499054",
+                                        "__typename": "FileSet"
+                                      }
+                                    ],
+                                    "embed": {
+                                      "type": "html",
+                                      "content": "\u003ciframe allowfullscreen=\"true\" id=\"uv_iframe\" src=\"https://figgy.princeton.edu/viewer#?manifest=https://figgy.princeton.edu/concern/scanned_maps/595ee476-d247-4339-83e2-bddb90a7d069/manifest\"\u003e\u003c/iframe\u003e",
+                                      "status": "authorized",
+                                      "__typename": "Embed"
+                                    },
+                                    "notice": null,
+                                    "manifestUrl": "https://figgy.princeton.edu/concern/scanned_maps/595ee476-d247-4339-83e2-bddb90a7d069/manifest",
+                                    "__typename": "ScannedMap"
+                                  }
+                                ]
+                              };
+
+      document.body.innerHTML =
+      '<div class="availability--online"><h3>Available Online</h3><ul><li></li></ul></div>' +
+      '<div id="view" class="document-viewers" data-bib-id="9968683243506421"></div>';
+
+      const queryFunction = jest.fn((_bibIds) => { return graphqlResponse })
+      const availableOnlineElement = document.getElementsByClassName('availability--online');
+      const viewerWrapperElement = document.getElementById('view');
+
+      const viewerSet = new FiggyViewerSet(viewerWrapperElement, queryFunction, '9968683243506421', null)
+      await viewerSet.render()
+      expect(viewerWrapperElement.getElementsByTagName('iframe')).toHaveLength(1);
+    })
+
+    test('displays two viewers for objects with multi-spectral imaging', async() => {
+      const graphqlResponse = {
+                                "resourcesByOrangelightId": [
+                                  {
+                                    "id": "bbc6f6c4-3b92-4ae9-8461-1a14c113af8c",
+                                    "thumbnail": {
+                                      "iiifServiceUrl": "https://iiif-cloud.princeton.edu/iiif/2/e4%2F2c%2F68%2Fe42c680b62c44540836cb59164cead42%2Fintermediate_file",
+                                      "thumbnailUrl": "https://iiif-cloud.princeton.edu/iiif/2/e4%2F2c%2F68%2Fe42c680b62c44540836cb59164cead42%2Fintermediate_file/full/!200,150/0/default.jpg",
+                                      "__typename": "Thumbnail"
+                                    },
+                                    "label": "At a Council held at Boston March 8. 1679,80. : The governour and Council, upon mature consideration of the many loud calls of Providence ... Do therefore appoint and order, that the fifteenth day of April next, be set apart for a day of humiliation and prayer ...",
+                                    "url": "https://figgy.princeton.edu/catalog/bbc6f6c4-3b92-4ae9-8461-1a14c113af8c",
+                                    "members": [
+                                      {
+                                        "id": "8ecd795b-cd1b-4efc-9f1b-1411574d948c",
+                                        "__typename": "FileSet"
+                                      },
+                                      {
+                                        "id": "2e6c63af-7e2d-4191-a1b6-b4113394ce33",
+                                        "__typename": "FileSet"
+                                      }
+                                    ],
+                                    "embed": {
+                                      "type": "html",
+                                      "content": "\u003ciframe allowfullscreen=\"true\" id=\"uv_iframe\" src=\"https://figgy.princeton.edu/viewer#?manifest=https://figgy.princeton.edu/concern/scanned_resources/bbc6f6c4-3b92-4ae9-8461-1a14c113af8c/manifest\"\u003e\u003c/iframe\u003e",
+                                      "status": "authorized",
+                                      "__typename": "Embed"
+                                    },
+                                    "notice": null,
+                                    "manifestUrl": "https://figgy.princeton.edu/concern/scanned_resources/bbc6f6c4-3b92-4ae9-8461-1a14c113af8c/manifest",
+                                    "__typename": "ScannedResource"
+                                  },
+                                  {
+                                    "id": "54b399c7-f28c-46f6-a7b4-c835a60516c4",
+                                    "thumbnail": {
+                                      "iiifServiceUrl": "https://iiif-cloud.princeton.edu/iiif/2/bb%2Ffa%2F24%2Fbbfa247e175149db8d9151180dfa3896%2Fintermediate_file",
+                                      "thumbnailUrl": "https://iiif-cloud.princeton.edu/iiif/2/bb%2Ffa%2F24%2Fbbfa247e175149db8d9151180dfa3896%2Fintermediate_file/full/!200,150/0/default.jpg",
+                                      "__typename": "Thumbnail"
+                                    },
+                                    "label": "At a Council held at Boston March 8. 1679,80. : The governour and Council, upon mature consideration of the many loud calls of Providence ... Do therefore appoint and order, that the fifteenth day of April next, be set apart for a day of humiliation and prayer ...",
+                                    "url": "https://figgy.princeton.edu/catalog/54b399c7-f28c-46f6-a7b4-c835a60516c4",
+                                    "members": [
+                                      {
+                                        "id": "b9ce8d56-2ab7-48e0-8e97-d510b904f920",
+                                        "__typename": "ScannedResource"
+                                      },
+                                      {
+                                        "id": "e3e5ba6b-e7c6-4016-8c62-fe6656c020ca",
+                                        "__typename": "ScannedResource"
+                                      }
+                                    ],
+                                    "embed": {
+                                      "type": "html",
+                                      "content": "\u003ciframe allowfullscreen=\"true\" id=\"uv_iframe\" src=\"https://figgy.princeton.edu/viewer#?manifest=https://figgy.princeton.edu/concern/scanned_resources/54b399c7-f28c-46f6-a7b4-c835a60516c4/manifest\"\u003e\u003c/iframe\u003e",
+                                      "status": "authorized",
+                                      "__typename": "Embed"
+                                    },
+                                    "notice": null,
+                                    "manifestUrl": "https://figgy.princeton.edu/concern/scanned_resources/54b399c7-f28c-46f6-a7b4-c835a60516c4/manifest",
+                                    "__typename": "ScannedResource"
+                                  }
+                                ]
+                              };
+      document.body.innerHTML =
+      '<div class="availability--online"><h3>Available Online</h3><ul><li></li></ul></div>' +
+      '<div id="view" class="document-viewers" data-bib-id="9950403683506421"></div>';
+  
+      const queryFunction = jest.fn((_bibIds) => { return graphqlResponse })
+      const viewerWrapperElement = document.getElementById('view');
+      const viewerSet = new FiggyViewerSet(viewerWrapperElement, queryFunction, '9968683243506421', null)
+      await viewerSet.render()
+      expect(viewerWrapperElement.getElementsByTagName('iframe')).toHaveLength(2);
+    });
+
     test('adds request link when graphql notice returns unauthorized for a PUL thesis', async() => {
       const graphqlResponse = {
                                 "resourcesByOrangelightId": [

--- a/spec/javascript/orangelight/figgy_manifest_manager.spec.js
+++ b/spec/javascript/orangelight/figgy_manifest_manager.spec.js
@@ -26,11 +26,8 @@ describe('RelatedRecords', function() {
                                     },
                                     "label": "Pennsylvania: Troy Quadrangle.",
                                     "url": "https://figgy.princeton.edu/catalog/26b01ff3-eb40-40b0-821c-42fade1cf349",
-                                    "members": [
-                                      {
-                                        "id": "85773d63-8a3a-4cea-b1c3-d9d0196bac3f",
-                                        "__typename": "FileSet"
-                                      }
+                                    "memberIds": [
+                                      "85773d63-8a3a-4cea-b1c3-d9d0196bac3f"
                                     ],
                                     "embed": {
                                       "type": "html",
@@ -51,15 +48,9 @@ describe('RelatedRecords', function() {
                                     },
                                     "label": "Pennsylvania: (Lycoming) Trout Run Quadrangle",
                                     "url": "https://figgy.princeton.edu/catalog/a65bd135-5356-4613-8089-d90fc445cfda",
-                                    "members": [
-                                      {
-                                        "id": "595ee476-d247-4339-83e2-bddb90a7d069",
-                                        "__typename": "ScannedMap"
-                                      },
-                                      {
-                                        "id": "26b01ff3-eb40-40b0-821c-42fade1cf349",
-                                        "__typename": "ScannedMap"
-                                      }
+                                    "memberIds": [
+                                      "595ee476-d247-4339-83e2-bddb90a7d069",
+                                      "26b01ff3-eb40-40b0-821c-42fade1cf349"
                                     ],
                                     "embed": {
                                       "type": "html",
@@ -80,11 +71,8 @@ describe('RelatedRecords', function() {
                                     },
                                     "label": "Pennsylvania: (Lycoming) Trout Run Quadrangle (Lycoming)",
                                     "url": "https://figgy.princeton.edu/catalog/595ee476-d247-4339-83e2-bddb90a7d069",
-                                    "members": [
-                                      {
-                                        "id": "8fa8bc9b-b0e9-456c-a1ee-a913b2499054",
-                                        "__typename": "FileSet"
-                                      }
+                                    "memberIds": [
+                                      "8fa8bc9b-b0e9-456c-a1ee-a913b2499054"
                                     ],
                                     "embed": {
                                       "type": "html",
@@ -124,15 +112,9 @@ describe('RelatedRecords', function() {
                                     },
                                     "label": "At a Council held at Boston March 8. 1679,80. : The governour and Council, upon mature consideration of the many loud calls of Providence ... Do therefore appoint and order, that the fifteenth day of April next, be set apart for a day of humiliation and prayer ...",
                                     "url": "https://figgy.princeton.edu/catalog/bbc6f6c4-3b92-4ae9-8461-1a14c113af8c",
-                                    "members": [
-                                      {
-                                        "id": "8ecd795b-cd1b-4efc-9f1b-1411574d948c",
-                                        "__typename": "FileSet"
-                                      },
-                                      {
-                                        "id": "2e6c63af-7e2d-4191-a1b6-b4113394ce33",
-                                        "__typename": "FileSet"
-                                      }
+                                    "memberIds": [
+                                      "8ecd795b-cd1b-4efc-9f1b-1411574d948c",
+                                      "2e6c63af-7e2d-4191-a1b6-b4113394ce33"
                                     ],
                                     "embed": {
                                       "type": "html",
@@ -153,15 +135,9 @@ describe('RelatedRecords', function() {
                                     },
                                     "label": "At a Council held at Boston March 8. 1679,80. : The governour and Council, upon mature consideration of the many loud calls of Providence ... Do therefore appoint and order, that the fifteenth day of April next, be set apart for a day of humiliation and prayer ...",
                                     "url": "https://figgy.princeton.edu/catalog/54b399c7-f28c-46f6-a7b4-c835a60516c4",
-                                    "members": [
-                                      {
-                                        "id": "b9ce8d56-2ab7-48e0-8e97-d510b904f920",
-                                        "__typename": "ScannedResource"
-                                      },
-                                      {
-                                        "id": "e3e5ba6b-e7c6-4016-8c62-fe6656c020ca",
-                                        "__typename": "ScannedResource"
-                                      }
+                                    "memberIds": [
+                                      "b9ce8d56-2ab7-48e0-8e97-d510b904f920",
+                                      "e3e5ba6b-e7c6-4016-8c62-fe6656c020ca"
                                     ],
                                     "embed": {
                                       "type": "html",
@@ -181,7 +157,7 @@ describe('RelatedRecords', function() {
   
       const queryFunction = jest.fn((_bibIds) => { return graphqlResponse })
       const viewerWrapperElement = document.getElementById('view');
-      const viewerSet = new FiggyViewerSet(viewerWrapperElement, queryFunction, '9968683243506421', null)
+      const viewerSet = new FiggyViewerSet(viewerWrapperElement, queryFunction, '9950403683506421', null)
       await viewerSet.render()
       expect(viewerWrapperElement.getElementsByTagName('iframe')).toHaveLength(2);
     });


### PR DESCRIPTION
Records to check:
* Multiple maps - should have one viewer
  * https://catalog-qa.princeton.edu/catalog/9968107933506421
* Another example of multiple maps - should have one viewer
  * https://catalog-qa.princeton.edu/catalog/9968683243506421
* Multi-spectral imaging - should have two viewers
  * https://catalog-qa.princeton.edu/catalog/9950403683506421
* (Gutenberg) Bible - two viewers, one for both volumes, one for a single leaf
  * https://catalog-qa.princeton.edu/catalog/9946093213506421

Closes #3450

