### PR TITLE
Remove stringex. serves 5.8MiB of memory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,6 @@ gem 'sneakers'
 gem 'sprockets-es6'
 # For call-stack profiling flamegraphs
 gem 'stackprof'
-gem 'stringex', git: 'https://github.com/pulibrary/stringex.git', tag: 'vpton.2.5.2.2'
 gem 'string_rtl'
 gem 'terser'
 gem 'view_component', '< 3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,13 +7,6 @@ GIT
       blacklight (~> 7.0)
       rails
 
-GIT
-  remote: https://github.com/pulibrary/stringex.git
-  revision: 357f70511532a35b11a240e5ae06d02725cb8d0a
-  tag: vpton.2.5.2.2
-  specs:
-    stringex (2.5.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -733,7 +726,6 @@ DEPENDENCIES
   sprockets-es6
   stackprof
   string_rtl
-  stringex!
   terser
   timecop
   vcr


### PR DESCRIPTION
Saves 5.8 MiB of memory when app starts
checked it with derialed_benchmark gem and `bundle exec derailed bundle:mem`