### PR TITLE
Use sub_location for Aeon SubLocation

### DIFF
--- a/app/models/concerns/requests/aeon.rb
+++ b/app/models/concerns/requests/aeon.rb
@@ -103,14 +103,15 @@ module Requests
 
       ## These two params were from Primo think they both go to
       ## location and location_note in our holdings statement
+      ## Note: moved sub_location out of this block 2023-06-22
       def sub_title
         holding.first.last[:location]
       end
+      ### end special params
 
       def sub_location
-        holding.first.last[:location_note]&.first
+        holding.first.last['sub_location']&.first
       end
-      ### end special params
 
       def aeon_title
         "#{bib[:title_display]}#{genre}"

--- a/app/models/requests/aeon_url.rb
+++ b/app/models/requests/aeon_url.rb
@@ -42,7 +42,7 @@ module Requests
           CallNumber: holding['call_number'],
           Site: site,
           Location: shelf_location_code,
-          SubLocation: location_note,
+          SubLocation: sub_location,
           ItemInfo1: I18n.t("requests.aeon.access_statement"),
           ItemNumber: item&.fetch('barcode', nil)
         }.compact
@@ -84,8 +84,8 @@ module Requests
         holding&.fetch('location_code', nil)
       end
 
-      def location_note
-        holding[:location_note]&.first
+      def sub_location
+        holding&.fetch('sub_location', nil)&.first
       end
 
       def thesis?

--- a/spec/models/concerns/requests/aeon_spec.rb
+++ b/spec/models/concerns/requests/aeon_spec.rb
@@ -8,7 +8,7 @@ class ObjectWithAeon
   end
 
   def holding
-    { "22740186070006421" => { "items" => [{ "holding_id" => "22740186070006421", "id" => "23740186060006421" }] } }
+    { "22740186070006421" => { "sub_location" => ["Euro 20Q"], "items" => [{ "holding_id" => "22740186070006421", "id" => "23740186060006421" }] } }
   end
 end
 
@@ -23,6 +23,10 @@ describe Requests::Aeon do
   describe '#aeon_basic_params' do
     it 'takes its ReferenceNumber from the bib MMS ID' do
       expect(subject.aeon_basic_params[:ReferenceNumber]).to eq(1234)
+    end
+
+    it 'takes its SubLocation from the holdings_1display' do
+      expect(subject.aeon_basic_params[:SubLocation]).to eq('Euro 20Q')
     end
   end
 end

--- a/spec/models/requests/aeon_url_spec.rb
+++ b/spec/models/requests/aeon_url_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Requests::AeonUrl do
       "library" => "Special Collections",
       "location_code" => "rare$num",
       "call_number" => "Coin 3750",
+      "sub_location" => ["Euro 20Q"],
       "items" => [{ "holding_id" => "22740186070006421", "id" => "23740186060006421", "barcode" => "24680" }]
     } }
   end
@@ -29,6 +30,9 @@ RSpec.describe Requests::AeonUrl do
   end
   it 'takes the CallNumber from holdings_1display' do
     expect(subject).to include('CallNumber=Coin+3750')
+  end
+  it 'takes the SubLocation from the holdings_1display' do
+    expect(subject).to include('SubLocation=Euro+20Q')
   end
   it 'typically uses RBSC as the Site' do
     expect(subject).to include('Site=RBSC')


### PR DESCRIPTION
Connected to #3549

Note for testing - in the Aeon UI, this value is under "Shelving Information"

### To test 
1. go to https://catalog-staging.princeton.edu/catalog/9947201943506421/ 
2. click on "Reading Room Request"
3. Log in to Aeon if necessary
4. Note that the "Shelving Information" field now has "Euro 20Q" in it