### PR TITLE
Update commit hash for health monitor dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: https://github.com/pulibrary/health-monitor-rails.git
-  revision: fe794a6a6846d6f10b158963e0b0dea4e4dd172c
+  revision: 44fb3d6e84935fe6094f5d7f3b731b7e38ff3f89
   branch: add_solr_monitor
   specs:
     health-monitor-rails (12.1.0)
@@ -161,7 +161,7 @@ GEM
       autoprefixer-rails (>= 9.1.0)
       popper_js (>= 1.16.1, < 2)
       sassc-rails (>= 2.0.0)
-    builder (3.2.4)
+    builder (3.3.0)
     bunny (2.22.0)
       amq-protocol (~> 2.3, >= 2.3.1)
       sorted_set (~> 1, >= 1.0.2)
@@ -191,7 +191,7 @@ GEM
     coderay (1.1.3)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
-    concurrent-ruby (1.3.1)
+    concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     coveralls_reborn (0.28.0)
       simplecov (~> 0.22.0)
@@ -240,7 +240,7 @@ GEM
       rubocop
       smart_properties
     erblint-github (0.5.1)
-    erubi (1.12.0)
+    erubi (1.13.0)
     execjs (2.9.1)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -359,7 +359,7 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
-    minitest (5.23.1)
+    minitest (5.24.1)
     mize (0.5.0)
     modernizr-rails (2.7.1)
     msgpack (1.7.2)
@@ -378,12 +378,12 @@ GEM
       net-protocol
     net-ssh (7.2.0)
     nio4r (2.7.0)
-    nokogiri (1.16.5)
+    nokogiri (1.16.6)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.16.5-aarch64-linux)
+    nokogiri (1.16.6-aarch64-linux)
       racc (~> 1.4)
-    nokogiri (1.16.5-x86_64-linux)
+    nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     omniauth (2.1.2)
       hashie (>= 3.4.6)
@@ -665,7 +665,7 @@ GEM
     yajl-ruby (1.4.3)
     yard (0.9.36)
     yell (2.2.2)
-    zeitwerk (2.6.15)
+    zeitwerk (2.6.16)
 
 PLATFORMS
   aarch64-linux


### PR DESCRIPTION
`bundle install` was failing for me locally on main.  `bundle update health-monitor-rails` fixed it, by finding the most up-to-date commit hash for our fork.