### PR TITLE
Refactor FeedbackForm to not use MailForm

### DIFF
--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -19,4 +19,9 @@ class ContactMailer < ApplicationMailer
     @form = params[:form]
     mail(to: @form.routed_mail_to, from: @form.from_email, subject: @form.email_subject)
   end
+
+  def feedback
+    @form = params[:form]
+    mail(to: @form.headers[:to], from: @form.headers[:from], subject: @form.headers[:subject])
+  end
 end

--- a/app/views/contact_mailer/feedback.html.erb
+++ b/app/views/contact_mailer/feedback.html.erb
@@ -1,0 +1,8 @@
+Name: <%= @form.name %><br>
+Email: <%= @form.email %><br>
+Comments: <%= @form.message %><br>
+<br>
+Request information<br>
+Remote ip: <%= @form.remote_ip %><br>
+User agent: <%= @form.user_agent %><br>
+Current url: <%= @form.current_url %>

--- a/spec/forms/feedback_form_spec.rb
+++ b/spec/forms/feedback_form_spec.rb
@@ -56,4 +56,36 @@ RSpec.describe FeedbackForm do
       expect(form.error_message).to eq(I18n.t('blacklight.feedback.error'))
     end
   end
+
+  describe "deliver" do
+    it "sends an email" do
+      form = described_class.new({
+                                   email: 'test@test.org',
+                                   name: 'A Nice Tester',
+                                   message: 'Good job on the catalog!'
+                                 })
+
+      expect { form.deliver }.to change { ActionMailer::Base.deliveries.length }.by 1
+      mail = ActionMailer::Base.deliveries.first
+      expect(mail.subject).to eq "Princeton University Library Catalog Feedback Form"
+      expect(mail.from).to eq ["test@test.org"]
+      expect(mail.body).to include "Good job on the catalog!"
+    end
+  end
+
+  describe 'remote_ip' do
+    it 'gets the IP from the request, if available' do
+      form.request = instance_double(ActionDispatch::Request)
+      allow(form.request).to receive(:remote_ip).and_return('10.11.12.13')
+      expect(form.remote_ip).to eq('10.11.12.13')
+    end
+  end
+
+  describe 'user_agent' do
+    it 'gets the User agent from the request, if available' do
+      form.request = instance_double(ActionDispatch::Request)
+      allow(form.request).to receive(:user_agent).and_return('Firefox')
+      expect(form.user_agent).to eq('Firefox')
+    end
+  end
 end

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -95,4 +95,33 @@ describe ContactMailer, type: :mailer do
       end
     end
   end
+
+  context 'with a feedback form' do
+    let(:valid_attributes) do
+      {
+        "name" => "Test",
+        "email" => "test@test.org",
+        "message" => "I think your site is great!"
+      }
+    end
+    let(:form) do
+      FeedbackForm.new(valid_attributes)
+    end
+    let(:mail) do
+      described_class.with(form:).feedback.deliver_now
+    end
+
+    it "renders the headers" do
+      mail
+      expect(mail.subject).to eq("Princeton University Library Catalog Feedback Form")
+      expect(mail.to).to eq(["test@princeton.edu"])
+      expect(mail.from).to eq(["test@test.org"])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to have_content('Name: Test')
+      expect(mail.body.encoded).to have_content('Email: test@test.org')
+      expect(mail.body.encoded).to have_content('Comments: I think your site is great!')
+    end
+  end
 end


### PR DESCRIPTION
This refactor makes the feedback form more similar to the other forms.  It also will enable us to more easily swap out the email functionality for Libanswers API ticket creation

Helps with #3909