### PR TITLE
Refactor new forms to not inherit from MailForm::Base

### DIFF
--- a/app/forms/ask_a_question_form.rb
+++ b/app/forms/ask_a_question_form.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
-class AskAQuestionForm < MailForm::Base
+class AskAQuestionForm
   include ActiveModel::Model
+  include Honeypot
   attr_accessor :name, :email, :message, :context, :title
 
   validates :name, :email, :message, presence: true
   validates :email, email: true
-  attribute :feedback_desc, captcha: true
 
   def email_subject
     "[Catalog] #{title}"

--- a/app/forms/concerns/honeypot.rb
+++ b/app/forms/concerns/honeypot.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+# This module identifies spam bots based on them
+# filling out a "honeypot" field.
+module Honeypot
+  attr_accessor :feedback_desc
+
+    private
+
+      def spam?
+        # feedback_desc is a hidden field that is not presented
+        # to human users.  If feedback_desc is present, it was almost
+        # certainly filled in by a spam robot.
+        feedback_desc.present?
+      end
+end

--- a/app/forms/report_harmful_language_form.rb
+++ b/app/forms/report_harmful_language_form.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
-class ReportHarmfulLanguageForm < MailForm::Base
+class ReportHarmfulLanguageForm
   include ActiveModel::Model
+  include Honeypot
   attr_accessor :name, :email, :message, :context, :title, :error
 
   validates :message, presence: true
-  attribute :feedback_desc, captcha: true
 
   def email_subject
     "[Possible Harmful Language] #{title}"

--- a/app/forms/suggest_correction_form.rb
+++ b/app/forms/suggest_correction_form.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-class SuggestCorrectionForm < MailForm::Base
+class SuggestCorrectionForm
   include ActiveModel::Model
+  include Honeypot
+
   attr_accessor :name, :email, :message, :context, :title
 
   validates :name, :email, :message, :context, presence: true
   validates :email, email: true
-  attribute :feedback_desc, captcha: true
 
   def email_subject
     "[Catalog] #{title}"


### PR DESCRIPTION
We were only using `MailForm::Base` for its `spam?` method, which is simple enough to implement ourselves.