### PR TITLE
[#4123] Avoid layout shift and quickly changing colors in the header

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -43,6 +43,7 @@
 @import 'components/font-face';
 @import 'components/front-page';
 @import 'components/footer';
+@import 'components/header';
 @import 'components/header--secondary';
 @import 'components/lists';
 @import 'components/nav--accounts';

--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -1,0 +1,8 @@
+/* The container that the lux header will be in.
+   It is the same background color and height as
+   the lux header, so that when the lux header loads,
+   there is no layout shift or sudden color change. */
+.pul_header {
+    background-color: var(--color-gray-100);
+    height: calc(2rem + 54px);
+}

--- a/app/javascript/orangelight/vue_components/orangelight_header.vue
+++ b/app/javascript/orangelight/vue_components/orangelight_header.vue
@@ -1,10 +1,8 @@
 <template>
-  <div class="pul_header">
-    <div class="container">
-      <lux-library-header app-name="Catalog" abbr-name="Catalog" app-url="/" theme="dark">
-        <lux-menu-bar type="main-menu" :menu-items="menuItems" @menu-item-clicked="handleMenuItemClicked"></lux-menu-bar>
-      </lux-library-header>
-    </div>
+  <div class="container">
+    <lux-library-header app-name="Catalog" abbr-name="Catalog" app-url="/" theme="dark">
+      <lux-menu-bar type="main-menu" :menu-items="menuItems" @menu-item-clicked="handleMenuItemClicked"></lux-menu-bar>
+    </lux-library-header>
   </div>
 </template>
 
@@ -65,8 +63,3 @@ function handleMenuItemClicked(event) {
   }
 }
 </script>
-<style>
-  .pul_header {
-    background-color: var(--color-gray-100);
-  }
-</style>

--- a/app/views/shared/_header_navbar.html.erb
+++ b/app/views/shared/_header_navbar.html.erb
@@ -1,13 +1,15 @@
 <%= render partial: "shared/announcement" %>
 <header class="lux">
-  <% if current_user.present? %>
-    <orangelight-header bookmarks="<%= current_or_guest_user.bookmarks.count %>"
-                        :logged-in="true"
-                        net-id="<%= current_user.to_s %>">
-    </orangelight-header>
-  <% else %>
-    <orangelight-header bookmarks="<%= current_or_guest_user.bookmarks.count %>" :logged-in="false"></orangelight-header>
-  <% end %>
+  <div class="pul_header">
+    <% if current_user.present? %>
+      <orangelight-header bookmarks="<%= current_or_guest_user.bookmarks.count %>"
+                          :logged-in="true"
+                          net-id="<%= current_user.to_s %>">
+      </orangelight-header>
+    <% else %>
+      <orangelight-header bookmarks="<%= current_or_guest_user.bookmarks.count %>" :logged-in="false"></orangelight-header>
+    <% end %>
+  </div>
 
   <%# Display the basic search bar on most (but not all) interfaces.
     # Note: if you remove the search bar from a particular

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -2,12 +2,14 @@ module.exports = {
   ci: {
     assert: {
       assertions: {
+        'cumulative-layout-shift': ['error', { maxNumericValue: 0.73 }],
         'largest-contentful-paint': ['error', { maxNumericValue: 19000 }],
         'errors-in-console': ['error', { maxLength: 10 }],
       },
     },
     collect: {
       url: [
+        'http://localhost:2999', // The catalog home page
         'http://localhost:2999/catalog/99122304923506421', // A show page
       ],
       startServerCommand: 'bundle exec rails server -p 2999',
@@ -16,4 +18,4 @@ module.exports = {
       target: 'temporary-public-storage',
     },
   },
-}
+};


### PR DESCRIPTION
This commit moves the .pul_header container out of the Vue component (which is rendered after the rest of the page), and into erb and the application CSS, which will block rendering.  It also gives the container an explicit height.

This prevents the situation where the page renders with light colored content at first, then changes to very dark gray and shifts the layout once the Vue component loads, which looks like a distracting flash.

Also, add a threshold for layout shift to our lighthouse check, to hopefully guard against regressions.

closes #4123 