### PR TITLE
Add initializing the browse list to the steps for running the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ bundle exec cap staging deploy # deploys main branch to staging
    ```
    *Note: You can stop everything with `rake servers:stop`
 
+1. initialiaze the browse lists
+  [see instructions](#building-the-browse-lists)
+
 1. Run the all the tests
     ```
     bundle exec rake spec

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ bundle exec cap staging deploy # deploys main branch to staging
    ```
    *Note: You can stop everything with `rake servers:stop`
 
-1. initialiaze the browse lists
+1. initialize the browse lists
   [see instructions](#building-the-browse-lists)
 
 1. Run the all the tests


### PR DESCRIPTION
I had 16 failures until I initialized the browse lists
```
Finished in 8 minutes 52 seconds (files took 5.6 seconds to load)
1722 examples, 16 failures, 22 pending

Failed examples:

rspec ./spec/features/browsables_spec.rb:11 # Browsables Browse by Call Number with an LC call number displays two browse entries before exact match
rspec ./spec/features/browsables_spec.rb:14 # Browsables Browse by Call Number with an LC call number has a call number link
rspec ./spec/features/browsables_spec.rb:17 # Browsables Browse by Call Number with an LC call number has the library name if it exists
rspec ./spec/features/browsables_spec.rb:26 # Browsables Browse by Call Number with oversize CDs sorts Oversize CDs with other CDs
rspec ./spec/requests/orangelight/browse_spec.rb:26 # Orangelight Browsables Paging Functionality per page value can be set
rspec ./spec/requests/orangelight/browse_spec.rb:31 # Orangelight Browsables Paging Functionality start parameter sets which db entry to return first
rspec ./spec/requests/orangelight/browse_spec.rb:37 # Orangelight Browsables Paging Functionality sets rpp=50 if rpp value is not in [10, 25, 50, 100]
rspec ./spec/requests/orangelight/browse_spec.rb:43 # Orangelight Browsables Paging Functionality shows last complete page if start param > db entries for any accepted rpp
rspec ./spec/requests/orangelight/browse_spec.rb:55 # Orangelight Browsables Paging Functionality shows the first page if start param < 1
rspec ./spec/requests/orangelight/browse_spec.rb:63 # Orangelight Browsables Browse Call Number Search escapes call number browse link urls
rspec ./spec/requests/orangelight/browse_spec.rb:67 # Orangelight Browsables Browse Call Number Search displays full publisher information
rspec ./spec/requests/orangelight/browse_spec.rb:72 # Orangelight Browsables Browse Call Number Search displays pub_created_vern_display field
rspec ./spec/requests/orangelight/browse_spec.rb:77 # Orangelight Browsables Browse Call Number Search displays author_s when author_display is not present
rspec ./spec/requests/orangelight/browse_spec.rb:86 # Orangelight Browsables Multiple locations/titles formats multiple titles as n titles with this call number
rspec ./spec/requests/orangelight/browse_spec.rb:92 # Orangelight Browsables Multiple locations/titles single title with multiple holdings in same location, display single location
rspec ./spec/requests/orangelight/browse_spec.rb:98 # Orangelight Browsables Multiple locations/titles single title with multiple locations
```