### PR TITLE
[#4054] Only ship the bootstrap js that we actually use

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,9 +13,13 @@
 //= require jquery3
 //= require jquery_ujs
 //= require popper
-//= require bootstrap
 //
-//= require bootstrap/tab
+//= require bootstrap/util
+//= require bootstrap/alert
+//= require bootstrap/button
+//= require bootstrap/collapse
+//= require bootstrap/dropdown
+//= require bootstrap/modal
 //
 // Required by Blacklight
 //= require blacklight/blacklight

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -2,7 +2,7 @@ module.exports = {
   ci: {
     assert: {
       assertions: {
-        'largest-contentful-paint': ['error', { maxNumericValue: 20800 }],
+        'largest-contentful-paint': ['error', { maxNumericValue: 19000 }],
         'errors-in-console': ['error', { maxLength: 10 }],
       },
     },


### PR DESCRIPTION
Helps with #4054.

This reduces the unminified, uncompressed application.js from 883 kB to 811 kB.

Lighthouse says that the application.js file takes 739 ms to execute in production (when emulating a slow phone CPU). This should reduce it a little.

