### PR TITLE
Search for empty string, rather than nil, in test

### DIFF
--- a/spec/requests/request_spec.rb
+++ b/spec/requests/request_spec.rb
@@ -335,7 +335,7 @@ describe 'blacklight tests' do
       expect(response.body).to include 'data-isbn="['
     end
     it 'is accessible from search results' do
-      get '/catalog?search_field=all_fields'
+      get '/catalog?search_field=all_fields&q='
       expect(response.body).to include '<meta property="isbn"'
       expect(response.body).to include 'data-isbn="['
     end


### PR DESCRIPTION
See https://github.com/projectblacklight/blacklight/issues/3067

Search result URLs without any q param fail when using the JSON Query DSL.  Since the point of this test is to confirm that the search results page has certain ISBNs, not to exercise this q-less param use case, let's change it to include an empty q= (which is what happens when a user does a blank search).

helps with #3645 