### PR TITLE
Remove modernizr

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,8 +51,6 @@ gem 'matrix'
 # For memory profiling
 # See https://github.com/MiniProfiler/rack-mini-profiler#memory-profiling for usage
 gem 'memory_profiler'
-# Modernizr.js library
-gem 'modernizr-rails'
 gem 'net-imap', require: false
 gem 'net-ldap'
 gem 'net-pop', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,7 +352,6 @@ GEM
     mini_portile2 (2.8.7)
     minitest (5.24.1)
     mize (0.5.0)
-    modernizr-rails (2.7.1)
     msgpack (1.7.2)
     multi_xml (0.6.0)
     net-imap (0.4.4)
@@ -709,7 +708,6 @@ DEPENDENCIES
   logstash-event
   matrix
   memory_profiler
-  modernizr-rails
   net-imap
   net-ldap
   net-pop

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,7 +15,6 @@
 //= require jquery_ujs
 //= require popper
 //= require bootstrap
-//= require modernizr
 //
 //= require bootstrap/tab
 //

--- a/app/assets/javascripts/requests/application.js
+++ b/app/assets/javascripts/requests/application.js
@@ -17,6 +17,5 @@
 //= require popper
 //= require bootstrap
 //= require datatables
-//= require modernizr
 
 //= require_tree .


### PR DESCRIPTION
We don't appear to be using any of its browser feature-detection features at the moment.

This reduces the unminified application.js by 30 KB.

Helps with #4054