### PR TITLE
Put back jquery in app/assets/javascripts/application.js and require_

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,6 +11,7 @@
 // about supported directives.
 //
 //= require jquery3
+//= require jquery
 //= require jquery_ujs
 //= require popper
 //= require bootstrap
@@ -23,5 +24,4 @@
 //= require requests/requests
 //= require babel/polyfill
 //
-//= require ./custom_range_limit.js
-//= require ./orangelight.js
+// = require_tree .

--- a/app/assets/javascripts/requests/application.js
+++ b/app/assets/javascripts/requests/application.js
@@ -12,7 +12,6 @@
 //
 //= require jquery
 //= require jquery3
-//= require jquery
 //= require jquery_ujs
 //= require popper
 //= require bootstrap


### PR DESCRIPTION
- Put back jquery in app/assets/javascripts/application.js and require_tree . to fix:  `TypeError: $(...).DataTable is not a function` 

- Remove duplicate jquery from requests/applications.js

In a previous [commit](https://github.com/pulibrary/orangelight/pull/4086/files#diff-0e145ba000e96b1a45d230275e350e4e8514efb4db7dbcfa228fe1003896c9b4L14-L27) require_tree was removed as an attempt not to load data-tables but datatables still loads in every page since the datatable.js code is bundled in the assets.  This will require back jquery in the app/assets/javascripts/application.js.