### PR TITLE
Add health monitor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem 'flipflop'
 gem 'font-awesome-rails'
 gem 'friendly_id', '~> 5.4.2'
 gem 'global'
+gem 'health-monitor-rails', git: 'https://github.com/pulibrary/health-monitor-rails.git', branch: 'add_solr_monitor'
 # Static pages
 gem 'high_voltage'
 gem 'honeybadger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,14 @@ GIT
       rails
 
 GIT
+  remote: https://github.com/pulibrary/health-monitor-rails.git
+  revision: fe794a6a6846d6f10b158963e0b0dea4e4dd172c
+  branch: add_solr_monitor
+  specs:
+    health-monitor-rails (12.1.0)
+      railties (>= 6.1)
+
+GIT
   remote: https://github.com/pulibrary/stringex.git
   revision: 357f70511532a35b11a240e5ae06d02725cb8d0a
   tag: vpton.2.5.2.2
@@ -698,6 +706,7 @@ DEPENDENCIES
   font-awesome-rails
   friendly_id (~> 5.4.2)
   global
+  health-monitor-rails!
   high_voltage
   honeybadger
   jbuilder (~> 2.0)

--- a/config/initializers/health_monitor.rb
+++ b/config/initializers/health_monitor.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+Rails.application.config.after_initialize do
+  HealthMonitor.configure do |config|
+    config.cache
+
+    config.solr.configure do |c|
+      c.url = Blacklight.default_index.connection.uri.to_s
+    end
+
+    # Make this health check available at /health
+    config.path = :health
+
+    config.error_callback = proc do |e|
+      Rails.logger.error "Health check failed with: #{e.message}"
+      Honeybadger.notify(e)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
 
   mount Flipflop::Engine => '/features'
 
+  mount HealthMonitor::Engine => '/'
+
   concern :searchable, Blacklight::Routes::Searchable.new
   concern :exportable, Blacklight::Routes::Exportable.new
   concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Health Check", type: :request do
+  describe "GET /health" do
+    it "has a health check" do
+      get "/health.json"
+      expect(response).to be_successful
+    end
+
+    context 'when solr is down' do
+      let(:solr_url) { /\/solr\/admin\/cores\?action=STATUS/ }
+      let(:solr_stub) do
+        stub_request(:get, solr_url)
+          .to_return(
+            body: { responseHeader: { status: 500 } }.to_json, headers: { "Content-Type" => "text/json" }
+          )
+      end
+
+      before { solr_stub }
+
+      it "errors when a service is down" do
+        get "/health.json"
+        expect(solr_stub).to have_been_requested
+        expect(response).not_to be_successful
+        expect(response.status).to eq 503
+        solr_response = JSON.parse(response.body)["results"].find { |x| x["name"] == "Solr" }
+        expect(solr_response["message"]).to start_with "The solr has an invalid status"
+      end
+    end
+  end
+end


### PR DESCRIPTION
- So far we monitor the database (automatically included), the cache, and Solr

This branch uses a fork of the health-monitor-rails gem which includes the Solr monitor.