### PR TITLE
I3412 built in advanced search form

### DIFF
--- a/app/components/orangelight/advanced_search_form_component.html.erb
+++ b/app/components/orangelight/advanced_search_form_component.html.erb
@@ -15,9 +15,10 @@
         <div class="input-criteria">
 
           <div id="guided_search">
-            <% search_field_controls.each do |control| %>
-              <%= control %>
-            <% end %>
+            <%= render 'advanced/guided_search_fields' %>
+            <%# search_field_controls.each do |control| %>
+              <%# control %>
+            <%# end %>
           </div>
         </div>
       <%# End Column 1 %>

--- a/app/components/orangelight/advanced_search_form_component.html.erb
+++ b/app/components/orangelight/advanced_search_form_component.html.erb
@@ -15,10 +15,7 @@
         <div class="input-criteria">
 
           <div id="guided_search">
-            <%= render 'advanced/guided_search_fields' %>
-            <%# search_field_controls.each do |control| %>
-              <%# control %>
-            <%# end %>
+            <%= render 'advanced/guided_search_fields_bl_8' %>
           </div>
         </div>
       <%# End Column 1 %>
@@ -41,9 +38,9 @@
         <div class="form-group advanced-search-facet row">
           <%= label_tag pub_date_field.parameterize, :class => "col-sm-4 control-label advanced-facet-label" do %>Publication Year<% end %>
           <div class="col-sm-8 range_limit">
-            <label for="range_pub_date_start_sort_begin" class="sr-only">date range (starting year)</label>
+            <label for="range_pub_date_start_sort_begin" class="sr-only">Publication date range (starting year)</label>
             <%= BlacklightRangeLimit::RangeFormComponent.new(facet_field: pub_date_presenter).render_range_input(:begin) %> –
-            <label for="range_pub_date_start_sort_end" class="sr-only">date range (ending year)</label>
+            <label for="range_pub_date_start_sort_end" class="sr-only">Publication date range (ending year)</label>
             <%= BlacklightRangeLimit::RangeFormComponent.new(facet_field: pub_date_presenter).render_range_input(:end) %>
           </div>
         </div>

--- a/app/components/orangelight/advanced_search_form_component.html.erb
+++ b/app/components/orangelight/advanced_search_form_component.html.erb
@@ -1,0 +1,65 @@
+<% if constraints? %>
+  <div class="constraints well search_history">
+    <h4><%= t 'blacklight.advanced_search.form.search_context' %></h4>
+    <% constraints.each do |constraint| %>
+      <%= constraint %>
+    <% end %>
+  </div>
+<% end %>
+<%= form_tag search_catalog_path, method: @method, class: @classes.join(' '), role: 'search', 'aria-label' => t('blacklight.search.form.submit') do %>
+  <%= render Blacklight::HiddenSearchStateComponent.new(params: @params) %>
+
+  <div class="advanced row">
+      <%# Column 1 %>
+      <div class="col-md-7">
+        <div class="input-criteria">
+
+          <div id="guided_search">
+            <% search_field_controls.each do |control| %>
+              <%= control %>
+            <% end %>
+          </div>
+        </div>
+      <%# End Column 1 %>
+      </div>
+      <%# Column 2 %>
+      <div class="col-md-5">
+        <% if search_filter_controls? %>
+          <div class="limit-criteria">
+            <h2 class="limit-criteria-heading"><%= t('blacklight.advanced_search.form.limit_criteria_heading_html')%></h2>
+
+            <div id="advanced_search_facets" class="limit_input">
+              <div class="advanced-facet-limits panel-group">
+                <% search_filter_controls.each do |control| %>
+                  <%= control %>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        <% end %>
+        <div class="form-group advanced-search-facet row">
+          <%= label_tag pub_date_field.parameterize, :class => "col-sm-4 control-label advanced-facet-label" do %>Publication Year<% end %>
+          <div class="col-sm-8 range_limit">
+            <label for="range_pub_date_start_sort_begin" class="sr-only">date range (starting year)</label>
+            <%= BlacklightRangeLimit::RangeFormComponent.new(facet_field: pub_date_presenter).render_range_input(:begin) %> –
+            <label for="range_pub_date_start_sort_end" class="sr-only">date range (ending year)</label>
+            <%= BlacklightRangeLimit::RangeFormComponent.new(facet_field: pub_date_presenter).render_range_input(:end) %>
+          </div>
+        </div>
+      </div>
+      <%# End Column 2 %>
+  </div>
+
+  <div class="search-submit-buttons clearfix col-sm-7">
+    <% if sort_fields_select %>
+      <div class="form-group sort-buttons pull-left">
+        <%= content_tag :label, t('blacklight.advanced_search.form.sort_label'), id: 'advanced-search-sort-label', for: 'sort', class: 'control-label' %>
+        <%= sort_fields_select %>
+      </div>
+    <% end %>
+    <div class="submit-buttons pull-right form-group">
+      <%= submit_tag t('blacklight.advanced_search.form.search_btn_html'), class: 'btn btn-primary advanced-search-submit', id: "advanced-search-submit" %>
+    </div>
+
+  </div>
+<% end %>

--- a/app/components/orangelight/advanced_search_form_component.rb
+++ b/app/components/orangelight/advanced_search_form_component.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class Orangelight::AdvancedSearchFormComponent < Blacklight::AdvancedSearchFormComponent
+  def sort_fields_select
+    options = sort_fields.values.map { |field_config| [helpers.sort_field_label(field_config.key), field_config.key] }
+    return unless options.any?
+
+    select_tag(:sort, options_for_select(options, params[:sort]), class: "sort-select", aria: { labelledby: 'advanced-search-sort-label' })
+  end
+
+  def initialize_search_filter_controls
+    fields = blacklight_config.facet_fields.select { |_k, v| v.include_in_advanced_search || v.include_in_advanced_search.nil? }
+
+    fields.each do |_k, config|
+      config.advanced_search_component = Orangelight::FacetFieldCheckboxesComponent
+      display_facet = @response.aggregations[config.field]
+      with_search_filter_control(config:, display_facet:)
+    end
+  end
+
+  def pub_date_field
+    blacklight_config.facet_fields['pub_date_start_sort']
+  end
+
+  def pub_date_presenter
+    view_context.facet_field_presenter(pub_date_field, {})
+  end
+  def initialize_search_field_controls
+    search_fields.values.each.with_index do |field, i|
+      with_search_field_control do
+        fields_for('clause[]', i, include_id: false) do |f|
+          content_tag(:div, class: 'form-group advanced-search-field row mb-3') do
+            f.label(:query, field.display_label('search'), class: "col-sm-3 col-form-label text-md-right") +
+              content_tag(:div, class: 'col-sm-9') do
+                f.hidden_field(:field, value: field.key) +
+                  f.text_field(:query, value: query_for_search_clause(field.key), class: 'form-control')
+              end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/orangelight/advanced_search_form_component.rb
+++ b/app/components/orangelight/advanced_search_form_component.rb
@@ -25,18 +25,23 @@ class Orangelight::AdvancedSearchFormComponent < Blacklight::AdvancedSearchFormC
   def pub_date_presenter
     view_context.facet_field_presenter(pub_date_field, {})
   end
+
   def initialize_search_field_controls
-    search_fields.values.each.with_index do |field, i|
+    search_fields.values.each.with_index do |field, index|
       with_search_field_control do
-        fields_for('clause[]', i, include_id: false) do |f|
-          content_tag(:div, class: 'form-group advanced-search-field row mb-3') do
-            f.label(:query, field.display_label('search'), class: "col-sm-3 col-form-label text-md-right") +
-              content_tag(:div, class: 'col-sm-9') do
-                f.hidden_field(:field, value: field.key) +
-                  f.text_field(:query, value: query_for_search_clause(field.key), class: 'form-control')
-              end
+        fields_for_etc(index:, field:)
+      end
+    end
+  end
+
+  def fields_for_etc(index:, field:)
+    fields_for('clause[]', index, include_id: false) do |foo|
+      content_tag(:div, class: 'form-group advanced-search-field row mb-3') do
+        foo.label(:query, field.display_label('search'), class: "col-sm-3 col-form-label text-md-right") +
+          content_tag(:div, class: 'col-sm-9') do
+            foo.hidden_field(:field, value: field.key) +
+              foo.text_field(:query, value: query_for_search_clause(field.key), class: 'form-control')
           end
-        end
       end
     end
   end

--- a/app/views/advanced/_guided_search_fields_bl_8.html.erb
+++ b/app/views/advanced/_guided_search_fields_bl_8.html.erb
@@ -1,0 +1,74 @@
+<div class="advanced-search-field">
+  <div class="search-field">
+    <label for="clause_0_field" class="sr-only">Options for advanced search</label>
+    <%= select_tag(
+          'clause[0][field]',
+          options_for_select(
+            advanced_key_value,
+            guided_field(:clause_0_field, 'all_fields')
+          ),
+          class: "search_field") %>
+    <div name="row1">
+      <label for='clause_0_query' class='sr-only'>Advanced search terms</label>
+      <%= text_field_tag(
+            "clause[0][query]",
+            label_tag_default_for(:clause_0_query),
+            class: 'form-control',
+            autocorrect: "off",
+            autocapitalize: "off",
+            autocomplete: "off",
+            spellcheck: "false") %>
+    </div>
+  </div>
+  <div class="search-operators" role="radiogroup" aria-label="Search operators">
+    <label><%= radio_button_tag("op2", "AND", guided_radio(:op2, "AND")) %> AND</label>
+    <label><%= radio_button_tag("op2", "OR", guided_radio(:op2, "OR")) %> OR</label>
+    <label><%= radio_button_tag("op2", "NOT", guided_radio(:op2, "NOT")) %> NOT</label>
+  </div>
+  <div class="search-field">
+    <label for="clause_1_field" class="sr-only">Options for advanced search - second parameter</label>
+    <%= select_tag(
+          'clause[1][field]', 
+          options_for_select(
+            advanced_key_value,
+            guided_field(:clause_1_field, 'author')
+          ), 
+          class: "search_field") %>
+    <div name="row2">
+      <label for='clause_1_query' class='sr-only'>Advanced search terms - second parameter</label>
+      <%= text_field_tag(
+            "clause[1][query]", 
+            label_tag_default_for(:clause_1_query), 
+            class: 'form-control', 
+            autocorrect: "off", 
+            autocapitalize: "off", 
+            autocomplete: "off", 
+            spellcheck: "false") %>
+    </div>
+  </div>
+  <div class="search-operators" role="radiogroup" aria-label="Search operators">
+    <label><%= radio_button_tag("op3", "AND", guided_radio(:op3, "AND")) %> AND</label>
+    <label><%= radio_button_tag("op3", "OR", guided_radio(:op3, "OR")) %> OR</label>
+    <label><%= radio_button_tag("op3", "NOT", guided_radio(:op3, "NOT")) %> NOT</label>
+  </div>
+  <div class="search-field">
+    <label for="clause_2_field" class="sr-only">Options for advanced search - third parameter</label>
+    <%= select_tag(
+          'clause[2][field]', 
+          options_for_select(
+            advanced_key_value, 
+            guided_field(:clause_2_field, 'title')
+          ),
+          class: "search_field") %>
+    <div name="row3">
+      <label for='clause_2_query' class='sr-only'>Advanced search terms - third parameter</label>
+      <%= text_field_tag(
+            "clause[2][query]", 
+            label_tag_default_for(:clause_2_query), 
+            :class => 'form-control', 
+            autocorrect: "off", 
+            autocapitalize: "off", 
+            spellcheck: "false") %>
+    </div>
+  </div>
+</div>

--- a/app/views/advanced/_guided_search_fields_bl_8.html.erb
+++ b/app/views/advanced/_guided_search_fields_bl_8.html.erb
@@ -21,9 +21,9 @@
     </div>
   </div>
   <div class="search-operators" role="radiogroup" aria-label="Search operators">
-    <label><%= radio_button_tag("op2", "AND", guided_radio(:op2, "AND")) %> AND</label>
-    <label><%= radio_button_tag("op2", "OR", guided_radio(:op2, "OR")) %> OR</label>
-    <label><%= radio_button_tag("op2", "NOT", guided_radio(:op2, "NOT")) %> NOT</label>
+    <label><%= radio_button_tag("clause[1][op]", "must", guided_radio(:clause_1_op, "AND")) %> AND</label>
+    <label><%= radio_button_tag("clause[1][op]", "should", guided_radio(:clause_1_op, "OR")) %> OR</label>
+    <label><%= radio_button_tag("clause[1][op]", "must_not", guided_radio(:clause_1_op, "NOT")) %> NOT</label>
   </div>
   <div class="search-field">
     <label for="clause_1_field" class="sr-only">Options for advanced search - second parameter</label>
@@ -47,9 +47,9 @@
     </div>
   </div>
   <div class="search-operators" role="radiogroup" aria-label="Search operators">
-    <label><%= radio_button_tag("op3", "AND", guided_radio(:op3, "AND")) %> AND</label>
-    <label><%= radio_button_tag("op3", "OR", guided_radio(:op3, "OR")) %> OR</label>
-    <label><%= radio_button_tag("op3", "NOT", guided_radio(:op3, "NOT")) %> NOT</label>
+    <label><%= radio_button_tag("clause[2][op]", "must", guided_radio(:clause_2_op, "AND")) %> AND</label>
+    <label><%= radio_button_tag("clause[2][op]", "should", guided_radio(:clause_2_op, "OR")) %> OR</label>
+    <label><%= radio_button_tag("clause[2][op]", "must_not", guided_radio(:clause_2_op, "NOT")) %> NOT</label>
   </div>
   <div class="search-field">
     <label for="clause_2_field" class="sr-only">Options for advanced search - third parameter</label>

--- a/app/views/advanced/index.html.erb
+++ b/app/views/advanced/index.html.erb
@@ -8,4 +8,13 @@
     <%= link_to t('blacklight_advanced_search.form.start_over'), blacklight_advanced_search_engine.advanced_search_path, :class =>"btn pull-right clear-form" %>
   </h1>
 </div>
-<%= render 'advanced_search_form' %>
+<% if Flipflop.view_components_advanced_search? %>
+  <%= render(Orangelight::AdvancedSearchFormComponent.new(
+        url: search_action_url,
+        classes: ['advanced', 'form-horizontal'],
+        params: search_state.params_for_search.except(:qt),
+        response: @response
+      )) %>
+<% else %>
+  <%= render 'advanced_search_form' %>
+<% end %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -37,5 +37,9 @@ Flipflop.configure do
 
     feature :view_components_numismatics,
     description: "When on / true, use the built-in advanced search form for numismatics.  When off / false, use the traditional one"
+
+    feature :view_components_advanced_search,
+    description: "When on / true, use the built-in advanced search form.  When off / false, use the traditional one"
+
   end
 end

--- a/config/features.rb
+++ b/config/features.rb
@@ -40,6 +40,5 @@ Flipflop.configure do
 
     feature :view_components_advanced_search,
     description: "When on / true, use the built-in advanced search form.  When off / false, use the traditional one"
-
   end
 end

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -4,6 +4,9 @@ en:
       previous: '&laquo; <span class="d-none d-lg-inline"> Previous</span>'
       next: '<span class="d-none d-lg-inline">Next</span> &raquo;'
   blacklight:
+    advanced_search:
+      form:
+        limit_criteria_heading_html: 'Limit results by'
     application_name: 'Princeton University Library Catalog'
     welcome: 'Welcome!'
     orangelight: 'Catalog'

--- a/spec/components/orangelight/advanced_search_form_component_spec.rb
+++ b/spec/components/orangelight/advanced_search_form_component_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Orangelight::AdvancedSearchFormComponent, type: :component do
+RSpec.describe Orangelight::AdvancedSearchFormComponent, type: :component, advanced_search: true do
   subject(:render) do
     component.render_in(view_context)
   end
@@ -42,5 +42,12 @@ RSpec.describe Orangelight::AdvancedSearchFormComponent, type: :component do
     ]
     options = rendered.all('select')[1].all('option').map(&:text)
     expect(options).to eq(expected_options)
+  end
+
+  it 'has text fields for each search field' do
+    expect(rendered).to have_selector '.advanced-search-field', count: 1
+    expect(rendered).to have_field 'clause_0_field', with: 'all_fields'
+    expect(rendered).to have_field 'clause_1_field', with: 'author'
+    expect(rendered).to have_field 'clause_2_field', with: 'title'
   end
 end

--- a/spec/components/orangelight/advanced_search_form_component_spec.rb
+++ b/spec/components/orangelight/advanced_search_form_component_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Orangelight::AdvancedSearchFormComponent, type: :component do
   subject(:render) do
     component.render_in(view_context)
   end
-  let(:component) { described_class.new(url: '/whatever', response: , params:) }
+  let(:component) { described_class.new(url: '/whatever', response:, params:) }
 
   let(:response) do
     Blacklight::Solr::Response.new({}.with_indifferent_access, {})
@@ -35,11 +35,12 @@ RSpec.describe Orangelight::AdvancedSearchFormComponent, type: :component do
     allow(view_context).to receive(:facet_limit_for).and_return(nil)
   end
 
-  it "renders fields in the correct order" do
-    expected_order = [
-      "Keyword", "Title", "Author/Creator", "Subject", "Title starts with", 
+  it "has a dropdown with the expected options" do
+    expected_options = [
+      "Keyword", "Title", "Author/Creator", "Subject", "Title starts with",
       "Publisher", "Notes", "Series title", "ISBN", "ISSN"
     ]
-    expect(rendered.all('label').map(&:text)).to match_array(expected_order)
+    options = rendered.all('select')[1].all('option').map(&:text)
+    expect(options).to eq(expected_options)
   end
 end

--- a/spec/components/orangelight/advanced_search_form_component_spec.rb
+++ b/spec/components/orangelight/advanced_search_form_component_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orangelight::AdvancedSearchFormComponent, type: :component do
+  subject(:render) do
+    component.render_in(view_context)
+  end
+  let(:component) { described_class.new(url: '/whatever', response: , params:) }
+
+  let(:response) do
+    Blacklight::Solr::Response.new({}.with_indifferent_access, {})
+    # Blacklight::Solr::Response.new({ facet_counts: { facet_fields: {
+    #   issue_object_type_s: { 'badge' => 4, 'counterfeit' => 10 },
+    #   issue_denomination_s: { '1 Qian' => 4, '1 and 1/3 dollar' => 10 },
+    #   issue_metal_s: { 'Brass' => 10 },
+    #   issue_city_s: { 'Aleppo' => 10, 'Amul' => 2 },
+    #   issue_state_s: { 'Andalusia' => 10, 'Antioch' => 2 },
+    #   issue_region_s: { 'Brazil' => 10 },
+    #   issue_ruler_s: { 'Alexios III Angelos' => 3 },
+    #   issue_artists_s: { 'Ada Possesse' => 1 },
+    #   find_place_s: { 'Kushan, India' => 1 }
+    # } } }.with_indifferent_access, {})
+  end
+
+  let(:params) { {} }
+
+  let(:rendered) do
+    Capybara::Node::Simple.new(render)
+  end
+
+  let(:view_context) { controller.view_context }
+
+  before do
+    allow(view_context).to receive(:facet_limit_for).and_return(nil)
+  end
+
+  it "renders fields in the correct order" do
+    expected_order = [
+      "Keyword", "Title", "Author/Creator", "Subject", "Title starts with", 
+      "Publisher", "Notes", "Series title", "ISBN", "ISSN"
+    ]
+    expect(rendered.all('label').map(&:text)).to match_array(expected_order)
+  end
+end

--- a/spec/features/advanced_searching_spec.rb
+++ b/spec/features/advanced_searching_spec.rb
@@ -50,6 +50,28 @@ describe 'advanced searching' do
     expect(page).to have_content('Aomen')
   end
 
+  context 'with the built-in advanced search form' do
+    before do
+      allow(Flipflop).to receive(:view_components_advanced_search?).and_return(true)
+      visit '/advanced'
+    end
+
+    it 'renders an accessible button for starting over the search' do
+      expect(page).to have_selector '.icon-refresh[aria-hidden="true"]'
+    end
+
+    it 'has the correct limit text' do
+      expect(page).to have_content('Limit results by')
+    end
+
+    xit 'has drop-downs for search fields' do
+      search_fields = page.find_all('.search-field')
+      expect(search_fields.size).to eq(4)
+      # expect(page).to have_selector('.search-field')
+    end
+
+  end
+
   context 'with a numismatics advanced search type' do
     it 'provides labels to numismatics form elements' do
       visit '/numismatics'

--- a/spec/features/advanced_searching_spec.rb
+++ b/spec/features/advanced_searching_spec.rb
@@ -64,12 +64,11 @@ describe 'advanced searching' do
       expect(page).to have_content('Limit results by')
     end
 
-    xit 'has drop-downs for search fields' do
+    it 'has drop-downs for search fields' do
       search_fields = page.find_all('.search-field')
       expect(search_fields.size).to eq(4)
       # expect(page).to have_selector('.search-field')
     end
-
   end
 
   context 'with a numismatics advanced search type' do

--- a/spec/features/advanced_searching_spec.rb
+++ b/spec/features/advanced_searching_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'advanced searching' do
+describe 'advanced searching', advanced_search: true do
   before do
     stub_holding_locations
   end

--- a/spec/features/advanced_searching_spec.rb
+++ b/spec/features/advanced_searching_spec.rb
@@ -50,9 +50,23 @@ describe 'advanced searching', advanced_search: true do
     expect(page).to have_content('Aomen')
   end
 
+  it 'can exclude terms from the search' do
+    visit '/advanced'
+    # defaults to keyword
+    fill_in(id: 'q1', with: 'gay')
+    choose(id: 'op3_NOT')
+    # defaults to title
+    fill_in(id: 'q3', with: 'RenoOut')
+    click_button('advanced-search-submit')
+    expect(page).to have_content('Seeking sanctuary')
+    expect(page).to have_content('Title NOT RenoOut')
+    expect(page).not_to have_content('Reno Gay Press and Promotions')
+  end
+
   context 'with the built-in advanced search form' do
     before do
       allow(Flipflop).to receive(:view_components_advanced_search?).and_return(true)
+      allow(Flipflop).to receive(:json_query_dsl?).and_return(true)
       visit '/advanced'
     end
 
@@ -67,7 +81,30 @@ describe 'advanced searching', advanced_search: true do
     it 'has drop-downs for search fields' do
       search_fields = page.find_all('.search-field')
       expect(search_fields.size).to eq(4)
-      # expect(page).to have_selector('.search-field')
+    end
+
+    it 'can run a search' do
+      visit '/advanced'
+      # defaults to keyword
+      fill_in(id: 'clause_0_query', with: 'gay')
+      click_button('advanced-search-submit')
+      expect(page).to have_content('Seeking sanctuary')
+      expect(page).to have_content('RenoOut')
+    end
+
+    it 'can exclude terms from the search', js: false do
+      # This passes locally with an older Solr LuceneMatchVersion
+      pending('JSON query DSL fix')
+      visit '/advanced'
+      # defaults to keyword
+      fill_in(id: 'clause_0_query', with: 'gay')
+      choose(id: 'clause_2_op_must_not')
+      # defaults to title
+      fill_in(id: 'clause_2_query', with: 'RenoOut')
+      click_button('advanced-search-submit')
+      expect(page).to have_content('Seeking sanctuary')
+      expect(page).not_to have_content('Reno Gay Press and Promotions')
+      # expect(page).to have_content('Title NOT RenoOut')
     end
   end
 

--- a/spec/features/advanced_searching_spec.rb
+++ b/spec/features/advanced_searching_spec.rb
@@ -58,6 +58,7 @@ describe 'advanced searching', advanced_search: true do
     # defaults to title
     fill_in(id: 'q3', with: 'RenoOut')
     click_button('advanced-search-submit')
+    expect(page.find(".page_entries").text).to eq('1 entry found')
     expect(page).to have_content('Seeking sanctuary')
     expect(page).to have_content('Title NOT RenoOut')
     expect(page).not_to have_content('Reno Gay Press and Promotions')
@@ -84,24 +85,25 @@ describe 'advanced searching', advanced_search: true do
     end
 
     it 'can run a search' do
-      visit '/advanced'
+      pending('Flipflop in controller fix')
       # defaults to keyword
       fill_in(id: 'clause_0_query', with: 'gay')
       click_button('advanced-search-submit')
+      expect(page.find(".page_entries").text).to eq('1 - 2 of 2')
       expect(page).to have_content('Seeking sanctuary')
       expect(page).to have_content('RenoOut')
     end
 
     it 'can exclude terms from the search', js: false do
       # This passes locally with an older Solr LuceneMatchVersion
-      pending('JSON query DSL fix')
-      visit '/advanced'
+      pending('Flipflop in controller fix')
       # defaults to keyword
       fill_in(id: 'clause_0_query', with: 'gay')
       choose(id: 'clause_2_op_must_not')
       # defaults to title
       fill_in(id: 'clause_2_query', with: 'RenoOut')
       click_button('advanced-search-submit')
+      expect(page.find(".page_entries").text).to eq('1 entry found')
       expect(page).to have_content('Seeking sanctuary')
       expect(page).not_to have_content('Reno Gay Press and Promotions')
       # expect(page).to have_content('Title NOT RenoOut')


### PR DESCRIPTION
Connected to #3412 

Current status:
- Styling parallels current advanced search
- Builds initial advanced searches correctly, including selecting field for search and passing along booleans
- Tests in `spec/features/advanced_searching_spec.rb` pass when run individually; however, not in the context of the whole suite, because the controller is not re-loaded, so the json dsl is not used when it should be. This should resolve if #3695 is resolved.
- From a search, clicking "Edit search" raises `Error: Pivot Facet needs at least one field name:`
- From advanced search, does not create a "constraint-value" on the search results page (also true for Numismatics search)
- When trying to remove a search constraint generated by regular search, raises `RSolr::Error::Http - 400 Bad Request
Error: Error when parsing json query, expect a json object here, but found : null`