### PR TITLE
i3943: don't send left_anchor field through the advanced_parser

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -549,6 +549,7 @@ class CatalogController < ApplicationController
         qf: '$left_anchor_qf',
         pf: '$left_anchor_pf'
       }
+      field.advanced_parse = false
     end
 
     config.add_search_field('publisher') do |field|

--- a/spec/requests/catalog_spec.rb
+++ b/spec/requests/catalog_spec.rb
@@ -14,6 +14,12 @@ describe 'search requests for the catalog' do
     expect(response.status).to eq(200)
   end
 
+  it 'can handle parentheses in the left_anchor field' do
+    get '/?search_field=left_anchor&q=Washington+post+(Washington%2C+D.C.+%3A+1877)'
+
+    expect(response.status).to eq(200)
+  end
+
   context "BadRequest when clicking back to search" do
     # This url produces ActionController::BadRequest
     let(:url) do


### PR DESCRIPTION
The blacklight advanced search gem was being overly helpful, noticing that there were a set of parentheses in the query:

    Washington post (Washington, D.C. : 1877)

And accordingly, it parsed it into the following nested query, which caused a Solr error:

    _query_:"{!edismax }Washington post" AND _query_:"{!edismax }Washington, D.C. : 1877"*

closes #3943 