### PR TITLE
Remove old action_note_display

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -354,8 +354,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'case_file_notes_display', label: 'Case file characteristics'
     config.add_show_field 'methodology_notes_display', label: 'Methodology note'
     config.add_show_field 'editor_notes_display', label: 'Editor note'
-    config.add_show_field 'action_notes_1display', label: 'Action note', helper_method: :action_notes_display, if: ->(_context, _field_config, _document) { Flipflop.new_action_note_display? }
-    config.add_show_field 'action_notes_display', label: 'Action note', if: ->(_context, _field_config, _document) { !Flipflop.new_action_note_display? }
+    config.add_show_field 'action_notes_1display', label: 'Action note', helper_method: :action_notes_display
     config.add_show_field 'accumulation_notes_display', label: 'Accumulation and frequency of use'
     config.add_show_field 'awards_notes_display', label: 'Awards'
     config.add_show_field 'source_desc_notes_display', label: 'Source of description'

--- a/config/features.rb
+++ b/config/features.rb
@@ -30,8 +30,4 @@ Flipflop.configure do
   feature :harmful_content_feedback,
     default: false,
     description: "When on / true, displays the Harmful Content Feedback bar."
-
-  feature :new_action_note_display,
-    default: false,
-    description: "When on / true, displays the new JSON-formatted action notes, including links. When off, only displays PULFA action notes as plain text."
 end

--- a/spec/system/catalog_show_spec.rb
+++ b/spec/system/catalog_show_spec.rb
@@ -185,9 +185,6 @@ describe 'Viewing Catalog Documents', type: :system, js: true do
 
   describe 'action note display' do
     context 'with the new display' do
-      before do
-        allow(Flipflop).to receive(:new_action_note_display?).and_return(true)
-      end
       context 'when the record does not have a link in the action note' do
         let(:document_id) { '99125628841606421' }
 
@@ -204,21 +201,6 @@ describe 'Viewing Catalog Documents', type: :system, js: true do
         it 'shows a linked action note' do
           visit("catalog/#{document_id}")
           expect(page).to have_link('Vol. 1: Committed to retain in perpetuity — ReCAP Italian Language Imprints Collaborative Collection (NjP)')
-        end
-      end
-    end
-
-    context 'with the old display' do
-      before do
-        allow(Flipflop).to receive(:new_action_note_display?).and_return(false)
-      end
-
-      context 'when the record only has a new style action note' do
-        let(:document_id) { '99126831126106421' }
-
-        it 'does not show the field' do
-          visit("catalog/#{document_id}")
-          expect(page).not_to have_content('Action note')
         end
       end
     end


### PR DESCRIPTION
- Fully implemented new display, flipflop feature no longer needed

Connected to #3611