### PR TITLE
Use libanswers API, rather than email, to create tickets in libanswers for the FeedbackForm

### DIFF
--- a/app/forms/feedback_form.rb
+++ b/app/forms/feedback_form.rb
@@ -9,7 +9,12 @@ class FeedbackForm
   validates :email, email: true
 
   def deliver
-    ContactMailer.with(form: self).feedback.deliver if valid? && !spam?
+    return if spam?
+    return unless valid?
+
+    FeedbackFormSubmission.new(
+      message:, patron_name: name, patron_email: email, user_agent:, current_url:
+    ).send_to_libanswers
   end
 
   def headers

--- a/app/models/feedback_form_submission.rb
+++ b/app/models/feedback_form_submission.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+# This class is responsible for conveying a
+# form submission to the libanswers API,
+# which will create a ticket for us to answer
+class FeedbackFormSubmission
+  def initialize(message:, patron_name:, patron_email:, user_agent:, current_url:)
+    @message = message
+    @patron_name = patron_name
+    @patron_email = patron_email
+    @user_agent = user_agent
+    @current_url = current_url
+  end
+
+  def send_to_libanswers
+    Net::HTTP.post uri, body, { Authorization: "Bearer #{token}" }
+  end
+
+    private
+
+      attr_reader :patron_name, :patron_email, :user_agent, :current_url
+
+      def body
+        @body ||= data.to_a.map { |entry| "#{entry[0]}=#{entry[1]}" }.join('&')
+      end
+
+      def data
+        {
+          quid: Rails.application.config_for(:orangelight)[:feedback_form][:queue_id],
+          pquestion: 'Princeton University Library Catalog Feedback Form',
+          pdetails: message,
+          pname: patron_name,
+          pemail: patron_email,
+          ua: user_agent
+        }.compact
+      end
+
+      def message
+        return "#{@message}\n\nSent from #{current_url} via LibAnswers API" if current_url
+
+        "#{@message}\n\nSent via LibAnswers API"
+      end
+
+      def uri
+        @uri ||= URI('https://faq.library.princeton.edu/api/1.1/ticket/create')
+      end
+
+      def token
+        @token ||= OAuthToken.find_or_create_by({ service: 'libanswers',
+                                                  endpoint: 'https://faq.library.princeton.edu/api/1.1/oauth/token' }).token
+      end
+end

--- a/app/models/oauth_token.rb
+++ b/app/models/oauth_token.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# This class is responsible for persisting
+# OAuth tokens to the database
+class OAuthToken < ApplicationRecord
+  def token
+    if expiration_time && not_yet_expired
+      self[:token]
+    else
+      fetch_new_token
+      reload[:token]
+    end
+  end
+
+    private
+
+      def fetch_new_token
+        service = OAuthService.new(service: self.service, endpoint:)
+        self.token = service.new_token
+        self.expiration_time = service.expiration_time
+        save
+      end
+
+      def not_yet_expired
+        (Time.zone.now < expiration_time)
+      end
+end

--- a/app/services/oauth_service.rb
+++ b/app/services/oauth_service.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# This class is responsible for communicating with an
+# OAuth server to get new access tokens
+class OAuthService
+  class CouldNotGenerateOAuthToken < StandardError; end
+
+  def initialize(endpoint:, service:)
+    @endpoint = URI(endpoint)
+    @service = service.to_sym
+  end
+
+  def new_token
+    token = JSON.parse(response.body)['access_token']
+    raise CouldNotGenerateOAuthToken unless token
+    token
+  end
+
+  def expiration_time
+    validity_in_seconds = JSON.parse(response.body)['expires_in']
+    validity_in_seconds.seconds.from_now - 1.hour
+  end
+
+    private
+
+      attr_reader :endpoint, :service
+
+      def client_id
+        configuration[:client_id]
+      end
+
+      def client_secret
+        configuration[:client_secret]
+      end
+
+      def response
+        @response ||= Net::HTTP.post_form(endpoint, client_id:, client_secret:, grant_type:)
+      end
+
+      def grant_type
+        'client_credentials'
+      end
+
+      def configuration
+        @configuration ||= Rails.application.config_for(:orangelight)[service]
+      end
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -8,6 +8,7 @@
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.irregular 'access', 'access types'
   inflect.acronym 'DB'
+  inflect.acronym 'OAuth'
 end
 
 # These inflection rules are supported but not enabled by default:

--- a/config/orangelight.yml
+++ b/config/orangelight.yml
@@ -5,6 +5,7 @@ defaults: &defaults
   feedback_form:
     to: <%= ENV['OL_FEEDBACK_TO'] %>
     cc: <%= ENV['OL_FEEDBACK_CC'] %>
+    queue_id: <%= ENV['CATALOG_FEEDBACK_QUEUE_ID'] %>
   ask_a_question_form:
     to: <%= ENV['OL_REFERENCE_TO'] %>
   suggest_correction_form:
@@ -45,6 +46,7 @@ test:
   feedback_form:
     to: 'test@princeton.edu'
     cc: 'test2w@princeton.edu, test3@princeton.edu'
+    queue_id: 1234
   ask_a_question_form:
     to: 'test-question@princeton.edu'
   redis:

--- a/config/orangelight.yml
+++ b/config/orangelight.yml
@@ -22,6 +22,9 @@ defaults: &defaults
       maximum: 3
   bookmarks:
     batch_size: 200
+  libanswers:
+    client_id: <%= ENV['LIBANSWERS_CLIENT_ID'] || 'ABC' %>
+    client_secret: <%= ENV['LIBANSWERS_CLIENT_SECRET'] || '12345' %>
 
 development:
   <<: *defaults
@@ -54,6 +57,9 @@ test:
     to: 'test-harmful-content@princeton.edu'
   report_biased_results_form:
     to: 'test-biased-results@princeton.edu'
+  libanswers:
+    client_id: ABC
+    client_secret: '12345'
 
 production:
   <<: *defaults

--- a/db/migrate/20240725171021_create_oauth_tokens.rb
+++ b/db/migrate/20240725171021_create_oauth_tokens.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class CreateOAuthTokens < ActiveRecord::Migration[6.1]
+  def change
+    create_table :oauth_tokens do |t|
+      t.string :service, null: false
+      t.string :endpoint, null: false
+      t.string :token
+      t.datetime :expiration_time
+
+      t.timestamps
+    end
+
+    add_index :oauth_tokens, :service, unique: true
+    add_index :oauth_tokens, :endpoint, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_07_175034) do
+ActiveRecord::Schema.define(version: 2024_07_25_171021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,17 @@ ActiveRecord::Schema.define(version: 2023_12_07_175034) do
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "oauth_tokens", force: :cascade do |t|
+    t.string "service", null: false
+    t.string "endpoint", null: false
+    t.string "token"
+    t.datetime "expiration_time"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["endpoint"], name: "index_oauth_tokens_on_endpoint", unique: true
+    t.index ["service"], name: "index_oauth_tokens_on_service", unique: true
   end
 
   create_table "searches", id: :serial, force: :cascade do |t|

--- a/spec/features/feedback_spec.rb
+++ b/spec/features/feedback_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 describe 'submitting feedback', js: true do
   before do
+    stub_libanswers_api
     visit 'feedback'
     fill_in(id: 'feedback_form_name', with: 'John Smith')
     fill_in(id: 'feedback_form_email', with: 'jsmith@localhost.localdomain')

--- a/spec/fixtures/files/libanswers/oauth_token.json
+++ b/spec/fixtures/files/libanswers/oauth_token.json
@@ -1,0 +1,6 @@
+{
+    "access_token": "abcdef1234567890abcdef1234567890abcdef12",
+    "expires_in": 604800,
+    "token_type": "Bearer",
+    "scope": "app_view"
+}

--- a/spec/models/feedback_form_submission_spec.rb
+++ b/spec/models/feedback_form_submission_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe FeedbackFormSubmission do
+  it 'sends the feedback via Libanswers API' do
+    stub_libanswers_api
+
+    described_class.new(
+        message: 'I have some thoughts about the catalog',
+        patron_name: 'Miles Morales',
+        patron_email: 'spiderman@example.com',
+        user_agent: 'Mozilla/5.0 (Android 4.4; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0',
+        current_url: 'https://catalog.princeton.edu/catalog/12345'
+      ).send_to_libanswers
+
+    expect(WebMock).to have_requested(
+        :post,
+        'https://faq.library.princeton.edu/api/1.1/ticket/create'
+      ).with(body: 'quid=1234&'\
+      'pquestion=Princeton University Library Catalog Feedback Form&'\
+      "pdetails=I have some thoughts about the catalog\n\nSent from https://catalog.princeton.edu/catalog/12345 via LibAnswers API&"\
+      'pname=Miles Morales&'\
+      'pemail=spiderman@example.com&'\
+      'ua=Mozilla/5.0 (Android 4.4; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0',
+             headers: { Authorization: 'Bearer abcdef1234567890abcdef1234567890abcdef12' })
+  end
+end

--- a/spec/models/oauth_token_spec.rb
+++ b/spec/models/oauth_token_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OAuthToken do
+  describe '#token' do
+    context 'when an unexpired token is already in the database' do
+      before do
+        described_class.create(service: 'libanswers', endpoint: 'http://my-api.com', token: 'valid-token',
+                               expiration_time: Time.utc(2050, 1, 1, 10, 30, 59))
+      end
+
+      it 'returns the token from the database' do
+        travel_to Date.new(2020, 1, 1)
+        entry = described_class.find_by(endpoint: 'http://my-api.com')
+        expect(entry.token).to eq('valid-token')
+      end
+    end
+
+    context 'when an expired token is in the database' do
+      before do
+        described_class.create(service: 'libanswers', endpoint: 'http://my-api.com', token: 'expired-token',
+                               expiration_time: Time.utc(1995, 1, 1, 10, 30, 59))
+      end
+
+      it 'fetches a new token from the endpoint' do
+        stub_request(:post, 'http://my-api.com')
+          .with(body: 'client_id=ABC&client_secret=12345&grant_type=client_credentials')
+          .to_return(status: 200, body: file_fixture('libanswers/oauth_token.json'))
+        travel_to Date.new(2020, 1, 1)
+        entry = described_class.find_by(endpoint: 'http://my-api.com')
+        expect(entry.token).to eq('abcdef1234567890abcdef1234567890abcdef12')
+        expect(entry.expiration_time).to eq(Time.zone.local(2020, 1, 7, 23, 0, 0))
+      end
+    end
+
+    context 'when there is not yet a token or expiration_time in the database' do
+      before do
+        described_class.create(service: 'libanswers', endpoint: 'http://my-api.com')
+      end
+
+      it 'fetches a new token from the endpoint' do
+        stub_request(:post, 'http://my-api.com')
+          .with(body: 'client_id=ABC&client_secret=12345&grant_type=client_credentials')
+          .to_return(status: 200, body: file_fixture('libanswers/oauth_token.json'))
+        travel_to Date.new(2020, 1, 1)
+        entry = described_class.find_by(endpoint: 'http://my-api.com')
+        expect(entry.token).to eq('abcdef1234567890abcdef1234567890abcdef12')
+        expect(entry.expiration_time).to eq(Time.zone.local(2020, 1, 7, 23, 0, 0))
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,6 +59,8 @@ RSpec.configure do |config|
 
   config.include ViewComponent::TestHelpers, type: :component
 
+  config.include ActiveSupport::Testing::TimeHelpers
+
   config.before(:each, type: :feature) do
     Warden.test_mode!
     OmniAuth.config.test_mode = true

--- a/spec/requests/feedback_forms_spec.rb
+++ b/spec/requests/feedback_forms_spec.rb
@@ -2,9 +2,10 @@
 
 require 'rails_helper'
 
-RSpec.describe "feedback emails", type: :request do
+RSpec.describe "feedback forms", type: :request do
   context 'main feedback form' do
     it 'adds a flash message on success' do
+      stub_libanswers_api
       post '/feedback.js', params: {
         controller: "FeedbackController",
         action: "create",

--- a/spec/services/oauth_service_spec.rb
+++ b/spec/services/oauth_service_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe OAuthService do
+  before do
+    stub_request(:post, 'https://faq.library.princeton.edu/api/1.1/oauth/token')
+      .with(body: 'client_id=ABC&client_secret=12345&grant_type=client_credentials')
+      .to_return(status: 200, body: file_fixture('libanswers/oauth_token.json'))
+  end
+
+  describe '#new_token' do
+    it 'gets a new token from the OAuth server' do
+      service = described_class.new(endpoint: 'https://faq.library.princeton.edu/api/1.1/oauth/token',
+                                    service: :libanswers)
+      expect(service.new_token).to eq('abcdef1234567890abcdef1234567890abcdef12')
+    end
+  end
+
+  describe '#expiration_time' do
+    it 'gets an expiration time for the new token, then adds an hour of padding' do
+      travel_to Time.utc(2000, 1, 1, 0, 0, 0)
+      service = described_class.new(endpoint: 'https://faq.library.princeton.edu/api/1.1/oauth/token',
+                                    service: :libanswers)
+      expect(service.expiration_time).to eq(Time.utc(2000, 1, 7, 23, 0, 0))
+    end
+
+    it 'does not make an additional call if you already called #new_token' do
+      service = described_class.new(endpoint: 'https://faq.library.princeton.edu/api/1.1/oauth/token',
+                                    service: :libanswers)
+      service.new_token
+      service.expiration_time
+      expect(WebMock).to have_requested(:post, 'https://faq.library.princeton.edu/api/1.1/oauth/token').once
+    end
+  end
+end

--- a/spec/support/stub_helpers.rb
+++ b/spec/support/stub_helpers.rb
@@ -52,3 +52,10 @@ def stub_scsb_availability(bib_id:, institution_id:, barcode:, item_availability
     .with(headers: { Accept: 'application/json', api_key: 'TESTME' }, body: scsb_availability_params)
     .to_return(status: 200, body: scsb_response.to_json)
 end
+
+def stub_libanswers_api
+  stub_request(:post, 'https://faq.library.princeton.edu/api/1.1/oauth/token')
+    .with(body: 'client_id=ABC&client_secret=12345&grant_type=client_credentials')
+    .to_return(status: 200, body: file_fixture('libanswers/oauth_token.json'))
+  stub_request(:post, 'https://faq.library.princeton.edu/api/1.1/ticket/create')
+end

--- a/spec/views/feedback/feedback_spec.rb
+++ b/spec/views/feedback/feedback_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 describe 'Feedback Form', type: :feature do
   before do
+    stub_libanswers_api
     stub_holding_locations
     current_illiad_user_uri = "#{Requests::Config[:illiad_api_base]}/ILLiadWebPlatform/Users/jstudent"
     stub_request(:get, current_illiad_user_uri).to_return(status: 404, body: '{"Message":"User jstudent was not found."}')


### PR DESCRIPTION
Does most of the work of #3909 (there is a bit of cleanup to be done after this is merged and deployed to all environments)