### PR TITLE
Minor performance refactor for advanced search forms

### DIFF
--- a/app/views/advanced/_facet_as_select.html.erb
+++ b/app/views/advanced/_facet_as_select.html.erb
@@ -3,6 +3,7 @@
       <% if display_facet.name == 'advanced_location_s' %>
         <%= render 'location_code_facet', display_facet: %>
       <% else %>
+      <% query_parser = BlacklightAdvancedSearch::QueryParser.new(params, blacklight_config) %>
       <%= render MultiselectComboboxComponent.new(
             label: facet_field_label(display_facet.name),
             dom_id: display_facet.name.parameterize,
@@ -11,7 +12,7 @@
               {
                 value: facet_item.value,
                 label: "#{facet_item.value}  (#{number_with_delimiter facet_item.hits})",
-                selected: facet_value_checked?(display_facet.name, facet_item.value)
+                selected: query_parser.filters_include_value?(display_facet.name, facet_item.value)
               }
             end) %>
       <% end %>


### PR DESCRIPTION
When running rubyprof on the numismatics screen locally, we noticed that
  * Object#blank is called 39863 times
  * Array#each is called 10480 times
  * BasicObject#! is called 97717 times

...and this is using the local development data set, which has very few coins.

When looking at the stack traces for some of these calls, they all came from the `facet_value_checked?` method in Blacklight Advanced Search gem, many of them from it parsing filters from the URL params, which is memoized so re-using the BlacklightAdvancedSearch::QueryParser saves us re-doing that work each time.

Re-using the `BlacklightAdvancedSearch::QueryParser` object reduces the number of calls we have to make to these methods to 22164, 7863, and 62083 respectively.