### PR TITLE
Upgrade selenium-webdrivers gem, remove webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,9 +108,9 @@ group :test do
   gem 'launchy'
   gem 'rails-controller-testing'
   gem 'rspec_junit_formatter'
+  gem 'selenium-webdriver'
   gem 'timecop'
   gem 'vcr'
-  gem 'webdrivers'
   gem 'webmock', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
     capistrano-rails (1.6.2)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
-    capybara (3.38.0)
+    capybara (3.39.2)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -337,7 +337,7 @@ GEM
     memory_profiler (1.0.1)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.1)
+    mini_portile2 (2.8.4)
     minitest (5.18.0)
     modernizr-rails (2.7.1)
     msgpack (1.6.0)
@@ -357,12 +357,12 @@ GEM
       net-protocol
     net-ssh (7.0.1)
     nio4r (2.5.9)
-    nokogiri (1.14.3)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.15.3)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.14.3-aarch64-linux)
+    nokogiri (1.15.3-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.14.3-x86_64-linux)
+    nokogiri (1.15.3-x86_64-linux)
       racc (~> 1.4)
     omniauth (1.9.2)
       hashie (>= 3.4.6)
@@ -391,11 +391,11 @@ GEM
     pry-byebug (3.10.1)
       byebug (~> 11.0)
       pry (>= 0.13, < 0.15)
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
     puma (6.0.1)
       nio4r (~> 2.0)
-    racc (1.6.2)
-    rack (2.2.6.4)
+    racc (1.7.1)
+    rack (2.2.7)
     rack-attack (6.6.1)
       rack (>= 1.0, < 3)
     rack-mini-profiler (3.1.0)
@@ -441,7 +441,7 @@ GEM
       redis-client (>= 0.9.0)
     redis-client (0.14.1)
       connection_pool
-    regexp_parser (2.6.1)
+    regexp_parser (2.8.1)
     request_store (1.5.1)
       rack (>= 1.4)
     responders (3.0.1)
@@ -449,7 +449,7 @@ GEM
       railties (>= 5.0)
     reverse_markdown (2.1.1)
       nokogiri
-    rexml (3.2.5)
+    rexml (3.2.6)
     rsolr (2.5.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
@@ -505,7 +505,7 @@ GEM
       sprockets-rails
       tilt
     scrub_rb (1.0.1)
-    selenium-webdriver (4.7.1)
+    selenium-webdriver (4.10.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -614,10 +614,6 @@ GEM
       rack (>= 1.4, < 3.0)
     warden (1.2.9)
       rack (>= 2.0.9)
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -714,6 +710,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubyzip (>= 1.2.2)
   sass-rails (~> 6.0)
+  selenium-webdriver
   simple_form
   sneakers
   solargraph
@@ -726,7 +723,6 @@ DEPENDENCIES
   vcr
   vite_rails (= 3.0.12)
   voight_kampff
-  webdrivers
   webmock
   whenever (~> 0.11)
   yajl-ruby (>= 1.3.1)

--- a/spec/support/capybara_selenium.rb
+++ b/spec/support/capybara_selenium.rb
@@ -5,13 +5,10 @@ require 'capybara/rspec'
 require "selenium-webdriver"
 
 Capybara.register_driver(:selenium) do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    'goog:chromeOptions': { args: %w[headless disable-gpu disable-setuid-sandbox window-size=7680,4320] }
-  )
-
   browser_options = ::Selenium::WebDriver::Chrome::Options.new
   browser_options.args << "--headless"
   browser_options.args << "--disable-gpu"
+  browser_options.args << "--disable-setuid-sandbox"
   browser_options.args << "--window-size=1920,1200"
 
   http_client = Selenium::WebDriver::Remote::Http::Default.new
@@ -20,7 +17,6 @@ Capybara.register_driver(:selenium) do |app|
 
   Capybara::Selenium::Driver.new(app,
                                  browser: :chrome,
-                                 capabilities:,
                                  http_client:,
                                  options: browser_options)
 end


### PR DESCRIPTION
Based on this guidance: https://github.com/titusfortner/webdrivers/issues/247#issuecomment-1648154088

I also had to `xattr -d com.apple.quarantine /opt/homebrew/bin/chromedriver`, possibly because I had inadvertently upgraded chromedriver via brew recently?