### PR TITLE
Add search algorithm dropdown

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -40,6 +40,7 @@
 @import 'components/browse';
 @import 'components/buttons';
 @import 'components/dropdown';
+@import 'components/dropdown-help-text';
 @import 'components/facets';
 @import 'components/font-face';
 @import 'components/footer';

--- a/app/assets/stylesheets/components/dropdown-help-text.scss
+++ b/app/assets/stylesheets/components/dropdown-help-text.scss
@@ -1,0 +1,5 @@
+.dropdown-help-text {
+  margin-left: 10px;
+  font-size: 0.8em;
+  font-style: italic;
+}

--- a/app/components/orangelight/dropdown_help_text_component.rb
+++ b/app/components/orangelight/dropdown_help_text_component.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class Orangelight::DropdownHelpTextComponent < Blacklight::System::DropdownComponent
+  # options are { label:, value:, helptext: } hashes
+  def option_text_and_value(option)
+    [option[:label], option[:value]]
+  end
+
+  # Override to allow adding and styling a helptext for each option
+  def before_render
+    with_button(classes: 'btn btn-outline-secondary dropdown-toggle', label: button_label) unless button
+
+    return if options.any?
+
+    with_options(@choices.map do |option|
+      value = option[:value]
+      { text: label_text(option), url: helpers.url_for(@search_state.params_for_search(@param => value)), selected: @selected == value }
+    end)
+  end
+
+  def label_text(option)
+    content_tag(:div) do
+      safe_join(
+        [
+          content_tag(:div, option[:label]),
+          content_tag(:div, option[:helptext], id: option[:value], class: "dropdown-help-text")
+        ]
+      )
+    end
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -661,9 +661,6 @@ class CatalogController < ApplicationController
     # mean") suggestion is offered.
     config.spell_max = 0
 
-    # Add bookmark all widget
-    config.add_results_collection_tool(:bookmark_all)
-
     config.add_results_document_tool(:bookmark, partial: 'bookmark_control')
 
     config.unapi = {

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -61,6 +61,14 @@ module CatalogHelper
     Rails.application.routes.url_helpers.url_for controller: 'catalog', params:, only_path: true
   end
 
+  def search_algorithm_value
+    if params[:search_algorithm] == "engineering"
+      "engineering"
+    else
+      "default"
+    end
+  end
+
   private
 
     def document_types(document)

--- a/app/views/catalog/_algorithm_select.html.erb
+++ b/app/views/catalog/_algorithm_select.html.erb
@@ -1,0 +1,14 @@
+<% if Flipflop.multi_algorithm? %>
+  <%= render(Orangelight::DropdownHelpTextComponent.new(
+    param: :search_algorithm,
+    choices: [
+      { label: "default", value: "default", helptext: "documents with highest term frequency are first"},
+      { label: "engineering", value: "engineering", helptext: "move documents about engineering to the top" }
+    ],
+    id: 'search-algorithm-dropdown',
+    search_state: search_state,
+    default: 'default',
+    interpolation: :algorithm,
+    selected: search_algorithm_value))
+  %>
+<% end %>

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -12,6 +12,9 @@
       <%= render partial: 'tools', locals: { document_list: @document_list } %>
     <% end %>
     <%= render partial: 'sort_widget' %>
+    <%# Normally you would add this widget to the catalog controller, like:
+      config.add_results_collection_tool(:algorithm_select) %>
+    <%= render partial: 'algorithm_select' %>
     <%= render partial: 'per_page_widget' %>
     <% unless bookmarks? %>
       <%= render partial: 'bookmark_all' %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -68,6 +68,8 @@ en:
         try_borrow_direct: 'Try Borrow Direct'
       show:
         label: '%{label}'
+      search_algorithm:
+        label_html: 'Rank by %{algorithm}'
     skip_links:
       first_result: 'Skip to result %{start} of %{total}'
     header_links:
@@ -78,7 +80,7 @@ en:
     login:
       netid_login_msg: 'Log in with netID'
       netid_button: 'Log in with netID'
-      redirect_text: 'You will be redirected to the secure Princeton University Central Authentication Service (CAS) login.'
+      redirect_text: 'You will be redirected to the secure Princeton University Central Authentication Service () login.'
       alma_login_msg: 'Log in with Alma Account (affiliates)'
       barcode_netid: 'Please log in with netID.'
       barcode_header: ''

--- a/spec/system/search_algorithms_spec.rb
+++ b/spec/system/search_algorithms_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Selecting search algorithms for results', type: :system, js: false do
+  before do
+    stub_holding_locations
+  end
+
+  context 'with the search algorithms feature enabled' do
+    before do
+      allow(Flipflop).to receive(:multi_algorithm?).and_return(true)
+    end
+
+    it 'renders a select widget used to select the ordering algorithm' do
+      visit '/catalog?search_field=all_fields&q=roman'
+      expect(page).to have_text('1. Огонек : роман')
+
+      click_button('Rank by default')
+      within('#engineering.dropdown-help-text') do
+        expect(page).to have_text("move documents about engineering to the top")
+      end
+      click_link('engineering')
+      expect(page).to have_button('Rank by engineering')
+      expect(page).to have_text('1. Reconstructing the Vitruvian Scorpio: An Engineering Analysis')
+    end
+  end
+
+  context 'with the search algorithms feature disabled' do
+    before do
+      allow(Flipflop).to receive(:multi_algorithm?).and_return(false)
+    end
+
+    it 'does not render a select widget' do
+      visit '/catalog?search_field=all_fields&q=roman'
+      expect(page).not_to have_button('Rank by default')
+    end
+  end
+end


### PR DESCRIPTION
1. Add search algorithm dropdown
1. Implement an  Orangelight::DropdownHelpTextComponent to support help text markup within the algorithm selection dropdown UI component

Closes #3748

screenshot:
![Screenshot 2023-11-13 at 12 38 53 PM](https://github.com/pulibrary/orangelight/assets/845363/35f85ade-62b1-48e6-8832-a02b957c8b84)

