### PR TITLE
i3597: show requests form for aeon records with multiple items

### DIFF
--- a/app/services/physical_holdings_markup_builder.rb
+++ b/app/services/physical_holdings_markup_builder.rb
@@ -284,6 +284,8 @@ class PhysicalHoldingsMarkupBuilder < HoldingRequestsBuilder
   def request_link_component(adapter:, holding_id:, doc_id:, holding:, location_rules:)
     if holding_id == 'thesis' || self.class.numismatics?(holding_id)
       AeonRequestButtonComponent.new(document: adapter.document, holding: { doc_id: holding }, url_class: Requests::NonAlmaAeonUrl)
+    elsif holding['items'] && holding['items'].length > 1
+      RequestButtonComponent.new(doc_id:, holding_id:, location: location_rules)
     elsif aeon_location?(location_rules)
       AeonRequestButtonComponent.new(document: adapter.document, holding: { doc_id: holding })
     elsif self.class.scsb_location?(location_rules)

--- a/spec/services/physical_holdings_markup_builder_spec.rb
+++ b/spec/services/physical_holdings_markup_builder_spec.rb
@@ -165,6 +165,27 @@ RSpec.describe PhysicalHoldingsMarkupBuilder do
       expect(request_placeholder_markup).to include 'href="/requests/123456?aeon=false&amp;mfhd=3668455"'
     end
 
+    context 'an aeon record with multiple items' do
+      let(:location_rules) do
+        {
+          "aeon_location": true
+        }
+      end
+      let(:holding) do
+        {
+          "items" => [
+            { "barcode" => "123" },
+            { "barcode" => "456" }
+          ]
+        }.with_indifferent_access
+      end
+      it 'links to the requests form' do
+        allow_any_instance_of(SolrDocument).to receive(:to_ctx).and_return(OpenURL::ContextObject.new)
+        mock_solr_document
+        expect(request_placeholder_markup).to include 'href="/requests/123456?aeon=true&amp;mfhd=3668455"'
+      end
+    end
+
     context "a numismatics item" do
       let(:holding_id) { "numismatics" }
       let(:location_rules) do

--- a/spec/system/catalog_show_spec.rb
+++ b/spec/system/catalog_show_spec.rb
@@ -231,5 +231,11 @@ describe 'Viewing Catalog Documents', type: :system, js: true do
         expect(page).to have_link('Reading Room Request', href: Regexp.new('https://lib-aeon\.princeton\.edu/aeon/aeon\.dll/OpenURL.*rft\.title=The\+reply\+of\+a\+member\+of\+Parliament.*CallNumber=HJ5118\+\.H4\+1733'))
       end
     end
+    context 'aeon holding with multiple items' do
+      it 'links to the requests form so user can select the item they want' do
+        visit("catalog/9930960283506421")
+        expect(page).to have_link('Reading Room Request', href: '/requests/9930960283506421?aeon=true&mfhd=22632199160006421')
+      end
+    end
   end
 end


### PR DESCRIPTION
closes #3597 

One way to check this on qa:

1. Go to https://catalog-qa.princeton.edu/catalog/9973529363506421
2. For box 41, press the "Reading Room Request" button
3. Confirm that it allows you to select which item you want before going to aeon.