### PR TITLE
[#3387] Make ConstraintsComponent compatible with Blacklight 8 (or 7)

### DIFF
--- a/app/components/orangelight/constraints_component.html.erb
+++ b/app/components/orangelight/constraints_component.html.erb
@@ -4,11 +4,11 @@
   <% end %>
 
   <div class="button--start-over">
-    <%= render_start_over_link(start_over_path) %>
+    <%= helpers.render_start_over_link(root_path) %>
   </div>
   <div class="button--edit-search">
     <%=link_to t('blacklight.search.edit_search'),
-               edit_search_link,
+               helpers.edit_search_link,
                class: "catalog_editSearchLink btn btn-outline-secondary",
                id: "editSearchLink" %>
   </div>


### PR DESCRIPTION
* `start_over_path` is deprecated, and in our application, it always points to the application root.  This commit replaces it with root_path.
* `render_start_over_link` and `edit_search_link` are Orangelight helpers.  Some kind of Blacklight 7 magic causes them to be displayed without using the [`helpers` proxy](https://viewcomponent.org/guide/helpers.html#proxy).  However, in Blacklight 8, that magic is gone.  So we can use the `helpers` proxy to access them now.

Helps with #3387