### PR TITLE
Adjust new 'go live' URL for hosted Aeon.

### DIFF
--- a/config/requests.yml
+++ b/config/requests.yml
@@ -5,7 +5,7 @@ defaults: &defaults
   proxy_base: https://login.ezproxy.princeton.edu/login?url=
   pulsearch_base: https://catalog.princeton.edu
   aeon_base_deprecated: https://lib-aeon.princeton.edu/aeon/aeon.dll
-  aeon_base: https://lib-aeon.princeton.edu/logon
+  aeon_base: https://princeton.aeon.atlas-sys.com/logon
   gfa_base: http://libweb5.princeton.edu/ReCAPNoUI/Default.aspx
   ill_base: https://lib-illiad.princeton.edu/illiad/illiad.dll/OpenURL
   scsb_base: https://scsb.recaplib.org:9093

--- a/spec/features/login_account_spec.rb
+++ b/spec/features/login_account_spec.rb
@@ -169,7 +169,7 @@ describe 'Account login' do
             end
             it 'does not require authentication', js: true do
               visit "/catalog/coin-1167"
-              expect(page).to have_link('Reading Room Request', href: Regexp.new('https://lib-aeon\.princeton\.edu/logon.*Coin.1167'))
+              expect(page).to have_link('Reading Room Request', href: Regexp.new('https://princeton\.aeon\.atlas-sys\.com/logon.*Coin.1167'))
               click_link('Reading Room Request')
               expect(page.current_url).to include(Requests::Config[:aeon_base])
             end
@@ -197,7 +197,7 @@ describe 'Account login' do
             end
             it 'does not require authentication', js: true do
               visit "/catalog/dsp01tq57ns24j"
-              expect(page).to have_link('Reading Room Request', href: Regexp.new('https://lib-aeon\.princeton\.edu/logon.*dsp01tq57ns24j'))
+              expect(page).to have_link('Reading Room Request', href: Regexp.new('https://princeton\.aeon\.atlas-sys\.com/logon.*dsp01tq57ns24j'))
               click_link('Reading Room Request')
               expect(page.current_url).to include(Requests::Config[:aeon_base])
             end
@@ -228,8 +228,8 @@ describe 'Account login' do
             end
             it 'does not require authentication', js: true do
               visit "/catalog/#{bib_id}"
-              expect(page).to have_link('Reading Room Request', href: Regexp.new('https://lib-aeon\.princeton\.edu/logon.*CallNumber\=RECAP-94760855'))
-              click_link('Reading Room Request', href: Regexp.new('https://lib-aeon\.princeton\.edu/logon.*CallNumber\=RECAP-94760855'))
+              expect(page).to have_link('Reading Room Request', href: Regexp.new('https://princeton\.aeon\.atlas-sys\.com/logon.*CallNumber\=RECAP-94760855'))
+              click_link('Reading Room Request', href: Regexp.new('https://princeton\.aeon\.atlas-sys\.com/logon.*CallNumber\=RECAP-94760855'))
               expect(page.current_url).to include(Requests::Config[:aeon_base])
             end
           end


### PR DESCRIPTION
We have decided to just use the vendor's URL for go live and will redirect the old lib-aeon domain to it. 