### PR TITLE
[#3387] Refactor "show" option for index fields

### DIFF
--- a/app/components/index_metadata_component.html.erb
+++ b/app/components/index_metadata_component.html.erb
@@ -1,4 +1,4 @@
-<% @presenter.field_presenters.reject { |field| field.field_config.show == false }.each do |field_presenter| -%>
+<% @presenter.field_presenters.each do |field_presenter| -%>
   <li>
     <% if field_presenter.component %>
       <%= render field_presenter.component.new field: field_presenter, layout: IndexMetadataFieldLayoutComponent %>

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -233,19 +233,19 @@ class CatalogController < ApplicationController
     config.add_index_field 'author_display', label: 'Author/Artist', browse_link: :name, presenter: Orangelight::HighlightPresenter
     config.add_index_field 'pub_created_display', label: 'Published/Created'
     config.add_index_field 'format', label: 'Format', helper_method: :format_icon
-    config.add_index_field 'holdings_1display', show: false
-    config.add_index_field 'contained_in_s', show: false
-    config.add_index_field 'isbn_t', show: false
-    config.add_index_field 'score', show: false
-    config.add_index_field 'marc_relator_display', show: false
-    config.add_index_field 'title_display', show: false, presenter: Orangelight::HighlightPresenter
-    config.add_index_field 'title_vern_display', show: false, presenter: Orangelight::HighlightPresenter
-    config.add_index_field 'isbn_s', show: false
-    config.add_index_field 'oclc_s', show: false
-    config.add_index_field 'lccn_s', show: false
-    config.add_index_field 'electronic_access_1display', show: false
-    config.add_index_field 'cataloged_tdt', show: false
-    config.add_index_field 'electronic_portfolio_s', show: false
+    config.add_index_field 'holdings_1display', if: :json_request?
+    config.add_index_field 'contained_in_s', if: :json_request?
+    config.add_index_field 'isbn_t', if: :json_request?
+    config.add_index_field 'score', if: :json_request?
+    config.add_index_field 'marc_relator_display', if: :json_request?
+    config.add_index_field 'title_display', if: :json_request?, presenter: Orangelight::HighlightPresenter
+    config.add_index_field 'title_vern_display', if: :json_request?, presenter: Orangelight::HighlightPresenter
+    config.add_index_field 'isbn_s', if: :json_request?
+    config.add_index_field 'oclc_s', if: :json_request?
+    config.add_index_field 'lccn_s', if: :json_request?
+    config.add_index_field 'electronic_access_1display', if: :json_request?
+    config.add_index_field 'cataloged_tdt', if: :json_request?
+    config.add_index_field 'electronic_portfolio_s', if: :json_request?
     config.add_index_field 'lc_subject_display', label: 'Subjects', browse_link: :name, presenter: Orangelight::HighlightPresenter
     config.add_index_field 'siku_subject_display', if: false, presenter: Orangelight::HighlightPresenter
     config.add_index_field 'homoit_subject_display', if: false, presenter: Orangelight::HighlightPresenter
@@ -755,6 +755,10 @@ class CatalogController < ApplicationController
   def biased_results_submit; end
 
   private
+
+    def json_request?
+      request.format.json?
+    end
 
     def render_empty_search
       # This code is a copy of Blacklight::Catalog.index() method but adapted to use

--- a/spec/components/index_metadata_component_spec.rb
+++ b/spec/components/index_metadata_component_spec.rb
@@ -13,14 +13,12 @@ RSpec.describe IndexMetadataComponent, type: :component do
     Blacklight::Configuration.new.configure do |config|
       config.add_index_field 'my_first_field'
       config.add_index_field 'my_second_field', show: true
-      config.add_index_field 'do_not_show_this_field', show: false
     end
   end
   let(:component) do
     document = SolrDocument.new({
                                   'my_first_field': 'Hello',
-                                  'my_second_field': ['Goodbye', 'Auf Wiedersehen'],
-                                  'do_not_show_this_field': 'Behind the scenes'
+                                  'my_second_field': ['Goodbye', 'Auf Wiedersehen']
                                 })
     view_context = double(document_index_view_type: 'index')
     allow(view_context).to receive(:should_render_field?).and_return true


### PR DESCRIPTION
Prior to this commit, we had a custom configuration option for index fields called `show`.  When `show` is true, the field displays in both the HTML and JSON search results.  When it is false, the field only displays in the JSON search results.

Previously, we implemented this behavior in `_index_default.html.erb`. This was later slightly refactored into a view component that was called by `_index_default.html.erb`.  However, `_index_default.html.erb` is no longer used in Blacklight 8, so our logic gets ignored in Blacklight 8.

This commit moves the behavior to the catalog controller, using a new private method named `json_request?`.

Helps with #3387