### PR TITLE
Remove mail_form gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,6 @@ gem 'lcsort', '>= 0.9.1'
 gem 'library_stdnums'
 gem 'lograge'
 gem 'logstash-event'
-gem 'mail_form'
 gem 'matrix'
 # For memory profiling
 # See https://github.com/MiniProfiler/rack-mini-profiler#memory-profiling for usage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -344,9 +344,6 @@ GEM
       net-imap
       net-pop
       net-smtp
-    mail_form (1.10.1)
-      actionmailer (>= 5.2)
-      activemodel (>= 5.2)
     marc (1.2.0)
       rexml
       scrub_rb (>= 1.0.1, < 2)
@@ -716,7 +713,6 @@ DEPENDENCIES
   library_stdnums
   lograge
   logstash-event
-  mail_form
   matrix
   memory_profiler
   modernizr-rails

--- a/app/forms/feedback_form.rb
+++ b/app/forms/feedback_form.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'mail_form'
-
 class FeedbackForm
   include ActiveModel::Model
   include Honeypot

--- a/app/forms/report_biased_results_form.rb
+++ b/app/forms/report_biased_results_form.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
-class ReportBiasedResultsForm < MailForm::Base
+class ReportBiasedResultsForm
   include ActiveModel::Model
+  include Honeypot
   attr_accessor :name, :email, :message, :context
 
   validates :message, presence: true
-  attribute :feedback_desc, captcha: true
 
   def email_subject
     "[Possible Biased Results]"


### PR DESCRIPTION
It is no longer needed (after #4066 and #4064).

This includes a refactor of the Report Biased Results form, which is not in production and is behind a feature flipper.  That form is not complete (for example, the form template does not have a honeypot field to catch spam bots), I did not attempt to fix it, just kept the incomplete behavior the same.