### PR TITLE
Flipflop to opt in to the JSON query DSL

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -478,6 +478,7 @@ class CatalogController < ApplicationController
     #   field.include_in_simple_select = false
 
     config.add_search_field 'all_fields', label: 'Keyword' do |field|
+      field.clause_params = { edismax: {} } if Flipflop.json_query_dsl?
     end
 
     # Now we see how to over-ride Solr request handler defaults, in this
@@ -496,6 +497,7 @@ class CatalogController < ApplicationController
         qf: '$title_qf',
         pf: '$title_pf'
       }
+      field.clause_params = { edismax: field.solr_parameters.dup } if Flipflop.json_query_dsl?
     end
 
     config.add_search_field('author') do |field|
@@ -510,6 +512,7 @@ class CatalogController < ApplicationController
         qf: '$author_qf',
         pf: '$author_pf'
       }
+      field.clause_params = { edismax: field.solr_parameters.dup } if Flipflop.json_query_dsl?
     end
 
     # Specifying a :qt only to show it's possible, and so our internal automated
@@ -527,6 +530,7 @@ class CatalogController < ApplicationController
         qf: '$subject_qf',
         pf: '$subject_pf'
       }
+      field.clause_params = { edismax: field.solr_parameters.dup } if Flipflop.json_query_dsl?
     end
 
     config.add_search_field('left_anchor') do |field|
@@ -539,6 +543,7 @@ class CatalogController < ApplicationController
         qf: '$left_anchor_qf',
         pf: '$left_anchor_pf'
       }
+      field.clause_params = { edismax: field.solr_parameters.dup } if Flipflop.json_query_dsl?
     end
 
     config.add_search_field('publisher') do |field|
@@ -548,6 +553,7 @@ class CatalogController < ApplicationController
         qf: '$publisher_qf',
         pf: '$publisher_pf'
       }
+      field.clause_params = { edismax: field.solr_parameters.dup } if Flipflop.json_query_dsl?
     end
 
     config.add_search_field('in_series') do |field|
@@ -558,6 +564,7 @@ class CatalogController < ApplicationController
         qf: '$in_series_qf',
         pf: '$in_series_pf'
       }
+      field.clause_params = { edismax: field.solr_parameters.dup } if Flipflop.json_query_dsl?
     end
 
     config.add_search_field('notes') do |field|
@@ -567,6 +574,7 @@ class CatalogController < ApplicationController
         qf: '$notes_qf',
         pf: '$notes_pf'
       }
+      field.clause_params = { edismax: field.solr_parameters.dup } if Flipflop.json_query_dsl?
     end
 
     config.add_search_field('series_title') do |field|
@@ -576,6 +584,7 @@ class CatalogController < ApplicationController
         qf: '$series_title_qf',
         pf: '$series_title_pf'
       }
+      field.clause_params = { edismax: field.solr_parameters.dup } if Flipflop.json_query_dsl?
     end
 
     config.add_search_field('isbn') do |field|
@@ -587,6 +596,7 @@ class CatalogController < ApplicationController
       field.solr_parameters = {
         qf: 'isbn_t'
       }
+      field.clause_params = { edismax: field.solr_parameters.dup } if Flipflop.json_query_dsl?
     end
 
     config.add_search_field('issn') do |field|
@@ -598,6 +608,7 @@ class CatalogController < ApplicationController
       field.solr_parameters = {
         qf: 'issn_s'
       }
+      field.clause_params = { edismax: field.solr_parameters.dup } if Flipflop.json_query_dsl?
     end
 
     config.add_search_field('lccn') do |field|

--- a/config/features.rb
+++ b/config/features.rb
@@ -26,4 +26,7 @@ Flipflop.configure do
   feature :firestone_locator,
     default: true,
     description: "When on / true, uses the old locator service for Firestone. When off / false uses the new Stackmap service for Firestone."
+
+  feature :json_query_dsl,
+    description: "When on / true, use the JSON query DSL for search fields in the advanced search.  When off / false, use query params"
 end


### PR DESCRIPTION
To make it easier to test the JSON query DSL, let's make it easy to turn on and off in the flipflop UI.  The steps to do this in a local dev environment:

1. Change the luceneMatchVersion to 7.1.0 in solr/conf/solrconfig.xml
2. Comment out the line `Rake::Task["pulsearch:solr:update"].invoke`  in lib/tasks/server.rake
3. `ORANGELIGHT_ADMIN_NETIDS=my-netid bundle exec rails s`
4. Turn the feature on/off as desired at localhost:3000/features

part of #3645 