### PR TITLE
Address fixture_path deprecation

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,7 +23,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = Rails.root.join('spec', 'fixtures')
+  config.fixture_paths = [Rails.root.join('spec', 'fixtures')]
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
 

--- a/spec/requests/request_spec.rb
+++ b/spec/requests/request_spec.rb
@@ -308,7 +308,7 @@ describe 'blacklight tests' do
       id = '9965749873506421'
       stub_request(:get, "#{Requests.config['bibdata_base']}/bibliographic/#{id}")
         .to_return(status: 200,
-                   body: File.read(File.join(fixture_path, 'bibdata', "#{id}.xml")))
+                   body: File.read(File.join(fixture_paths.first, 'bibdata', "#{id}.xml")))
       get "/catalog/#{id}.marcxml"
       staff_view = response.body
       bibdata = Faraday.get("#{Requests.config['bibdata_base']}/bibliographic/#{id}").body

--- a/spec/support/stub_helpers.rb
+++ b/spec/support/stub_helpers.rb
@@ -2,7 +2,7 @@
 def stub_delivery_locations
   stub_request(:get, "#{Requests::Config[:bibdata_base]}/locations/delivery_locations.json")
     .to_return(status: 200,
-               body: File.read(File.join(fixture_path, 'bibdata', 'delivery_locations.json')),
+               body: File.read(File.join(fixture_paths.first, 'bibdata', 'delivery_locations.json')),
                headers: {})
 end
 

--- a/spec/support/webmock_stubs.rb
+++ b/spec/support/webmock_stubs.rb
@@ -3,17 +3,17 @@
 def stub_holding_locations
   stub_request(:get, "#{Requests.config['bibdata_base']}/locations/holding_locations.json")
     .to_return(status: 200,
-               body: File.read(File.join(fixture_path, 'bibdata', 'holding_locations.json')))
+               body: File.read(File.join(fixture_paths.first, 'bibdata', 'holding_locations.json')))
 end
 
 def stub_alma_holding_locations
   stub_request(:get, "#{Requests.config['bibdata_base']}/locations/holding_locations.json")
     .to_return(status: 200,
-               body: File.read(File.join(fixture_path, 'bibdata', 'alma', 'holding_locations.json')))
+               body: File.read(File.join(fixture_paths.first, 'bibdata', 'alma', 'holding_locations.json')))
 end
 
 def stub_single_holding_location(location_code)
-  file_path = File.join(fixture_path, 'holding_locations', "#{location_code.tr('$', '_')}.json")
+  file_path = File.join(fixture_paths.first, 'holding_locations', "#{location_code.tr('$', '_')}.json")
   stub_request(:get, "#{Requests.config['bibdata_base']}/locations/holding_locations/#{location_code}.json")
     .to_return(status: 200, body: File.read(file_path))
 end
@@ -29,7 +29,7 @@ def stub_availability_by_holding_id(bib_id:, holding_id:, body: true)
     stub_request(:get, url)
       .to_return(status: 200)
   else
-    file_path = File.join(fixture_path, 'availability', 'by_holding_id', "#{bib_id}_#{holding_id}.json")
+    file_path = File.join(fixture_paths.first, 'availability', 'by_holding_id', "#{bib_id}_#{holding_id}.json")
     stub_request(:get, url)
       .to_return(status: 200, body: File.read(file_path))
   end
@@ -39,9 +39,9 @@ def stub_catalog_raw(bib_id:, type: nil, body: true)
   url = "#{Requests::Config[:pulsearch_base]}/catalog/#{bib_id}/raw"
   return stub_request(:get, url).to_return(status: 200, body: {}.to_json) if body == false
   file_path = if type
-                File.join(fixture_path, 'raw', type, "#{bib_id}.json")
+                File.join(fixture_paths.first, 'raw', type, "#{bib_id}.json")
               else
-                File.join(fixture_path, 'raw', "#{bib_id}.json")
+                File.join(fixture_paths.first, 'raw', "#{bib_id}.json")
               end
   stub_request(:get, url)
     .to_return(status: 200, body: File.read(file_path))

--- a/spec/system/catalog_show_spec.rb
+++ b/spec/system/catalog_show_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 describe 'Viewing Catalog Documents', type: :system, js: true do
-  let(:availability_fixture_path) { File.join(fixture_path, 'bibdata', 'availability.json') }
+  let(:availability_fixture_path) { File.join(fixture_paths.first, 'bibdata', 'availability.json') }
   let(:availability_fixture) { File.read(availability_fixture_path) }
 
   before do


### PR DESCRIPTION
Addresses the following deprecation, which is filling up the terminal output when running tests:

```
DEPRECATION WARNING: TestFixtures#fixture_path is deprecated and will be removed in Rails 7.2. Use #fixture_paths instead.
```