### PR TITLE
[#4054] Add lighthouse to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,6 +131,33 @@ jobs:
         - store_test_results:
             path: ~/rspec
 
+  lighthouse:
+    executor: orangelight-executor
+    steps:
+      - attach_workspace:
+          at: '~/orangelight'
+      - setup-bundler-and-node
+      - run:
+          name: Wait for DB
+          command: dockerize -wait tcp://localhost:5432 -timeout 1m
+      - run: sudo apt install postgresql-client
+      - run:
+          name: Database setup
+          command: bundle exec rake db:setup
+      - run:
+          name: Load config into solr
+          command: |
+            cd solr/conf
+            zip -1 -r solr_config.zip ./*
+            curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://solr:SolrRocks@127.0.0.1:8983/solr/admin/configs?action=UPLOAD&name=orangelight"
+            curl -H 'Content-type: application/json' http://solr:SolrRocks@127.0.0.1:8983/api/collections/  -d '{create: {name: orangelight-core-test, config: orangelight, numShards: 1}}'
+      - run:
+          name: Index Test Data
+          command: bundle exec rake pulsearch:solr:index
+      - browser-tools/install-chrome
+      - run: sudo npm install -g @lhci/cli@0.14.x
+      - run: lhci autorun 
+
   rubocop:
     executor: basic-executor
     steps:
@@ -169,6 +196,9 @@ workflows:
          requires:
           - build
       - js_tests:
+         requires:
+          - build
+      - lighthouse:
          requires:
           - build
       - test:

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ solr/conf/lucene-umich-solr-filters-6.0.0-SNAPSHOT.jar
 
 orangelight-codeql
 codeql_results.csv
+
+.lighthouseci

--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ The browser will only display for system specs with `js: true`.
 * [erblint](https://github.com/Shopify/erb-lint)
 * `bundle exec erblint --lint-all`
 
+#### Run lighthouse from the command line
+
+```
+npm install -g @lhci/cli@0.14.x
+lhci autorun
+```
+
+It will tell you if you've passed the assertion(s) specified
+in `lighthouserc.js`.  It will also give you a URL where you
+can see the complete lighthouse results.
+
 #### Running CodeQL locally
 
 If you get a CodeQL warning on your branch, you may wish to run

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,0 +1,18 @@
+module.exports = {
+  ci: {
+    assert: {
+      assertions: {
+        'largest-contentful-paint': ['error', { maxNumericValue: 21000 }],
+      },
+    },
+    collect: {
+      url: [
+        'http://localhost:2999/catalog/99122304923506421', // A show page
+      ],
+      startServerCommand: 'bundle exec rails server -p 2999',
+    },
+    upload: {
+      target: 'temporary-public-storage',
+    },
+  },
+}


### PR DESCRIPTION
Includes an assertion that the Largest Contentful Paint is under 21 seconds, which is super high! This is partly because:
* we are not running in the production Rails environment (which would be better)
* partly because of lighthouse's throttling, which emulate a device with a slow CPU and a slow 4G connection
* partly because of performance problems in the catalog (which we actually want to measure)

I think it would be nice to gradually reduce the number of seconds in our assertion as we make performance improvements in the application.

Helps with #4054.