### PR TITLE
Update header css to fit in screen less than 322px #1918

### DIFF
--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -35,12 +35,6 @@
   .menu--level-1,
   .logo__pul {
     z-index: 10;
-
-    @media (min-width: $bp-small) and (max-width: 589px) {
-      &.col-sm-auto {
-        width: 100%;
-      }
-    }
   }
 
   .logo__pul a {
@@ -57,7 +51,6 @@
       margin-left: 1rem;
       border-left: 1px solid darken($gray, 50%);
       height: 35px;
-      padding-left: 1rem;
       color: white;
       font-size: 1.6em;
       line-height: 35px;


### PR DESCRIPTION
closes #1918 

I don't think there is a screen less than 306px. In 305px the header will wrap.

See the following screenshoot. The top one is my local. The bottom one is production.

![Screenshot 2023-12-01 at 9 23 26 AM](https://github.com/pulibrary/orangelight/assets/9905193/af8b531d-0833-453d-87b6-e0d973187237)
