### PR TITLE
[#3909] Remove unused code

### DIFF
--- a/app/mailers/contact_mailer.rb
+++ b/app/mailers/contact_mailer.rb
@@ -19,9 +19,4 @@ class ContactMailer < ApplicationMailer
     @form = params[:form]
     mail(to: @form.routed_mail_to, from: @form.from_email, subject: @form.email_subject)
   end
-
-  def feedback
-    @form = params[:form]
-    mail(to: @form.headers[:to], from: @form.headers[:from], subject: @form.headers[:subject])
-  end
 end

--- a/app/views/contact_mailer/feedback.html.erb
+++ b/app/views/contact_mailer/feedback.html.erb
@@ -1,8 +1,0 @@
-Name: <%= @form.name %><br>
-Email: <%= @form.email %><br>
-Comments: <%= @form.message %><br>
-<br>
-Request information<br>
-Remote ip: <%= @form.remote_ip %><br>
-User agent: <%= @form.user_agent %><br>
-Current url: <%= @form.current_url %>

--- a/config/orangelight.yml
+++ b/config/orangelight.yml
@@ -3,8 +3,6 @@ defaults: &defaults
     server: 'amqp://localhost:5672'
     exchange: 'orangelight_events'
   feedback_form:
-    to: <%= ENV['OL_FEEDBACK_TO'] %>
-    cc: <%= ENV['OL_FEEDBACK_CC'] %>
     queue_id: <%= ENV['CATALOG_FEEDBACK_QUEUE_ID'] %>
   ask_a_question_form:
     to: <%= ENV['OL_REFERENCE_TO'] %>
@@ -44,8 +42,6 @@ development:
 test:
   <<: *defaults
   feedback_form:
-    to: 'test@princeton.edu'
-    cc: 'test2w@princeton.edu, test3@princeton.edu'
     queue_id: 1234
   ask_a_question_form:
     to: 'test-question@princeton.edu'

--- a/spec/forms/feedback_form_spec.rb
+++ b/spec/forms/feedback_form_spec.rb
@@ -33,24 +33,6 @@ RSpec.describe FeedbackForm do
     end
   end
 
-  describe '#headers' do
-    it 'returns mail headers' do
-      expect(form.headers).to be_truthy
-    end
-
-    it 'pulls TO header from configuration' do
-      expect(form.headers[:to]).to eq 'test@princeton.edu'
-    end
-
-    it 'pulls CC header from configuration' do
-      expect(form.headers[:cc]).to eq 'test2w@princeton.edu, test3@princeton.edu'
-    end
-
-    it "Contains the submitter's email address" do
-      expect(form.headers[:from]).to eq('"Bob Smith" <bsmith@university.edu>')
-    end
-  end
-
   describe 'error_message' do
     it 'returns the configured error string' do
       expect(form.error_message).to eq(I18n.t('blacklight.feedback.error'))
@@ -77,14 +59,6 @@ RSpec.describe FeedbackForm do
       'pname=A Nice Tester&'\
       'pemail=test@test.org',
              headers: { Authorization: 'Bearer abcdef1234567890abcdef1234567890abcdef12' })
-    end
-  end
-
-  describe 'remote_ip' do
-    it 'gets the IP from the request, if available' do
-      form.request = instance_double(ActionDispatch::Request)
-      allow(form.request).to receive(:remote_ip).and_return('10.11.12.13')
-      expect(form.remote_ip).to eq('10.11.12.13')
     end
   end
 

--- a/spec/mailers/contact_mailer_spec.rb
+++ b/spec/mailers/contact_mailer_spec.rb
@@ -95,33 +95,4 @@ describe ContactMailer, type: :mailer do
       end
     end
   end
-
-  context 'with a feedback form' do
-    let(:valid_attributes) do
-      {
-        "name" => "Test",
-        "email" => "test@test.org",
-        "message" => "I think your site is great!"
-      }
-    end
-    let(:form) do
-      FeedbackForm.new(valid_attributes)
-    end
-    let(:mail) do
-      described_class.with(form:).feedback.deliver_now
-    end
-
-    it "renders the headers" do
-      mail
-      expect(mail.subject).to eq("Princeton University Library Catalog Feedback Form")
-      expect(mail.to).to eq(["test@princeton.edu"])
-      expect(mail.from).to eq(["test@test.org"])
-    end
-
-    it "renders the body" do
-      expect(mail.body.encoded).to have_content('Name: Test')
-      expect(mail.body.encoded).to have_content('Email: test@test.org')
-      expect(mail.body.encoded).to have_content('Comments: I think your site is great!')
-    end
-  end
 end


### PR DESCRIPTION
This code is no longer needed because:
  * We no longer email feedback form submissions, we use the libanswers API
  * We no longer record user IP addresses when they submit feedback

Helps with #3909 