### PR TITLE
[#4054] Don't serve jquery v1.12.4 outside of requests

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,4 +23,5 @@
 //= require requests/requests
 //= require babel/polyfill
 //
-//= require_tree .
+//= require ./custom_range_limit.js
+//= require ./orangelight.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,6 @@
 // about supported directives.
 //
 //= require jquery3
-//= require jquery
 //= require jquery_ujs
 //= require popper
 //= require bootstrap

--- a/app/assets/javascripts/custom_range_limit.js
+++ b/app/assets/javascripts/custom_range_limit.js
@@ -3,12 +3,9 @@
 // it's supposed to customize the look
 // of the range limit plot
 
-//= require 'jquery'
-
-
 $('.blacklight-pub_date').data('plot-config', {
   selection: { color: '#C0FF83' },
   colors: ['#ffffff'],
-  series: { lines: { fillColor: 'rgba(255,255,255, 0.5)' }},
-  grid: { color: '#aaaaaa', tickColor: '#aaaaaa', borderWidth: 0 }
-});
+  series: { lines: { fillColor: 'rgba(255,255,255, 0.5)' } },
+  grid: { color: '#aaaaaa', tickColor: '#aaaaaa', borderWidth: 0 },
+})

--- a/app/assets/javascripts/orangelight.js
+++ b/app/assets/javascripts/orangelight.js
@@ -1,5 +1,3 @@
-//= require 'jquery'
-
 $(function () {
   //link highlighting of hierarchy
   $('.search-subject, .search-name-title, .search-title').hover(

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -2,7 +2,7 @@ module.exports = {
   ci: {
     assert: {
       assertions: {
-        'largest-contentful-paint': ['error', { maxNumericValue: 21000 }],
+        'largest-contentful-paint': ['error', { maxNumericValue: 20000 }],
       },
     },
     collect: {


### PR DESCRIPTION
Previously, we were asking clients to download two different versions of jquery, but they only need one.  They may need both for requests, due to the datatables dependency, that could use some further investigation.  This commit only removes the old jquery for non-requests pages.

Helps with #4054 