### PR TITLE
Part of 3645 - component-based numismatics search form

### DIFF
--- a/app/components/numismatics_search_form_component.html.erb
+++ b/app/components/numismatics_search_form_component.html.erb
@@ -1,0 +1,40 @@
+<% if constraints? %>
+  <div class="constraints well search_history">
+    <h4><%= t 'blacklight.advanced_search.form.search_context' %></h4>
+    <% constraints.each do |constraint| %>
+      <%= constraint %>
+    <% end %>
+  </div>
+<% end %>
+<%= form_tag @url, method: @method, class: @classes.join(' '), role: 'search', 'aria-label' => t('blacklight.search.form.submit') do %>
+  <%= render_hash_as_hidden_fields(@params) %>
+  <%= render Blacklight::HiddenSearchStateComponent.new(params: {'advanced_type' => 'numismatics'}) %>
+  <div style="columns: 2">
+      <% search_filter_controls.each do |control| %>
+        <%= control %>
+      <% end %>
+      <div class="form-group advanced-search-facet row">
+        <%= label_tag pub_date_field.parameterize, :class => "col-sm-4 control-label advanced-facet-label" do %>Year<% end %>
+        <div class="col-sm-8 range_limit">
+          <label for="range_pub_date_start_sort_begin" class="sr-only">date range (starting year)</label>
+          <%= BlacklightRangeLimit::RangeFormComponent.new(facet_field: pub_date_presenter).render_range_input(:begin) %> –
+          <label for="range_pub_date_start_sort_end" class="sr-only">date range (ending year)</label>
+          <%= BlacklightRangeLimit::RangeFormComponent.new(facet_field: pub_date_presenter).render_range_input(:end) %>
+        </div>
+      </div>
+      <div class="form-group advanced-search-facet row">
+        <%= hidden_field_tag('clause[1][field]', 'all_fields') %>
+        <label for="clause_1_query" class="col-sm-4 control-label advanced-facet-label">Keyword</label>
+      <div class="col-sm-8">
+        <%= text_field_tag "clause[1][query]", '', # TODO: if there is an existing keyword search, set it as the default
+          id: 'clause_1_field',
+          class: 'form-control',
+          autocorrect: "off",
+          autocapitalize: "off",
+          autocomplete: "off",
+          spellcheck: "false" %>
+      </div>
+    </div>
+  </div>
+
+<% end %>

--- a/app/components/numismatics_search_form_component.rb
+++ b/app/components/numismatics_search_form_component.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class NumismaticsSearchFormComponent < Blacklight::AdvancedSearchFormComponent
+  def initialize_search_filter_controls
+    fields = ['issue_object_type_s', 'issue_denomination_s',
+              'issue_metal_s', 'issue_city_s', 'issue_state_s',
+              'issue_region_s', 'issue_ruler_s',
+              'issue_artists_s', 'find_place_s'].map do |field_name|
+      blacklight_config.facet_fields[field_name]
+    end.compact
+
+    fields.each do |config|
+      config.advanced_search_component = Orangelight::FacetFieldCheckboxesComponent
+      display_facet = @response.aggregations[config.field]
+      search_filter_control(config:, display_facet:)
+    end
+  end
+
+  def pub_date_field
+    blacklight_config.facet_fields['pub_date_start_sort']
+  end
+
+  def pub_date_presenter
+    view_context.facet_field_presenter(pub_date_field, {})
+  end
+end

--- a/app/components/orangelight/facet_field_checkboxes_component.html.erb
+++ b/app/components/orangelight/facet_field_checkboxes_component.html.erb
@@ -1,0 +1,17 @@
+<div class="form-group advanced-search-facet row">
+  <label class="col-sm-4 control-label advanced-facet-label"><%= @facet_field.label %></label>
+  <div class="col-sm-8">
+  <%= content_tag(:select, :multiple => true, "aria-hidden" => "true",
+    :name   => "f_inclusive[#{@facet_field.key}][]",
+    :id     => @facet_field.key.parameterize,
+    :class  => "form-control custom-select selectpicker",
+    :title  => "Type or select #{ @facet_field.label.downcase.pluralize }",
+    :data   => { "live-search": "true" }) do %>
+    <% presenters.each do |presenter| %>
+      <%= content_tag :option, :value => presenter.value, :selected => presenter.selected? do %>
+        <%= presenter.label %>&nbsp;&nbsp;(<%= number_with_delimiter presenter.hits %>)
+        <% end %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/components/orangelight/facet_field_checkboxes_component.rb
+++ b/app/components/orangelight/facet_field_checkboxes_component.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Orangelight::FacetFieldCheckboxesComponent < Blacklight::FacetFieldCheckboxesComponent
+end

--- a/app/views/advanced/numismatics.html.erb
+++ b/app/views/advanced/numismatics.html.erb
@@ -14,4 +14,13 @@
   contact Alan Stahl, Curator of Numismatics (<a href="mailto:astahl@princeton.edu">astahl@princeton.edu</a>)
   </p>
 </div>
-<%= render 'advanced/numismatics_advanced_search_form' %>
+<% if Flipflop.view_components_numismatics? %>
+  <%= render(NumismaticsSearchFormComponent.new(
+      url: search_action_url,
+      classes: ['advanced', 'form-horizontal'],
+      params: search_state.params_for_search.except(:qt),
+      response: @response
+    )) %>
+<% else %>
+  <%= render 'advanced/numismatics_advanced_search_form' %>
+<% end %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -27,6 +27,11 @@ Flipflop.configure do
     default: true,
     description: "When on / true, uses the old locator service for Firestone. When off / false uses the new Stackmap service for Firestone."
 
-  feature :json_query_dsl,
+  group :blacklight_8 do
+    feature :json_query_dsl,
     description: "When on / true, use the JSON query DSL for search fields in the advanced search.  When off / false, use query params"
+
+    feature :view_components_numismatics,
+    description: "When on / true, use the built-in advanced search form for numismatics.  When off / false, use the traditional one"
+  end
 end

--- a/spec/components/numismatics_search_form_component_spec.rb
+++ b/spec/components/numismatics_search_form_component_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe NumismaticsSearchFormComponent, type: :component do
+  subject(:render) do
+    component.render_in(view_context)
+  end
+
+  let(:component) { described_class.new(url: '/whatever', response:, params:) }
+  let(:response) do
+    Blacklight::Solr::Response.new({ facet_counts: { facet_fields: {
+      issue_object_type_s: { 'badge' => 4, 'counterfeit' => 10 },
+      issue_denomination_s: { '1 Qian' => 4, '1 and 1/3 dollar' => 10 },
+      issue_metal_s: { 'Brass' => 10 },
+      issue_city_s: { 'Aleppo' => 10, 'Amul' => 2 },
+      issue_state_s: { 'Andalusia' => 10, 'Antioch' => 2 },
+      issue_region_s: { 'Brazil' => 10 },
+      issue_ruler_s: { 'Alexios III Angelos' => 3 },
+      issue_artists_s: { 'Ada Possesse' => 1 },
+      find_place_s: { 'Kushan, India' => 1 }
+    } } }.with_indifferent_access, {})
+  end
+  let(:params) { {} }
+
+  let(:rendered) do
+    Capybara::Node::Simple.new(render)
+  end
+
+  let(:view_context) { controller.view_context }
+
+  before do
+    allow(view_context).to receive(:facet_limit_for).and_return(nil)
+  end
+
+  it "renders fields in the correct order" do
+    expected_order = [
+      'Object Type', 'Denomination', 'Metal', 'City', 'State',
+      'Region', 'Ruler', 'Artist', 'Find Place', 'Year',
+      'date range (ending year)', 'date range (starting year)',
+      'Keyword'
+    ]
+    expect(rendered.all('label').map(&:text)).to match_array(expected_order)
+  end
+end

--- a/spec/components/orangelight/facet_field_checkboxes_component_spec.rb
+++ b/spec/components/orangelight/facet_field_checkboxes_component_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orangelight::FacetFieldCheckboxesComponent, type: :component do
+  let(:paginator) do
+    instance_double(Blacklight::FacetPaginator, items: [
+                      double(label: 'a', hits: 10, value: 'a'),
+                      double(label: 'b', hits: 33, value: 'b'),
+                      double(label: 'c', hits: 3, value: 'c')
+                    ])
+  end
+  let(:search_state) { Blacklight::SearchState.new({}.with_indifferent_access, Blacklight::Configuration.new) }
+  let(:facet_field) do
+    instance_double(
+      Blacklight::FacetFieldPresenter,
+      facet_field: Blacklight::Configuration::NullField.new(key: 'field', item_component: Blacklight::FacetItemComponent, item_presenter: Blacklight::FacetItemPresenter),
+      paginator:,
+      key: 'field',
+      label: 'Field',
+      active?: false,
+      collapsed?: false,
+      modal_path: nil,
+      search_state:
+    )
+  end
+  it 'renders a visible facet label' do
+    expect(
+      render_inline(described_class.new(facet_field:)).to_s
+    ).to include(
+      "Field"
+    )
+  end
+end


### PR DESCRIPTION
Brings over some advanced search components from the upgrade_to_blacklight_8 branch.

The new form is not ready yet, but it is hidden behind Flipflop.

Part of #3645 