### PR TITLE
[#4156] Fix second page of blank search results

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -126,7 +126,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   private
 
     def search_query_present?
-      blacklight_params[:q].present? || json_query_dsl_clauses&.any? { |clause| clause.dig('query')&.present? }
+      !blacklight_params[:q].nil? || json_query_dsl_clauses&.any? { |clause| clause.dig('query')&.present? }
     end
 
     def facet_query_present?

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe SearchBuilder do
       expect(search_builder.excessive_paging?).to be false
     end
 
+    it 'returns false if the search is empty' do
+      search_builder.blacklight_params[:page] = reasonable
+      search_builder.blacklight_params[:q] = ''
+      expect(search_builder.excessive_paging?).to be false
+    end
+
     it 'does not allow paging without a search or facet' do
       search_builder.blacklight_params[:page] = reasonable
       expect(search_builder.excessive_paging?).to be true


### PR DESCRIPTION
This addresses a regression caused by PR #4151.

closes #4156 