### PR TITLE
Use prettier for the spec directory

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,5 @@
 node_modules
 .gitignore
-spec
 tmp
 vendor
 public

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,4 @@
-semi: false
+semi: true
 singleQuote: true
 printWidth: 80
 trailingComma: 'es5'


### PR DESCRIPTION
This helps us maintain consistent formatting for javascript tests and JSON fixtures

Also, configure prettier to require semicolons

Part of #4088 -- I'm trying to break a large PR into some smaller changes