### PR TITLE
Add Vale to CircleCI for linting documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ orbs:
   browser-tools: circleci/browser-tools@1.4.6
   ruby: circleci/ruby@2.0.0
   node: circleci/node@5.0.2
+  vale: circleci/vale@1.0.0
 executors:
   orangelight-executor:
     docker:
@@ -175,6 +176,7 @@ workflows:
       - test:
          requires:
           - build
+      - vale/lint
       - finish:
          requires:
            - test

--- a/README.md
+++ b/README.md
@@ -126,6 +126,16 @@ The browser will only display for system specs with `js: true`.
 * [erblint](https://github.com/Shopify/erb-lint)
 * `bundle exec erblint --lint-all`
 
+#### Documentation linting with vale
+
+To run locally:
+```
+brew install vale
+cd docs
+vale sync
+vale .
+```
+
 #### Running CodeQL locally
 
 If you get a CodeQL warning on your branch, you may wish to run

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -1,0 +1,11 @@
+StylesPath = .vale
+
+MinAlertLevel = suggestion
+
+Packages = RedHat
+
+Vocab = Base
+
+[*]
+BasedOnStyles = Vale, RedHat
+

--- a/docs/.vale/config/vocabularies/Base/accept.txt
+++ b/docs/.vale/config/vocabularies/Base/accept.txt
@@ -1,0 +1,12 @@
+Ctrl
+figgy
+Figgy
+iiif
+Marquand
+Mudd
+orangelight
+Orangelight
+postgres
+solr
+Solr
+tmux

--- a/docs/browse-lists.md
+++ b/docs/browse-lists.md
@@ -39,7 +39,7 @@ Fix:
 - Find which machine to use from section: `How to know which machine to use`. Currently the `call_numbers` task is deployed to run on `catalog-indexer3`.
 - SSH as `deploy` user to the machine used to produce the subjects lists
 
-- Run the first rake task to generate the CSV file from solr data:
+- Run the first rake task to generate the CSV file from Solr data:
 - `cd /opt/orangelight/current`
 - `OL_DB_PORT=5432 bundle exec rake browse:subjects`
 


### PR DESCRIPTION
* Configure vale, including accept.txt to define terminology we use in the documentation
* Add instructions for running vale locally to the README