### PR TITLE
[OrangelightHeader]Add LuxHeader in a container to get the Bootstrap width.

### DIFF
--- a/app/javascript/orangelight/vue_components/orangelight_header.vue
+++ b/app/javascript/orangelight/vue_components/orangelight_header.vue
@@ -1,7 +1,11 @@
 <template>
-<lux-library-header app-name="Catalog" abbr-name="Catalog" app-url="/" theme="dark">
-  <lux-menu-bar type="main-menu" :menu-items="menuItems" @menu-item-clicked="handleMenuItemClicked"></lux-menu-bar>
-</lux-library-header>
+  <div class="pul_header">
+    <div class="container">
+      <lux-library-header app-name="Catalog" abbr-name="Catalog" app-url="/" theme="dark">
+        <lux-menu-bar type="main-menu" :menu-items="menuItems" @menu-item-clicked="handleMenuItemClicked"></lux-menu-bar>
+      </lux-library-header>
+    </div>
+  </div>
 </template>
 
 <script setup>
@@ -61,3 +65,8 @@ function handleMenuItemClicked(event) {
   }
 }
 </script>
+<style>
+  .pul_header {
+    background-color: var(--color-gray-100);
+  }
+</style>


### PR DESCRIPTION
[OrangelightHeader]Add header in a container to get the Bootstrap width.
[OrangelightHeader]Add container in a parent class with background-color var(--color-gray-100)

# Notes
Lux is using a different max-width to match with the max-width of the new Library Website. 
Bootstrap's container width is smaller. 
We move the header the same way we moved the footer in a container so that they are aligned with the main content of the app which is part of a different container.

## Lux Header not in a  container
![Lux Header not in a  container](https://github.com/user-attachments/assets/163261c1-a144-4af5-a5a3-1d5d5e55bd73)

## Lux Header in a container:
![Lux Header in a container](https://github.com/user-attachments/assets/8675a70b-40dd-4141-b0a1-2ebad6d597ea)

