### PR TITLE
Added config value with clearer screen reader text

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -58,6 +58,7 @@ en:
       sort:
         label: 'Sort<span class="d-none d-xl-inline"> by %{field}</span>'
       per_page:
+        label: '%{count}<span class="sr-only visually-hidden"> results per page</span>'
         button_label: '%{count}<span class="d-none d-xl-inline"> per page</span>'
       start_over: 'Start over'
       cite: 'Cite'


### PR DESCRIPTION
Resolves #3375 

There was a configuration that was not set for this element. We had discussed a possible upstream PR, but since it's able to be configured I don't think it's necessary.