### PR TITLE
Remove unused dependency: cobravsmongoose

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem 'capistrano', '~> 3.4'
 gem 'capistrano-passenger'
 # jquery multiselect plugin for advanced search
 gem 'chosen-rails'
-gem 'cobravsmongoose', '~> 0.0.2'
 gem 'ddtrace', '~> 1.14.0'
 # Authentication and authorization
 gem 'devise', '>= 4.6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,6 @@ GEM
       railties (>= 3.0)
       sassc-rails (>= 2.1.2)
     chronic (0.10.2)
-    cobravsmongoose (0.0.2)
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -687,7 +686,6 @@ DEPENDENCIES
   capistrano-rails
   capybara
   chosen-rails
-  cobravsmongoose (~> 0.0.2)
   coveralls_reborn
   ddtrace (~> 1.14.0)
   devise (>= 4.6.0)


### PR DESCRIPTION
We don't use it anywhere in the code; also, this is a pre-production release version from 2006!