### PR TITLE
Show page links directly to aeon, rather than a redirect

### DIFF
--- a/app/components/aeon_request_button_component.rb
+++ b/app/components/aeon_request_button_component.rb
@@ -2,9 +2,9 @@
 
 # ViewComponent that displays an aeon request button on the show page
 class AeonRequestButtonComponent < RequestButtonComponent
-  def initialize(document:, location:)
+  def initialize(document:, holding: nil)
     @document = document
-    @location = location
+    @holding = holding
   end
 
   def label
@@ -16,6 +16,6 @@ class AeonRequestButtonComponent < RequestButtonComponent
   end
 
   def url
-    Requests::AeonUrl.new(document: @document).to_s
+    Requests::AeonUrl.new(document: @document, holding: @holding).to_s
   end
 end

--- a/app/components/aeon_request_button_component.rb
+++ b/app/components/aeon_request_button_component.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# ViewComponent that displays an aeon request button on the show page
+class AeonRequestButtonComponent < RequestButtonComponent
+  def initialize(document:, location:)
+    @document = document
+    @location = location
+  end
+
+  def label
+    'Reading Room Request'
+  end
+
+  def tooltip
+    'Request to view in Reading Room'
+  end
+
+  def url
+    Requests::AeonUrl.new(document: @document).to_s
+  end
+end

--- a/app/components/request_button_component.rb
+++ b/app/components/request_button_component.rb
@@ -2,11 +2,10 @@
 
 # ViewComponent that displays a request button on the show page
 class RequestButtonComponent < ViewComponent::Base
-  def initialize(location:, doc_id:, holding_id: nil, force_aeon: false)
+  def initialize(location:, doc_id:, holding_id: nil)
     @location = location
     @doc_id = doc_id
     @holding_id = holding_id
-    @force_aeon = force_aeon
   end
 
   def label
@@ -27,6 +26,6 @@ class RequestButtonComponent < ViewComponent::Base
   private
 
     def aeon?
-      @aeon ||= @force_aeon || @location&.dig(:aeon_location)
+      @aeon ||= @location&.dig(:aeon_location)
     end
 end

--- a/app/components/request_button_component.rb
+++ b/app/components/request_button_component.rb
@@ -2,9 +2,10 @@
 
 # ViewComponent that displays a request button on the show page
 class RequestButtonComponent < ViewComponent::Base
-  def initialize(location:, doc_id:, holding_id: nil)
+  def initialize(location:, doc_id:, holding: nil, holding_id: nil)
     @location = location
     @doc_id = doc_id
+    @holding = holding
     @holding_id = holding_id
   end
 
@@ -26,6 +27,12 @@ class RequestButtonComponent < ViewComponent::Base
   private
 
     def aeon?
-      @aeon ||= @location&.dig(:aeon_location)
+      @aeon ||= (@location&.dig(:aeon_location) || scsb_supervised_items?)
+    end
+
+    def scsb_supervised_items?
+      return false unless @holding
+      return false unless @holding['items']
+      @holding['items'].all? { |item| item['use_statement'] == 'Supervised Use' }
     end
 end

--- a/app/controllers/requests/request_controller.rb
+++ b/app/controllers/requests/request_controller.rb
@@ -42,7 +42,7 @@ module Requests
       if @request.thesis? || @request.numismatics?
         redirect_to "#{Requests::Config[:aeon_base]}?#{@request.requestable.first.aeon_mapped_params.to_query}"
       elsif @request.single_aeon_requestable?
-        redirect_to @request.first_filtered_requestable.aeon_request_url(@request.ctx)
+        redirect_to @request.first_filtered_requestable.aeon_request_url
       end
     end
 

--- a/app/models/concerns/requests/aeon.rb
+++ b/app/models/concerns/requests/aeon.rb
@@ -34,7 +34,7 @@ module Requests
     end
 
     def aeon_request_url
-      AeonUrl.new(document: bib).to_s
+      AeonUrl.new(document: bib, holding:, item:).to_s
     end
 
     # returns encoded OpenURL string for alma derived records

--- a/app/models/concerns/requests/aeon.rb
+++ b/app/models/concerns/requests/aeon.rb
@@ -33,9 +33,8 @@ module Requests
       }.compact
     end
 
-    # accepts the base Openurl Context Object and formats it appropriately for Aeon
-    def aeon_request_url(ctx = nil)
-      "#{Requests::Config[:aeon_base]}/OpenURL?#{aeon_openurl(ctx)}"
+    def aeon_request_url
+      AeonUrl.new(document: bib).to_s
     end
 
     # returns encoded OpenURL string for alma derived records

--- a/app/models/requests/aeon_url.rb
+++ b/app/models/requests/aeon_url.rb
@@ -57,7 +57,15 @@ module Requests
       end
 
       def item
-        @item ||= holding&.fetch('items', nil)&.first
+        @item ||= barcode_from_holding || barcode_from_document
+      end
+
+      def barcode_from_holding
+        holding&.fetch('items', nil)&.first
+      end
+
+      def barcode_from_document
+        @document.holdings_all_display.values.first&.fetch('items', nil)&.first
       end
 
       def at_mudd?

--- a/app/models/requests/aeon_url.rb
+++ b/app/models/requests/aeon_url.rb
@@ -2,8 +2,13 @@
 module Requests
   # Create a URL that creates an aeon request
   class AeonUrl
-    def initialize(document:)
+    # @param document [SolrDocument]
+    # @param holding [Hash]
+    # @param item [Requests::Requestable::Item]
+    def initialize(document:, holding: nil, item: nil)
       @document = document
+      @holding = holding.values.first if holding
+      @item = item if item
     end
 
     def to_s

--- a/app/models/requests/aeon_url.rb
+++ b/app/models/requests/aeon_url.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+module Requests
+  # Create a URL that creates an aeon request
+  class AeonUrl
+    def initialize(document:)
+      @document = document
+    end
+
+    def to_s
+      @compiled_string ||= "#{Requests::Config[:aeon_base]}/OpenURL?#{query_string}"
+    end
+
+    private
+
+      def query_string
+        "#{ctx_with_item_info.kev}&#{aeon_basic_params.to_query}"
+      end
+
+      def ctx_with_item_info
+        ctx = @document.to_ctx
+        if item.present?
+          ctx.referent.set_metadata('iteminfo5', item['id']&.to_s)
+          if enum_value.present?
+            ctx.referent.set_metadata('volume', enum_value)
+            ctx.referent.set_metadata('issue', item[:chron_display]) if item[:chron_display].present?
+          else
+            ctx.referent.set_metadata('volume', holding['location_has']&.first)
+            ctx.referent.set_metadata('issue', nil)
+          end
+        end
+        ctx
+      end
+
+      def aeon_basic_params
+        {
+          ReferenceNumber: @document[:id],
+          CallNumber: holding['call_number'],
+          Site: site,
+          Location: shelf_location_code,
+          SubLocation: location_note,
+          ItemInfo1: I18n.t("requests.aeon.access_statement"),
+          ItemNumber: item&.fetch('barcode', nil)
+        }.compact
+      end
+
+      def holding
+        @holding ||= @document.holdings_all_display.values.first
+      end
+
+      def enum_value
+        [item['enum_display'], item['enumeration']].join(" ").strip
+      end
+
+      def item
+        @item ||= holding&.fetch('items', nil)&.first
+      end
+
+      def at_mudd?
+        location = ::Bibdata.holding_locations.fetch(shelf_location_code, nil)
+        location&.fetch('library', nil)&.fetch('code', nil) == 'mudd' || thesis?
+      end
+
+      def shelf_location_code
+        holding&.fetch('location_code', nil)
+      end
+
+      def location_note
+        holding[:location_note]&.first
+      end
+
+      def thesis?
+        @document.holdings_all_display&.keys&.first == "thesis"
+      end
+
+      def site
+        return 'MUDD' if at_mudd?
+        'RBSC'
+      end
+  end
+end

--- a/app/models/requests/requestable_decorator.rb
+++ b/app/models/requests/requestable_decorator.rb
@@ -141,9 +141,9 @@ module Requests
       I18n.t("requests.help_me.brief_msg.#{key}_html").html_safe # rubocop:disable Rails/OutputSafety
     end
 
-    def aeon_url(request_ctx)
+    def aeon_url(_request_ctx)
       if requestable.alma_managed?
-        requestable.aeon_request_url(request_ctx)
+        requestable.aeon_request_url
       else
         "#{Requests::Config[:aeon_base]}?#{requestable.aeon_mapped_params.to_query}"
       end

--- a/app/services/physical_holdings_markup_builder.rb
+++ b/app/services/physical_holdings_markup_builder.rb
@@ -278,17 +278,10 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
     # so that it will be "/request/#{doc_id}", where doc_id can be either the record page mms_id or the host id(s) if they exist.
     doc_id = doc_id(holding)
     view_base = ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil)
-    link = if aeon_location?(location_rules)
+    link = if display_direct_aeon_link?(location_rules, holding_id)
              AeonRequestButtonComponent.new(document: adapter.document, location: location_rules).render_in(view_base)
-           elsif !location_rules.nil? && /^scsb.+/ =~ location_rules['code']
-             if scsb_supervised_items?(holding)
-               # All SCSB supervised items go through Aeon
-               AeonRequestButtonComponent.new(document: adapter.document, location: location_rules).render_in(view_base)
-             else
-               RequestButtonComponent.new(doc_id:, location: location_rules).render_in(view_base)
-             end
-           elsif !adapter.alma_holding?(holding_id)
-             AeonRequestButtonComponent.new(document: adapter.document, location: location_rules).render_in(view_base)
+           elsif self.class.scsb_location?(location_rules)
+             RequestButtonComponent.new(doc_id:, location: location_rules, holding:).render_in(view_base)
            elsif self.class.temporary_holding_id?(holding_id)
              holding_identifier = self.class.temporary_location_holding_id_first(holding)
              RequestButtonComponent.new(doc_id:, holding_id: holding_identifier, location: location_rules).render_in(view_base)
@@ -297,6 +290,15 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
            end
     markup = self.class.location_services_block(adapter, holding_id, location_rules, link, holding)
     markup
+  end
+
+  def display_direct_aeon_link?(location_rules, holding_id)
+    return true if aeon_location?(location_rules)
+
+    # If it is not from SCSB or alma, it must be aeon
+    return true unless self.class.scsb_location?(location_rules) || adapter.alma_holding?(holding_id)
+
+    false
   end
 
   def request_url(doc_id:, aeon:, holding_id: nil)

--- a/app/services/physical_holdings_markup_builder.rb
+++ b/app/services/physical_holdings_markup_builder.rb
@@ -279,7 +279,7 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
     doc_id = doc_id(holding)
     view_base = ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil)
     link = if display_direct_aeon_link?(location_rules, holding_id)
-             AeonRequestButtonComponent.new(document: adapter.document, location: location_rules).render_in(view_base)
+             AeonRequestButtonComponent.new(document: adapter.document, holding: { doc_id: holding }).render_in(view_base)
            elsif self.class.scsb_location?(location_rules)
              RequestButtonComponent.new(doc_id:, location: location_rules, holding:).render_in(view_base)
            elsif self.class.temporary_holding_id?(holding_id)

--- a/app/services/physical_holdings_markup_builder.rb
+++ b/app/services/physical_holdings_markup_builder.rb
@@ -278,7 +278,9 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
     # so that it will be "/request/#{doc_id}", where doc_id can be either the record page mms_id or the host id(s) if they exist.
     doc_id = doc_id(holding)
     view_base = ActionView::Base.new(ActionView::LookupContext.new([]), {}, nil)
-    link = if !location_rules.nil? && /^scsb.+/ =~ location_rules['code']
+    link = if aeon_location?(location_rules)
+             AeonRequestButtonComponent.new(document: adapter.document, location: location_rules).render_in(view_base)
+           elsif !location_rules.nil? && /^scsb.+/ =~ location_rules['code']
              if scsb_supervised_items?(holding)
                # All SCSB supervised items go through Aeon
                AeonRequestButtonComponent.new(document: adapter.document, location: location_rules).render_in(view_base)

--- a/app/services/physical_holdings_markup_builder.rb
+++ b/app/services/physical_holdings_markup_builder.rb
@@ -281,12 +281,12 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
     link = if !location_rules.nil? && /^scsb.+/ =~ location_rules['code']
              if scsb_supervised_items?(holding)
                # All SCSB supervised items go through Aeon
-               RequestButtonComponent.new(doc_id:, location: location_rules, force_aeon: true).render_in(view_base)
+               AeonRequestButtonComponent.new(document: adapter.document, location: location_rules).render_in(view_base)
              else
                RequestButtonComponent.new(doc_id:, location: location_rules).render_in(view_base)
              end
            elsif !adapter.alma_holding?(holding_id)
-             RequestButtonComponent.new(doc_id:, location: location_rules, holding_id:, force_aeon: true).render_in(view_base)
+             AeonRequestButtonComponent.new(document: adapter.document, location: location_rules).render_in(view_base)
            elsif self.class.temporary_holding_id?(holding_id)
              holding_identifier = self.class.temporary_location_holding_id_first(holding)
              RequestButtonComponent.new(doc_id:, holding_id: holding_identifier, location: location_rules).render_in(view_base)

--- a/spec/components/aeon_request_button_component_spec.rb
+++ b/spec/components/aeon_request_button_component_spec.rb
@@ -9,13 +9,10 @@ RSpec.describe AeonRequestButtonComponent, type: :component do
   let(:holding) do
     { "22740186070006421" => { "items" => [{ "holding_id" => "22740186070006421", "id" => "23740186060006421", "barcode" => "24680" }] } }
   end
-  let(:location) do
-    { aeon_location: false, 'library' => { 'code' => 'eastasian' } }
-  end
   let(:document) do
     SolrDocument.new({ id: '1234', holdings_1display: holding.to_json.to_s })
   end
-  subject { render_inline(described_class.new(document:, location:)) }
+  subject { render_inline(described_class.new(document:)) }
   it "renders a link with the appropriate classes" do
     expect(subject.css('a').attribute('class').to_s).to eq('request btn btn-xs btn-primary')
   end

--- a/spec/components/aeon_request_button_component_spec.rb
+++ b/spec/components/aeon_request_button_component_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe AeonRequestButtonComponent, type: :component do
+  before do
+    stub_holding_locations
+  end
+  let(:holding) do
+    { "22740186070006421" => { "items" => [{ "holding_id" => "22740186070006421", "id" => "23740186060006421", "barcode" => "24680" }] } }
+  end
+  let(:location) do
+    { aeon_location: false, 'library' => { 'code' => 'eastasian' } }
+  end
+  let(:document) do
+    SolrDocument.new({ id: '1234', holdings_1display: holding.to_json.to_s })
+  end
+  subject { render_inline(described_class.new(document:, location:)) }
+  it "renders a link with the appropriate classes" do
+    expect(subject.css('a').attribute('class').to_s).to eq('request btn btn-xs btn-primary')
+  end
+  it 'renders the typical title tooltip' do
+    expect(subject.css('a').attribute('title').text).to eq('Request to view in Reading Room')
+  end
+  it 'renders the typical request text' do
+    expect(subject.css('a').text).to eq('Reading Room Request')
+  end
+  it 'includes aeon=false in the link url' do
+    expect(subject.css('a').attribute('href').text).to include('https://lib-aeon.princeton.edu/aeon/aeon.dll/OpenURL?')
+  end
+end

--- a/spec/components/request_button_component_spec.rb
+++ b/spec/components/request_button_component_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe RequestButtonComponent, type: :component do
   it 'includes aeon=false in the link url' do
     expect(subject.css('a').attribute('href').text).to eq('/requests/123?aeon=false&mfhd=456')
   end
+
   context 'when at an aeon location' do
     let(:location) do
       { aeon_location: true }
@@ -33,10 +34,21 @@ RSpec.describe RequestButtonComponent, type: :component do
       expect(subject.css('a').attribute('href').text).to eq('/requests/123?aeon=true&mfhd=456')
     end
   end
+
   context 'when no holding_id' do
     subject { render_inline(described_class.new(location:, doc_id: '123')) }
     it 'does not include mfhd param in the link url' do
       expect(subject.css('a').attribute('href').text).to eq('/requests/123?aeon=false')
+    end
+  end
+
+  context 'scsb supervised use' do
+    let(:holding) do
+      { 'items' => [{ 'use_statement' => 'Supervised Use' }] }
+    end
+    subject { render_inline(described_class.new(location:, doc_id: '123', holding_id: '456', holding:)) }
+    it 'includes aeon=true in the link url' do
+      expect(subject.css('a').attribute('href').text).to eq('/requests/123?aeon=true&mfhd=456')
     end
   end
 end

--- a/spec/controllers/requests/request_controller_spec.rb
+++ b/spec/controllers/requests/request_controller_spec.rb
@@ -60,6 +60,7 @@ describe Requests::RequestController, type: :controller, vcr: { cassette_name: '
         expect(response.status).to eq(302)
       end
       it 'redirects you when a single aeon record is requested' do
+        stub_holding_locations
         get :generate, params: {
           source: 'pulsearch',
           system_id: '9995768803506421',

--- a/spec/features/login_account_spec.rb
+++ b/spec/features/login_account_spec.rb
@@ -182,7 +182,7 @@ describe 'Account login' do
           end
           it 'does not require authentication', js: true do
             visit "/catalog/#{bib_id}"
-            expect(page).to have_link('Reading Room Request', href: "/requests/#{bib_id}?aeon=true&mfhd=22745123330006421")
+            expect(page).to have_link('Reading Room Request', href: Regexp.new('https://lib-aeon\.princeton\.edu/aeon/aeon\.dll/OpenURL.*dsp01tq57ns24j'))
             click_link('Reading Room Request', href: "/requests/#{bib_id}?aeon=true&mfhd=22745123330006421")
             expect(page.current_url).to include(Requests::Config[:aeon_base])
           end

--- a/spec/features/login_account_spec.rb
+++ b/spec/features/login_account_spec.rb
@@ -155,7 +155,7 @@ describe 'Account login' do
 
           it 'does not require authentication', js: true do
             visit "/catalog/coin-1167"
-            expect(page).to have_link('Reading Room Request', href: '/requests/coin-1167?aeon=true&mfhd=numismatics')
+            expect(page).to have_link('Reading Room Request', href: Regexp.new('https://lib-aeon\.princeton\.edu/aeon/aeon\.dll/OpenURL.*Coin.1167'))
             click_link('Reading Room Request')
             expect(page.current_url).to include(Requests::Config[:aeon_base])
           end
@@ -167,7 +167,7 @@ describe 'Account login' do
           end
           it 'does not require authentication', js: true do
             visit "/catalog/dsp01tq57ns24j"
-            expect(page).to have_link('Reading Room Request', href: '/requests/dsp01tq57ns24j?aeon=true&mfhd=thesis')
+            expect(page).to have_link('Reading Room Request', href: Regexp.new('https://lib-aeon\.princeton\.edu/aeon/aeon\.dll/OpenURL.*dsp01tq57ns24j'))
             click_link('Reading Room Request')
             expect(page.current_url).to include(Requests::Config[:aeon_base])
           end

--- a/spec/features/login_account_spec.rb
+++ b/spec/features/login_account_spec.rb
@@ -182,8 +182,8 @@ describe 'Account login' do
           end
           it 'does not require authentication', js: true do
             visit "/catalog/#{bib_id}"
-            expect(page).to have_link('Reading Room Request', href: Regexp.new('https://lib-aeon\.princeton\.edu/aeon/aeon\.dll/OpenURL.*dsp01tq57ns24j'))
-            click_link('Reading Room Request', href: "/requests/#{bib_id}?aeon=true&mfhd=22745123330006421")
+            expect(page).to have_link('Reading Room Request', href: Regexp.new('https://lib-aeon\.princeton\.edu/aeon/aeon\.dll/OpenURL.*CallNumber\=RECAP-94760855'))
+            click_link('Reading Room Request', href: Regexp.new('https://lib-aeon\.princeton\.edu/aeon/aeon\.dll/OpenURL.*CallNumber\=RECAP-94760855'))
             expect(page.current_url).to include(Requests::Config[:aeon_base])
           end
         end

--- a/spec/features/requests/request_spec.rb
+++ b/spec/features/requests/request_spec.rb
@@ -1536,6 +1536,7 @@ describe 'request', vcr: { cassette_name: 'request_features', record: :none }, t
         end
 
         it 'allows aeon requests for all users' do
+          stub_holding_locations
           visit '/requests/9973529363506421?mfhd=22667098990006421'
           expect(page).to have_content 'Request to View in Reading Room'
           expect(page).not_to have_content 'Request this Item'

--- a/spec/models/requests/aeon_url_spec.rb
+++ b/spec/models/requests/aeon_url_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Requests::AeonUrl do
+  let(:holdings) do
+    { "12345" => {
+      "location" => "Special Collections - Numismatics Collection",
+      "library" => "Special Collections",
+      "location_code" => "rare$num",
+      "call_number" => "Coin 3750",
+      "items" => [{ "holding_id" => "22740186070006421", "id" => "23740186060006421", "barcode" => "24680" }]
+    } }
+  end
+  let(:document) do
+    SolrDocument.new({
+                       id: '9999999',
+                       holdings_1display: holdings.to_json.to_s
+                     })
+  end
+  before do
+    stub_holding_locations
+  end
+  subject { described_class.new(document:).to_s }
+  it 'begins with the aeon prefix' do
+    expect(subject).to match(/^#{Requests::Config[:aeon_base]}/)
+  end
+  it 'uses the document id as the ReferenceNumber' do
+    expect(subject).to include('ReferenceNumber=9999999')
+  end
+  it 'takes the CallNumber from holdings_1display' do
+    expect(subject).to include('CallNumber=Coin+3750')
+  end
+  it 'typically uses RBSC as the Site' do
+    expect(subject).to include('Site=RBSC')
+  end
+  it 'takes the openurl iteminfo5 from the item id' do
+    expect(subject).to include('rft.iteminfo5=23740186060006421')
+  end
+  it 'takes the ItemNumber from the barcode' do
+    expect(subject).to include('ItemNumber=24680')
+  end
+  context 'when the location is at a Mudd location' do
+    let(:holdings) do
+      { "12345" => {
+        "location_code" => "mudd$prnc",
+        "call_number" => "Coin 3750",
+        "items" => [{ "holding_id" => "22740186070006421", "id" => "23740186060006421" }]
+      } }
+    end
+    it 'uses MUDD as the site' do
+      expect(subject).to include('Site=MUDD')
+    end
+  end
+  context 'when a thesis holding' do
+    let(:holdings) do
+      { "thesis": { "call_number": "AC102", "call_number_browse": "AC102", "dspace": true } }
+    end
+    it 'uses MUDD as the site' do
+      expect(subject).to include('Site=MUDD')
+    end
+  end
+  context 'when bib record is a constituent' do
+    let(:document) { SolrDocument.new({ id: '1234', contained_in_s: ['9999'] }) }
+    it 'takes its ItemNumber from the host record barcode' do
+      allow(document).to receive(:doc_by_id) { { 'holdings_1display' => '{"1":{"items":[{"barcode":"33_host_barcode"}]}}' } }
+      expect(subject).to include('ItemNumber=33_host_barcode')
+    end
+  end
+end

--- a/spec/models/requests/aeon_url_spec.rb
+++ b/spec/models/requests/aeon_url_spec.rb
@@ -66,4 +66,27 @@ RSpec.describe Requests::AeonUrl do
       expect(subject).to include('ItemNumber=33_host_barcode')
     end
   end
+  context 'when a specific holding is passed in' do
+    subject do
+      holding = { "22667098990006421" => { "location_code" => "rare$ctsn", "location" => "Cotsen Children's Library", "library" => "Special Collections", "call_number" => "153521 Pams / NR / Chinese / Box 41", "call_number_browse" => "153521 Pams / NR / Chinese / Box 41", "location_has" => ["Vol. 1: [no. 1]-[no. 4] ([Jan.] 2013 - [Oct.] 2013)", "Vol. 2: no. 1-6 (=Issue no. 5-10; Jan. 2014 - Nov. 2014)", "Vol. 3: no. 1-6 (=Issue no. 11-16; Jan. 2015 - Nov. 2015)", "Vol. 4: no. 1-6 (=Issue no. 17-22; Jan. 2016 - Nov. 2016)", "Vol. 5: no. 1-6 (=Issue no. 23-28; Jan. 2017 - Nov. 2017)", "Princeton copy 1"],
+                                           "items" => [{ "holding_id" => "22667098990006421", "id" => "23667098920006421", "status_at_load" => "1", "enumeration" => "Vol. 4: no. 1 - 6", "barcode" => "32101091127959", "copy_number" => "1" }, { "holding_id" => "22667098990006421", "id" => "23667098930006421", "status_at_load" => "1", "enumeration" => "Vol. 5: no. 1-6", "barcode" => "32101094417795", "copy_number" => "1" }, { "holding_id" => "22667098990006421", "id" => "23667098940006421", "status_at_load" => "1", "enumeration" => "Vol. 3: no. 1 - 6", "barcode" => "32101071686446", "copy_number" => "1" },
+                                                       { "holding_id" => "22667098990006421", "id" => "23667098950006421", "status_at_load" => "1", "enumeration" => "Vol. 2: no. 1 - 6", "barcode" => "32101071686438", "copy_number" => "1" }, { "holding_id" => "22667098990006421", "id" => "23667098970006421", "status_at_load" => "0", "enumeration" => "9", "barcode" => "ISSitm51830.290-princetondb" }, { "holding_id" => "22667098990006421", "id" => "23667098960006421", "status_at_load" => "1", "enumeration" => "Vol 1: no. 1 - 4", "barcode" => "32101071302192", "copy_number" => "1" }] } }
+      described_class.new(document:, holding:).to_s
+    end
+    it('takes the call number from the holding') do
+      expect(subject).to include('CallNumber=153521+Pams+%2F+NR+%2F+Chinese+%2F+Box+41')
+    end
+  end
+  context 'when a specific item is passed in' do
+    subject do
+      item = Requests::Requestable::Item.new({ "barcode" => "32101071302192", "id" => "23667098960006421", "holding_id" => "22667098990006421", "copy_number" => "1", "status" => "Available", "status_label" => "Item in place", "status_source" => "base_status", "process_type" => nil, "on_reserve" => "N", "item_type" => "Closed", "pickup_location_id" => "rare", "pickup_location_code" => "rare", "location" => "rare$ctsn", "label" => "Special Collections - Cotsen Children's Library", "description" => "Vol 1: no. 1 - 4 Jan 2013 - Oct 2013", "enum_display" => "Vol 1: no. 1 - 4", "chron_display" => "Jan 2013 - Oct 2013", "in_temp_library" => false })
+      described_class.new(document:, item:).to_s
+    end
+    it('takes the barcode from the item') do
+      expect(subject).to include('ItemNumber=32101071302192')
+    end
+    it('takes enumeration from the item') do
+      expect(subject).to include('rft.volume=Vol+1%3A+no.+1+-+4')
+    end
+  end
 end

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -344,7 +344,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
       end
     end
 
-    describe '#aeon_open_url' do
+    describe '#aeon_openurl' do
       it 'returns an openurl with a Call Number param' do
         expect(requestable.aeon_openurl(request.ctx)).to be_a(String)
       end

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -684,7 +684,8 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
 
     describe '#aeon_request_url' do
       it 'beings with Aeon GFA base' do
-        expect(requestable.aeon_request_url(request.ctx)).to match(/^#{Requests::Config[:aeon_base]}/)
+        stub_holding_locations
+        expect(requestable.aeon_request_url).to match(/^#{Requests::Config[:aeon_base]}/)
       end
     end
 

--- a/spec/services/physical_holdings_markup_builder_spec.rb
+++ b/spec/services/physical_holdings_markup_builder_spec.rb
@@ -201,8 +201,11 @@ RSpec.describe PhysicalHoldingsMarkupBuilder do
 
       before do
         allow(adapter).to receive(:alma_holding?).and_return(false)
+        allow_any_instance_of(SolrDocument).to receive(:to_ctx).and_return(OpenURL::ContextObject.new)
+        allow(document).to receive(:[]).and_return('data')
+        allow(document).to receive(:to_ctx).and_return(OpenURL::ContextObject.new)
+        allow(document).to receive(:holdings_all_display).and_return({ 'my_id' => holding })
         allow(adapter).to receive(:document).and_return(document)
-        allow(holding).to receive(:dig).and_return("coin-3750")
       end
       # this should be hitting the third condition, but does not seem to be
       it 'generates the request link for the host record' do
@@ -213,7 +216,8 @@ RSpec.describe PhysicalHoldingsMarkupBuilder do
         expect(request_placeholder_markup).to include 'data-holding-id="numismatics"'
         expect(request_placeholder_markup).to include '<a '
         expect(request_placeholder_markup).to include 'title="Request to view in Reading Room"'
-        expect(request_placeholder_markup).to include 'href="/requests/coin-3750?aeon=true&amp;mfhd=numismatics"'
+        expect(request_placeholder_markup).to include 'href="https://lib-aeon.princeton.edu/aeon/aeon.dll/OpenURL'
+        expect(request_placeholder_markup).to include 'Coin+3750'
       end
     end
 
@@ -265,6 +269,10 @@ RSpec.describe PhysicalHoldingsMarkupBuilder do
       end
 
       before do
+        allow_any_instance_of(SolrDocument).to receive(:to_ctx).and_return(OpenURL::ContextObject.new)
+        allow(document).to receive(:[]).and_return('data')
+        allow(document).to receive(:to_ctx).and_return(OpenURL::ContextObject.new)
+        allow(document).to receive(:holdings_all_display).and_return({ 'my_id' => holding })
         allow(adapter).to receive(:document).and_return(document)
         allow(holding).to receive(:dig).and_return("SCSB-6593031")
       end
@@ -278,8 +286,8 @@ RSpec.describe PhysicalHoldingsMarkupBuilder do
         expect(request_placeholder_markup).to include 'title="Request to view in Reading Room"'
         # The general scsbnypl location is *not* an aeon location, but if the holding use_statement is "Supervised Use",
         # it goes through aeon.
-        expect(request_placeholder_markup).to include 'data-aeon="false"'
-        expect(request_placeholder_markup).to include 'href="/requests/SCSB-6593031?aeon=true"'
+        expect(request_placeholder_markup).to include 'href="https://lib-aeon.princeton.edu/aeon/aeon.dll/OpenURL'
+        expect(request_placeholder_markup).to include 'ItemNumber=33433115858387'
       end
     end
 

--- a/spec/services/physical_holdings_markup_builder_spec.rb
+++ b/spec/services/physical_holdings_markup_builder_spec.rb
@@ -746,5 +746,5 @@ def mock_solr_document
   allow_any_instance_of(SolrDocument).to receive(:to_ctx).and_return(OpenURL::ContextObject.new)
   allow(document).to receive(:[]).and_return('data')
   allow(document).to receive(:to_ctx).and_return(OpenURL::ContextObject.new)
-  allow(document).to receive(:holdings_all_display).and_return({ 'host_id' => {'items' => [{'barcode' => 'host123'}]} })
+  allow(document).to receive(:holdings_all_display).and_return({ 'host_id' => { 'items' => [{ 'barcode' => 'host123' }] } })
 end

--- a/spec/services/physical_holdings_markup_builder_spec.rb
+++ b/spec/services/physical_holdings_markup_builder_spec.rb
@@ -201,14 +201,11 @@ RSpec.describe PhysicalHoldingsMarkupBuilder do
 
       before do
         allow(adapter).to receive(:alma_holding?).and_return(false)
-        allow_any_instance_of(SolrDocument).to receive(:to_ctx).and_return(OpenURL::ContextObject.new)
-        allow(document).to receive(:[]).and_return('data')
-        allow(document).to receive(:to_ctx).and_return(OpenURL::ContextObject.new)
-        allow(document).to receive(:holdings_all_display).and_return({ 'my_id' => holding })
+        mock_solr_document
         allow(adapter).to receive(:document).and_return(document)
       end
       # this should be hitting the third condition, but does not seem to be
-      it 'generates the request link for the host record' do
+      it 'generates an aeon link including data from the host and constituent record' do
         expect(request_placeholder_markup).to include '<td class="location-services service-always-requestable"'
         expect(request_placeholder_markup).to include 'data-open="false"'
         expect(request_placeholder_markup).to include 'data-requestable="true"'
@@ -217,7 +214,7 @@ RSpec.describe PhysicalHoldingsMarkupBuilder do
         expect(request_placeholder_markup).to include '<a '
         expect(request_placeholder_markup).to include 'title="Request to view in Reading Room"'
         expect(request_placeholder_markup).to include 'href="https://lib-aeon.princeton.edu/aeon/aeon.dll/OpenURL'
-        expect(request_placeholder_markup).to include 'Coin+3750'
+        expect(request_placeholder_markup).to include 'ItemNumber=host123'
       end
     end
 
@@ -270,14 +267,12 @@ RSpec.describe PhysicalHoldingsMarkupBuilder do
 
       before do
         allow_any_instance_of(SolrDocument).to receive(:to_ctx).and_return(OpenURL::ContextObject.new)
-        allow(document).to receive(:[]).and_return('data')
-        allow(document).to receive(:to_ctx).and_return(OpenURL::ContextObject.new)
-        allow(document).to receive(:holdings_all_display).and_return({ 'my_id' => holding })
+        mock_solr_document
         allow(adapter).to receive(:document).and_return(document)
         allow(holding).to receive(:dig).and_return("SCSB-6593031")
       end
 
-      it 'generates the request link for the host record' do
+      it 'generates an aeon link including data from the host and constituent record' do
         expect(request_placeholder_markup).to include '<td class="location-services service-always-requestable"'
         expect(request_placeholder_markup).to include 'data-open="false"'
         expect(request_placeholder_markup).to include 'data-requestable="true"'
@@ -287,7 +282,7 @@ RSpec.describe PhysicalHoldingsMarkupBuilder do
         # The general scsbnypl location is *not* an aeon location, but if the holding use_statement is "Supervised Use",
         # it goes through aeon.
         expect(request_placeholder_markup).to include 'href="https://lib-aeon.princeton.edu/aeon/aeon.dll/OpenURL'
-        expect(request_placeholder_markup).to include 'ItemNumber=33433115858387'
+        expect(request_placeholder_markup).to include 'ItemNumber=host123'
       end
     end
 
@@ -392,10 +387,11 @@ RSpec.describe PhysicalHoldingsMarkupBuilder do
         }
       end
       before do
+        mock_solr_document
         allow(adapter).to receive(:document).and_return(document)
         allow(holding).to receive(:dig).and_return("99125038613506421")
       end
-      it 'generates the request link for the host record' do
+      it 'generates an aeon link including data from the host and constituent record' do
         expect(request_placeholder_markup).to include '<td class="location-services service-always-requestable"'
         expect(request_placeholder_markup).to include 'data-open="false"'
         expect(request_placeholder_markup).to include 'data-requestable="true"'
@@ -403,7 +399,7 @@ RSpec.describe PhysicalHoldingsMarkupBuilder do
         expect(request_placeholder_markup).to include 'data-holding-id="22692760320006421"'
         expect(request_placeholder_markup).to include '<a '
         expect(request_placeholder_markup).to include 'title="Request to view in Reading Room"'
-        expect(request_placeholder_markup).to include 'href="/requests/99125038613506421?aeon=true&amp;mfhd=22692760320006421"'
+        expect(request_placeholder_markup).to include 'ItemNumber=host123'
       end
     end
     context "when there is temporary location with a request button" do
@@ -744,4 +740,11 @@ RSpec.describe PhysicalHoldingsMarkupBuilder do
       expect(css_class).to eq 'service-conditional'
     end
   end
+end
+
+def mock_solr_document
+  allow_any_instance_of(SolrDocument).to receive(:to_ctx).and_return(OpenURL::ContextObject.new)
+  allow(document).to receive(:[]).and_return('data')
+  allow(document).to receive(:to_ctx).and_return(OpenURL::ContextObject.new)
+  allow(document).to receive(:holdings_all_display).and_return({ 'host_id' => {'items' => [{'barcode' => 'host123'}]} })
 end

--- a/spec/services/physical_holdings_markup_builder_spec.rb
+++ b/spec/services/physical_holdings_markup_builder_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe PhysicalHoldingsMarkupBuilder do
         allow(holding).to receive(:dig).and_return("SCSB-6593031")
       end
 
-      it 'generates an aeon link including data from the host and constituent record' do
+      it 'generates the request link for the host record' do
         expect(request_placeholder_markup).to include '<td class="location-services service-always-requestable"'
         expect(request_placeholder_markup).to include 'data-open="false"'
         expect(request_placeholder_markup).to include 'data-requestable="true"'
@@ -281,8 +281,8 @@ RSpec.describe PhysicalHoldingsMarkupBuilder do
         expect(request_placeholder_markup).to include 'title="Request to view in Reading Room"'
         # The general scsbnypl location is *not* an aeon location, but if the holding use_statement is "Supervised Use",
         # it goes through aeon.
-        expect(request_placeholder_markup).to include 'href="https://lib-aeon.princeton.edu/aeon/aeon.dll/OpenURL'
-        expect(request_placeholder_markup).to include 'ItemNumber=host123'
+        expect(request_placeholder_markup).to include 'data-aeon="false"'
+        expect(request_placeholder_markup).to include 'href="/requests/SCSB-6593031?aeon=true"'
       end
     end
 

--- a/spec/system/catalog_show_spec.rb
+++ b/spec/system/catalog_show_spec.rb
@@ -223,4 +223,13 @@ describe 'Viewing Catalog Documents', type: :system, js: true do
       end
     end
   end
+
+  describe 'Request button' do
+    context 'aeon constituent record' do
+      it 'links directly to aeon with data about the host and constituent' do
+        visit("catalog/9923427953506421")
+        expect(page).to have_link('Reading Room Request', href: Regexp.new('https://lib-aeon\.princeton\.edu/aeon/aeon\.dll/OpenURL.*rft\.title=The\+reply\+of\+a\+member\+of\+Parliament.*CallNumber=HJ5118\+\.H4\+1733'))
+      end
+    end
+  end
 end


### PR DESCRIPTION
This passes information from both the host and constituent record, closing #3273

Still to-do:

- [x] Manual qa
- [x] Add an integration test