### PR TITLE
Add COinS (for Zotero integration) to show page for SCSB records

### DIFF
--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -7,15 +7,7 @@
   </div>
 </div>
 
-<% if @document.alma_record? %>
-  <!--
-       // COinS, for Zotero among others.
-       // This document_partial_name(@document) business is not quite right,
-       // but has been there for a while.
-       // If we add non-MARC doc types to the project they need to respond to this
-       // method with a valid ctx (context) object.
-  -->
-  <span class="Z3988" aria-hidden='true' title="<%= @document.export_as_openurl_ctx_kev %>"></span>
-<% end %>
+<!-- COinS, for Zotero among others. -->
+<span class="Z3988" aria-hidden='true' title="<%= @document.export_as_openurl_ctx_kev %>"></span>
 
 <%= render 'show_coin_description', document: @document if @document.numismatics_record? %>

--- a/spec/features/zotero_support_spec.rb
+++ b/spec/features/zotero_support_spec.rb
@@ -17,6 +17,11 @@ describe 'Zotero Support via Context Objects' do
     expect(page.all('.Z3988').length).to eq 1
   end
 
+  it 'is available on an individual SCSB record page' do
+    visit '/catalog/SCSB-2143785'
+    expect(page.all('.Z3988').length).to eq 1
+  end
+
   it 'Has a context object referencing the bib ID' do
     visit '/catalog/9990315453506421'
     expect(page.find('span.Z3988')[:title]).to have_text('9990315453506421')


### PR DESCRIPTION
Previously, we only had them for Alma records.