### PR TITLE
Explicitly turn off enable_starttls for SMTP

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,6 +82,7 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     address: "#{ENV['SMTP_HOST'] || 'lib-ponyexpr-prod.princeton.edu' }",
     port: (ENV['SMTP_PORT'] || 25).to_i,
+    enable_starttls: false,
     open_timeout: 10,
     read_timeout: 10
   }


### PR DESCRIPTION
In testing with the rails console, @kayiwa found that we need `enable_starttls: false` in order to send mail via the new lib-ponyexpr-prod.  See https://github.com/pulibrary/princeton_ansible/pull/4980#issuecomment-2140181019.  We may decide to use TLS for this connection in the future.

Using the rails console, I confirmed that I can still send mail through the old lib-ponyexpr with an explicit `enable_starttls: false`.