### PR TITLE
Use SameSite=strict for orangelight cookie

### DIFF
--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -3,3 +3,4 @@
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.action_dispatch.cookies_serializer = :json
+Rails.application.config.action_dispatch.cookies_same_site_protection = :strict

--- a/spec/requests/cookies_spec.rb
+++ b/spec/requests/cookies_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+require 'rails_helper'
+RSpec.describe 'Cookies' do
+  it 'sets SameSite=strict' do
+    get '/'
+    expect(response.headers['Set-Cookie']).to include('SameSite=Strict')
+  end
+  it 'sets HttpOnly' do
+    get '/'
+    expect(response.headers['Set-Cookie']).to include('HttpOnly')
+  end
+end


### PR DESCRIPTION
This reduces the number of scenarios in which the cookie will be sent, providing better CSRF protection and reducing the size of the Cookies header in some cases.

Part of https://github.com/pulibrary/dacs_handbook/issues/154