### PR TITLE
[#3387] Use if: false to hide fields from the search results screen

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -233,19 +233,19 @@ class CatalogController < ApplicationController
     config.add_index_field 'author_display', label: 'Author/Artist', browse_link: :name, presenter: Orangelight::HighlightPresenter
     config.add_index_field 'pub_created_display', label: 'Published/Created'
     config.add_index_field 'format', label: 'Format', helper_method: :format_icon
-    config.add_index_field 'holdings_1display', show: false
-    config.add_index_field 'contained_in_s', show: false
-    config.add_index_field 'isbn_t', show: false
-    config.add_index_field 'score', show: false
-    config.add_index_field 'marc_relator_display', show: false
-    config.add_index_field 'title_display', show: false, presenter: Orangelight::HighlightPresenter
-    config.add_index_field 'title_vern_display', show: false, presenter: Orangelight::HighlightPresenter
-    config.add_index_field 'isbn_s', show: false
-    config.add_index_field 'oclc_s', show: false
-    config.add_index_field 'lccn_s', show: false
-    config.add_index_field 'electronic_access_1display', show: false
-    config.add_index_field 'cataloged_tdt', show: false
-    config.add_index_field 'electronic_portfolio_s', show: false
+    config.add_index_field 'holdings_1display', if: false
+    config.add_index_field 'contained_in_s', if: false
+    config.add_index_field 'isbn_t', if: false
+    config.add_index_field 'score', if: false
+    config.add_index_field 'marc_relator_display', if: false
+    config.add_index_field 'title_display', if: false, presenter: Orangelight::HighlightPresenter
+    config.add_index_field 'title_vern_display', if: false, presenter: Orangelight::HighlightPresenter
+    config.add_index_field 'isbn_s', if: false
+    config.add_index_field 'oclc_s', if: false
+    config.add_index_field 'lccn_s', if: false
+    config.add_index_field 'electronic_access_1display', if: false
+    config.add_index_field 'cataloged_tdt', if: false
+    config.add_index_field 'electronic_portfolio_s', if: false
     config.add_index_field 'lc_subject_display', label: 'Subjects', browse_link: :name, presenter: Orangelight::HighlightPresenter
     config.add_index_field 'siku_subject_display', if: false, presenter: Orangelight::HighlightPresenter
     config.add_index_field 'homoit_subject_display', if: false, presenter: Orangelight::HighlightPresenter

--- a/spec/requests/request_spec.rb
+++ b/spec/requests/request_spec.rb
@@ -537,15 +537,6 @@ describe 'blacklight tests' do
     end
   end
 
-  describe "bento search JSON API requirements" do
-    it "returns electronic_portfolio_s" do
-      get "/catalog.json?q=99122306151806421"
-      json = JSON.parse(response.body)
-
-      expect(json["data"][0]["attributes"]["electronic_portfolio_s"]).not_to be_blank
-    end
-  end
-
   describe 'search algorithm selection' do
     before do
       allow(Flipflop).to receive(:multi_algorithm?).and_return(true)


### PR DESCRIPTION
Blacklight 8 seems to no longer support show: false for index fields.
Fortunately, we can use if: false to achieve the same effect.

helps with #3387 