### PR TITLE
[#4054] Don't serve jquery v1.12.4 outside of requests (attempt #2)

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,6 @@
 // about supported directives.
 //
 //= require jquery3
-//= require jquery
 //= require jquery_ujs
 //= require popper
 //= require bootstrap
@@ -21,7 +20,7 @@
 // Required by Blacklight
 //= require blacklight/blacklight
 //= require 'blacklight_range_limit'
-//= require requests/requests
 //= require babel/polyfill
 //
-// = require_tree .
+//= require ./custom_range_limit.js
+//= require ./orangelight.js

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -2,7 +2,8 @@ module.exports = {
   ci: {
     assert: {
       assertions: {
-        'largest-contentful-paint': ['error', { maxNumericValue: 20080 }],
+        'largest-contentful-paint': ['error', { maxNumericValue: 20800 }],
+        'errors-in-console': ['error', { maxLength: 10 }],
       },
     },
     collect: {


### PR DESCRIPTION
Previously, we were asking clients to download two different versions of jquery, but they only need one.  They may need both for requests, due to the datatables dependency, that could use some further investigation.  This commit only removes the old jquery for non-requests pages.

This also removes the requests js from non-requests pages, which avoids the issue reported in #4098.  I've confirmed that the requests form still has pagination and enumeration search.

Also, add a lighthouse check that we haven't added any new console warnings to the show page.

Helps with #4054 