### PR TITLE
Container footer

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -43,6 +43,7 @@
 @import 'components/font-face';
 @import 'components/front-page';
 @import 'components/header';
+@import 'components/footer';
 @import 'components/header--secondary';
 @import 'components/lists';
 @import 'components/nav--accounts';

--- a/app/assets/stylesheets/components/footer.scss
+++ b/app/assets/stylesheets/components/footer.scss
@@ -1,0 +1,3 @@
+.pul_footer {
+  background: $black-pul;
+}

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,3 +1,7 @@
-<footer class="lux">
-  <lux-library-footer></lux-library-footer>
-</footer>
+<div class="pul_footer">
+  <div class="container">
+    <footer class="lux">
+      <lux-library-footer></lux-library-footer>
+    </footer>
+  </div>
+</div>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@vitejs/plugin-vue": "^5.1.2",
     "graphql": "^16.8.1",
     "jest-environment-jsdom": "^29.4.0",
-    "lux-design-system": "^5.3.3",
+    "lux-design-system": "^5.4.0",
     "serialize-javascript": "^5.0.1",
     "unfetch": "^3.1.1",
     "vue": "^3.4.21"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3669,10 +3669,10 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lux-design-system@^5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.3.3.tgz#d57cdca1b830dcc4f1419263e9afe24dad7d9393"
-  integrity sha512-TVMP+aQNMd0MrufgqRCKVg+EXLdBQVPWFfMbZ2asLod63O93fWWYjMlRWlAq1UyUw6RRUpyLksPbYei6SeTi3g==
+lux-design-system@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.4.0.tgz#3d5f0b80acbe794910cfa6fcd6d1f76aa18151b9"
+  integrity sha512-deTGAAJF5Kqu9nM4kLi4GfxWhs7LUqyCWDqhfX7AWqYXM4u2jtiPf+hg8ELGfz6i6+so02UtpEe32a2P3uFXcw==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"


### PR DESCRIPTION
Wrap the footer in a container to give the Bootstrap maximum width. (We are using bootstrap to set the maximum width for the header and the main content)
Also create a new pul_footer class to give the black background.

Use the latest lux-release 5.4.0
See release notes: https://github.com/pulibrary/lux-design-system/releases

Because of the different max-width between Bootstrap and Lux there will be a difference on the length  of the subscribe-newsletter button between the rails apps and the all-search.
