### PR TITLE
Remove unnecessary holding_request_block calls from views

### DIFF
--- a/app/views/catalog/_show_other_versions.html.erb
+++ b/app/views/catalog/_show_other_versions.html.erb
@@ -1,4 +1,3 @@
-<% online, physical = holding_request_block(document) %>
 <% document_linked_records = document.linked_records(field: 'other_version_s', query_field: 'other_version_s').decorated %>
 <% unless document_linked_records.empty? %>
   <div class="location--panel location--linked availability--other-versions">

--- a/app/views/catalog/_show_restrictions.html.erb
+++ b/app/views/catalog/_show_restrictions.html.erb
@@ -1,4 +1,3 @@
-<% online, physical = holding_request_block(document) %>
 <% unless holding_requests_adapter.restrictions.empty? %>
   <div class="restrictions--panel alert alert-warning">
     <%= PhysicalHoldingsMarkupBuilder.restrictions_markup(holding_requests_adapter.restrictions) %>


### PR DESCRIPTION
Two views call `holding_request_block`, then don't actually use the returned values for anything.  `_show_other_versions` is the slowest partial in the show page, according to the datadog APM, so this is a low-hanging fruit to make it faster.

Helps with #4054