### PR TITLE
Match black colors in the footer

### DIFF
--- a/app/assets/stylesheets/components/footer.scss
+++ b/app/assets/stylesheets/components/footer.scss
@@ -1,3 +1,3 @@
 .pul_footer {
-  background: $black-pul;
+  background: var(--color-gray-100);
 }


### PR DESCRIPTION
Prior to this commit, the lux footer had a background color of #121212, while the surrounding container had a background color of #040404, which clashed a little bit.  This commit uses #121212 for both blocks.

Before:
![The catalog footer, with two different shades of black in the background](https://github.com/user-attachments/assets/7ada6982-d453-496a-887e-4a64ea324387)


After:
![The catalog footer, but with only one shade of black in the background](https://github.com/user-attachments/assets/72b14313-3f44-4f4f-beda-032c128fa0df)
