### PR TITLE
Update browser tools in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 ---
 version: 2.1
 orbs:
-  browser-tools: circleci/browser-tools@1.4.3
+  browser-tools: circleci/browser-tools@1.4.6
   ruby: circleci/ruby@2.0.0
   node: circleci/node@5.0.2
 executors:


### PR DESCRIPTION
Because of this [failure](https://app.circleci.com/pipelines/github/pulibrary/orangelight/4469/workflows/6d86396d-56cc-4be7-bb2c-dfdb2e3a9fa6/jobs/15308?invite=true#step-102-2685_41) to find node 