### PR TITLE
Left anchor search

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -10,7 +10,7 @@ class SearchBuilder < Blacklight::SearchBuilder
 
   self.default_processor_chain += %i[parslet_trick cleanup_boolean_operators add_advanced_search_to_solr
                                      cjk_mm wildcard_char_strip excessive_paging_error
-                                     only_home_facets left_anchor_escape_whitespace
+                                     only_home_facets prepare_left_anchor_search
                                      series_title_results pul_holdings html_facets
                                      numismatics_facets numismatics_advanced]
 

--- a/app/views/advanced/_guided_search_fields.html.erb
+++ b/app/views/advanced/_guided_search_fields.html.erb
@@ -9,9 +9,9 @@
     </div>
   </div>
   <div class="search-operators" role="radiogroup" aria-label="Search operators">
-    <label><%= radio_button_tag("op2", "AND", guided_radio(:op2, "AND")) %> AND</label>
-    <label><%= radio_button_tag("op2", "OR", guided_radio(:op2, "OR")) %> OR</label>
-    <label><%= radio_button_tag("op2", "NOT", guided_radio(:op2, "NOT")) %> NOT</label>
+    <label><%= radio_button_tag("op2", "AND", guided_radio(:op2, "AND"), class: 'first-and') %> AND</label>
+    <label><%= radio_button_tag("op2", "OR", guided_radio(:op2, "OR"), class: 'first-or') %> OR</label>
+    <label><%= radio_button_tag("op2", "NOT", guided_radio(:op2, "NOT"), class: 'first-not') %> NOT</label>
   </div>
   <div class="search-field">
     <label for="f2" class="sr-only">Options for advanced search - second parameter</label>
@@ -22,9 +22,9 @@
     </div>
   </div>
   <div class="search-operators" role="radiogroup" aria-label="Search operators">
-    <label><%= radio_button_tag("op3", "AND", guided_radio(:op3, "AND")) %> AND</label>
-    <label><%= radio_button_tag("op3", "OR", guided_radio(:op3, "OR")) %> OR</label>
-    <label><%= radio_button_tag("op3", "NOT", guided_radio(:op3, "NOT")) %> NOT</label>
+    <label><%= radio_button_tag("op3", "AND", guided_radio(:op3, "AND"), class: 'second-and') %> AND</label>
+    <label><%= radio_button_tag("op3", "OR", guided_radio(:op3, "OR"), class: 'second-or') %> OR</label>
+    <label><%= radio_button_tag("op3", "NOT", guided_radio(:op3, "NOT"), class: 'second-not') %> NOT</label>
   </div>
   <div class="search-field">
     <label for="f3" class="sr-only">Options for advanced search - third parameter</label>

--- a/app/views/advanced/_guided_search_fields_bl_8.html.erb
+++ b/app/views/advanced/_guided_search_fields_bl_8.html.erb
@@ -21,9 +21,9 @@
     </div>
   </div>
   <div class="search-operators" role="radiogroup" aria-label="Search operators">
-    <label><%= radio_button_tag("clause[1][op]", "must", guided_radio(:clause_1_op, "AND")) %> AND</label>
-    <label><%= radio_button_tag("clause[1][op]", "should", guided_radio(:clause_1_op, "OR")) %> OR</label>
-    <label><%= radio_button_tag("clause[1][op]", "must_not", guided_radio(:clause_1_op, "NOT")) %> NOT</label>
+    <label><%= radio_button_tag("clause[1][op]", "must", guided_radio(:clause_1_op, "AND"), class: 'first-and') %> AND</label>
+    <label><%= radio_button_tag("clause[1][op]", "should", guided_radio(:clause_1_op, "OR"), class: 'first-or') %> OR</label>
+    <label><%= radio_button_tag("clause[1][op]", "must_not", guided_radio(:clause_1_op, "NOT"), class: 'first-not') %> NOT</label>
   </div>
   <div class="search-field">
     <label for="clause_1_field" class="sr-only">Options for advanced search - second parameter</label>

--- a/spec/components/orangelight/advanced_search_form_component_spec.rb
+++ b/spec/components/orangelight/advanced_search_form_component_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Orangelight::AdvancedSearchFormComponent, type: :component, advan
     allow(view_context).to receive(:facet_limit_for).and_return(nil)
   end
 
-  it "has a dropdown with the expected options" do
+  it "has a dropdown with the expected options", left_anchor: true do
     expected_options = [
       "Keyword", "Title", "Author/Creator", "Subject", "Title starts with",
       "Publisher", "Notes", "Series title", "ISBN", "ISSN"

--- a/spec/features/search_input_facets_spec.rb
+++ b/spec/features/search_input_facets_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-context 'clicking facet limits with values in the search bar' do
+context 'clicking facet limits with values in the search bar', left_anchor: true do
   before do
     stub_holding_locations
   end

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -55,6 +55,21 @@ describe BlacklightHelper do
         expect(query.dig('json', 'query', 'bool', 'must', 1, :edismax, :query)).to eq("searching\\ for*")
         expect(query.dig('json', 'query', 'bool', 'must', 2, :edismax, :query)).to eq("searching\\ for*")
       end
+      it 'escapes all left_anchor terms' do
+        query = { "qt" => nil, "json" => { "query" => { "bool" => { "must" => [
+          { edismax:
+            {
+              query: "lord of the rings"
+            } },
+          { edismax:
+            {
+              qf: "${left_anchor_qf}",
+              pf: "${left_anchor_pf}",
+              query: "lord"
+            } }
+        ] } } } }
+        expect(left_anchor_search?(query)).to be true
+      end
     end
   end
 

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -13,16 +13,48 @@ describe BlacklightHelper do
     end
   end
 
-  describe '#left_anchor_escape_whitespace' do
+  describe '#prepare_left_anchor_search', left_anchor: true do
     it 'escapes white spaces before sending :q to solr along with wildcard character' do
       query = { qf: '${left_anchor_qf}', pf: '${left_anchor_pf}', q: 'searching for a test value' }
-      left_anchor_escape_whitespace(query)
+      prepare_left_anchor_search(query)
       expect(query[:q]).to eq 'searching\ for\ a\ test\ value*'
     end
     it 'only a single wildcard character is included when user supplies the wildcard in query' do
       query = { qf: '${left_anchor_qf}', pf: '${left_anchor_pf}', q: 'searching for a test value*' }
-      left_anchor_escape_whitespace(query)
+      prepare_left_anchor_search(query)
       expect(query[:q]).to eq 'searching\ for\ a\ test\ value*'
+    end
+    context 'with a complex boolean advanced search' do
+      before do
+        allow(Flipflop).to receive(:json_query_dsl?).and_return(true)
+        allow(Flipflop).to receive(:view_components_advanced_search?).and_return(true)
+      end
+      it 'escapes all left_anchor terms' do
+        query = { "qt" => nil, "json" => { "query" => { "bool" => { "must" => [
+          { edismax:
+            {
+              qf: "${left_anchor_qf}",
+              pf: "${left_anchor_pf}",
+              query: "searching for"
+            } },
+          { edismax:
+            {
+              qf: "${left_anchor_qf}",
+              pf: "${left_anchor_pf}",
+              query: "searching for"
+            } },
+          { edismax:
+            {
+              qf: "${left_anchor_qf}",
+              pf: "${left_anchor_pf}",
+              query: "searching for"
+            } }
+        ] } } } }
+        prepare_left_anchor_search(query)
+        expect(query.dig('json', 'query', 'bool', 'must', 0, :edismax, :query)).to eq("searching\\ for*")
+        expect(query.dig('json', 'query', 'bool', 'must', 1, :edismax, :query)).to eq("searching\\ for*")
+        expect(query.dig('json', 'query', 'bool', 'must', 2, :edismax, :query)).to eq("searching\\ for*")
+      end
     end
   end
 
@@ -79,7 +111,7 @@ describe BlacklightHelper do
     end
   end
 
-  describe '#wildcard_char_strip' do
+  describe '#wildcard_char_strip', left_anchor: true do
     it 'strips question marks which are wildcard characters before sending :q to solr' do
       query = { q: '{!qf=$left_anchor_qf pf=$left_anchor_pf}China and Angola: a marriage of convenience?' }
       wildcard_char_strip(query)

--- a/spec/requests/catalog_spec.rb
+++ b/spec/requests/catalog_spec.rb
@@ -14,7 +14,7 @@ describe 'search requests for the catalog' do
     expect(response.status).to eq(200)
   end
 
-  it 'can handle parentheses in the left_anchor field' do
+  it 'can handle parentheses in the left_anchor field', left_anchor: true do
     get '/?search_field=left_anchor&q=Washington+post+(Washington%2C+D.C.+%3A+1877)'
 
     expect(response.status).to eq(200)

--- a/spec/requests/left_anchor_spec.rb
+++ b/spec/requests/left_anchor_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "left anchor search", left_anchor: true do
+  before do
+    allow(Flipflop).to receive(:json_query_dsl?).and_return(true)
+    allow(Flipflop).to receive(:view_components_advanced_search?).and_return(true)
+  end
+  it 'finds result despite accents and capitals in query' do
+    get '/catalog.json?&search_field=left_anchor&q=s%C3%A8arChing+for'
+    r = JSON.parse(response.body)
+    expect(r['data'].any? { |d| d['id'] == '9965749873506421' }).to eq true
+    get '/catalog.json?&search_field=left_anchor&q=s%C3%A8arChing+for'
+    r = JSON.parse(response.body)
+    expect(r['data'].any? { |d| d['id'] == '9965749873506421' }).to eq true
+  end
+
+  it "no matches if it doesn't occur at the beginning of the starts with fields" do
+    get '/catalog.json?&search_field=left_anchor&q=modern+aesthetic'
+    r = JSON.parse(response.body)
+    expect(r['meta']['pages']['total_count']).to eq 0
+  end
+
+  it 'page loads without erroring when query is not provided' do
+    get '/catalog.json?per_page=100&search_field=left_anchor'
+    expect(response.status).to eq(200)
+  end
+
+  it 'works in advanced search' do
+    get '/catalog.json?clause[0][field]=left_anchor&clause[0][query]=searching+for&clause[1][op]=must&clause[1][field]=left_anchor&clause[1][query]=searching+for&clause[2][op]=must&clause[2][field]=left_anchor&clause[2][query]=searching+for'
+    r = JSON.parse(response.body)
+    expect(r['data'].any? { |d| d['id'] == '9965749873506421' }).to eq true
+  end
+
+  context 'with punctuation marks in the title' do
+    it 'handles whitespace characters padding punctuation' do
+      get '/catalog.json?search_field=left_anchor&q=JSTOR+%5Belectronic+resource%5D+%3A'
+      r = JSON.parse(response.body)
+      expect(r['data'].any? { |d| d['id'] == '9928379683506421' }).to eq true
+
+      get '/catalog.json?search_field=left_anchor&q=JSTOR+%5Belectronic+resource%5D%3A'
+      r = JSON.parse(response.body)
+      expect(r['data'].any? { |d| d['id'] == '9928379683506421' }).to eq true
+    end
+  end
+
+  context 'with user-supplied * in query string' do
+    it 'are handled in simple search' do
+      get '/catalog.json?search_field=left_anchor&q=JSTOR*'
+      r = JSON.parse(response.body)
+      expect(r['data'].any? { |d| d['id'] == '9928379683506421' }).to eq true
+    end
+    it 'are handled in advanced search' do
+      get '/catalog.json?clause[0][field]=left_anchor&clause[0][query]=JSTOR*'
+      r = JSON.parse(response.body)
+      expect(r['data'].any? { |d| d['id'] == '9928379683506421' }).to eq true
+    end
+  end
+
+  context 'solr operator characters' do
+    # These tests are only relevant for the standard query parser
+    # # TODO: remove for standard dsl deprecation
+    before do
+      allow(Flipflop).to receive(:json_query_dsl?).and_return(false)
+      allow(Flipflop).to receive(:view_components_advanced_search?).and_return(false)
+    end
+    it 'are handled in simple search' do
+      get '/catalog.json?search_field=left_anchor&q=JSTOR%7B%7D%3A%26%26%7C%7C"%2B%5E~-%2F%3F+%5BElectronic+Resource%5D'
+      r = JSON.parse(response.body)
+      expect(r['data'].any? { |d| d['id'] == '9928379683506421' }).to eq true
+    end
+    it 'are handled in advanced search' do
+      get '/catalog.json?f1=left_anchor&q1=JSTOR%7B%7D%3A%26%26%7C%7C"%2B%5E~-%2F%3F+%5BElectronic+Resource%5D&search_field=advanced'
+      r = JSON.parse(response.body)
+      expect(r['data'].any? { |d| d['id'] == '9928379683506421' }).to eq true
+    end
+  end
+
+  context 'cjk characters' do
+    it 'are searchable in simple search' do
+      get "/catalog.json?search_field=left_anchor&q=#{CGI.escape('浄名玄論 / 京都国立博物館編 ; 解說石塚晴道 (北海道大学名誉教授)')}"
+      r = JSON.parse(response.body)
+      expect(r['data'].any? { |d| d['id'] == '9981818493506421' }).to eq true
+    end
+    it 'are searchable in advanced search' do
+      get "/catalog.json?clause[0][field]=left_anchor&clause[0][query]=#{CGI.escape('浄名玄論 / 京都国立博物館編 ; 解說石塚晴道 (北海道大学名誉教授)')}&search_field=advanced"
+      r = JSON.parse(response.body)
+      expect(r['data'].any? { |d| d['id'] == '9981818493506421' }).to eq true
+    end
+  end
+  it 'supports advanced render constraints' do
+    stub_holding_locations
+    get '/catalog?clause[0][field]=left_anchor&clause[0][query]=plasticity&clause[1][op]=must&clause[1][field]=author&clause[1][query]=&clause[2][op]=must&clause[2][field]=title&clause[2][query]=&range[pub_date_start_sort][begin]=&range[pub_date_start_sort][end]=&commit=Search'
+    expect(response.body).to include 'Remove constraint Title starts with: plasticity'
+    get '/catalog.json?clause[0][field]=left_anchor&clause[0][query]=plasticity&clause[1][op]=must&clause[1][field]=author&clause[1][query]=&clause[2][op]=must&clause[2][field]=title&clause[2][query]=&range%5Bpub_date_start_sort%5D%5Bbegin%5D=&range%5Bpub_date_start_sort%5D%5Bend%5D=&search_field=advanced&commit=Search'
+    r = JSON.parse(response.body)
+    expect(r['data'].any? { |d| d['id'] == '99125535710106421' }).to eq true
+    get '/catalog?search_field=advanced&clause[0][field]=left_anchor&clause[1][field]=author&clause[2][field]=title&clause[1][op]=must_not&clause[2][op]=must&clause[0][query]=plasticity&clause[1][query]=&clause[2][query]=&range%5Bpub_date_start_sort%5D%5Bbegin%5D=&range%5Bpub_date_start_sort%5D%5Bend%5D=&clause[0][field]=all_fields&clause[0][query]=&clause[1][op]=must_not&clause[1][field]=left_anchor&clause[1][query]=plasticity&clause[2][op]=must&clause[2][field]=title&clause[2][query]=&range%5Bpub_date_start_sort%5D%5Bbegin%5D=&range%5Bpub_date_start_sort%5D%5Bend%5D=&search_field=advanced&commit=Search'
+    expect(response.body).not_to include 'Remove constraint Title starts with: plasticity'
+    get '/catalog.json?search_field=advanced&clause[0][field]=left_anchor&clause[1][field]=author&clause[2][field]=title&clause[1][op]=must_not&clause[2][op]=must&clause[0][query]=plasticity&clause[1][query]=&clause[2][query]=&range%5Bpub_date_start_sort%5D%5Bbegin%5D=&range%5Bpub_date_start_sort%5D%5Bend%5D=&clause[0][field]=all_fields&clause[0][query]=&clause[1][op]=must_not&clause[1][field]=left_anchor&clause[1][query]=plasticity&clause[2][op]=must&clause[2][field]=title&clause[2][query]=&range%5Bpub_date_start_sort%5D%5Bbegin%5D=&range%5Bpub_date_start_sort%5D%5Bend%5D=&search_field=advanced&commit=Search'
+    r = JSON.parse(response.body)
+    expect(r['data'].any? { |d| d['id'] == '99125535710106421' }).to eq false
+  end
+  it 'title starts with can be ORed across several 3 queries', left_anchor: true do
+    get '/catalog.json?clause[0][field]=left_anchor&clause[0][query]=Reconstructing+the&clause[1][op]=should&clause[1][field]=left_anchor&clause[1][query]='\
+        'This+angel+on&clause[2][op]=should&clause[2][field]=left_anchor&clause[2][query]=Almost+Human&search_field=advanced&commit=Search'
+    r = JSON.parse(response.body)
+    doc_ids = %w[9992220243506421 9222024 dsp01ft848s955 dsp017s75dc44p]
+    expect(r['data'].all? { |d| doc_ids.include?(d['id']) }).to eq true
+  end
+  context 'with punctuation marks in the title' do
+    it 'handles whitespace characters padding punctuation in the left_anchor field', left_anchor: true do
+      get '/catalog.json?clause[0][field]=left_anchor&clause[0][query]=JSTOR+%5Belectronic+resource%5D+%3A&op2='\
+          'AND&clause[1][field]=author&clause[1][query]=&clause[2][op]=must&clause[2][field]=title&clause[2][query]=&range%5Bpub_date_start_sort%5D%5Bbegin%5D='\
+          '&range%5Bpub_date_start_sort%5D%5Bend%5D=&sort=score+desc%2C+pub_date_start_sort'\
+          '+desc%2C+title_sort+asc&search_field=advanced&commit=Search'
+      r = JSON.parse(response.body)
+      expect(r['data'].any? { |d| d['id'] == '9928379683506421' }).to eq true
+
+      get '/catalog.json?clause[0][field]=left_anchor&clause[0][query]=JSTOR+%5Belectronic+resource%5D%3A&op2='\
+          'AND&clause[1][field]=author&clause[1][query]=&clause[2][op]=must&clause[2][field]=title&clause[2][query]=&range%5Bpub_date_start_sort%5D%5Bbegin%5D='\
+          '&range%5Bpub_date_start_sort%5D%5Bend%5D=&sort=score+desc%2C+pub_date_start_sort'\
+          '+desc%2C+title_sort+asc&search_field=advanced&commit=Search'
+      r = JSON.parse(response.body)
+      expect(r['data'].any? { |d| d['id'] == '9928379683506421' }).to eq true
+    end
+  end
+end

--- a/spec/system/catalog_show_spec.rb
+++ b/spec/system/catalog_show_spec.rb
@@ -64,7 +64,7 @@ describe 'Viewing Catalog Documents', type: :system, js: true do
       solr.commit
     end
 
-    it 'shows the Uniform title' do
+    it 'shows the Uniform title', left_anchor: true do
       visit "catalog/#{document_id}"
       # Regular display title
       expect(page).to have_content('Bible, Latin.')

--- a/spec/system/left_anchor_spec.rb
+++ b/spec/system/left_anchor_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.shared_examples "a simple search" do
+  it 'uses a wildcard for left anchored search' do
+    visit '/catalog'
+    select('Title starts with', from: 'search_field')
+    fill_in('Search...', with: 'The')
+    click_on('Search')
+    expect(page).to have_content('The senses : a comprehensive reference')
+  end
+  it 'does not do boolean searching' do
+    visit '/catalog'
+    select('Title starts with', from: 'search_field')
+    fill_in('Search...', with: 'The OR Black')
+    click_on('Search')
+    expect(page).to have_content('No results found for your search')
+  end
+end
+
+RSpec.shared_examples "an advanced search" do
+  it 'uses a wildcard for left anchored search' do
+    visit '/advanced'
+    select('Title starts with', from: 'Options for advanced search')
+    fill_in('Advanced search terms', with: 'The')
+    click_on('Search')
+    expect(page).to have_content('The senses : a comprehensive reference')
+  end
+  it 'uses a wildcard for left anchored search from the second search box' do
+    visit '/advanced'
+    fill_in('Advanced search terms', with: 'senses')
+    page.find('.first-or').choose
+    select('Title starts with', from: 'Options for advanced search - second parameter')
+    fill_in('Advanced search terms - second parameter', with: 'The')
+    click_on('Search')
+    expect(page).to have_content('The senses : a comprehensive reference')
+  end
+  it 'does not do boolean searching', js: true do
+    visit '/advanced'
+    select('Title starts with', from: 'Options for advanced search')
+    fill_in('Advanced search terms', with: 'The')
+    page.find('.first-or').choose
+    select('Title starts with', from: 'Options for advanced search - second parameter')
+    fill_in('Advanced search terms - second parameter', with: 'Black')
+    click_on('Search')
+    expect(page).to have_content(/Title starts with.{1,2}The/)
+    expect(page).to have_content(/Title starts with.{1,4}Black/)
+  end
+end
+
+RSpec.describe 'left anchored searching', type: :system, left_anchor: true do
+  before { stub_holding_locations }
+  context 'old query dsl and advanced search' do
+    before do
+      allow(Flipflop).to receive(:view_components_advanced_search?).and_return(false)
+      allow(Flipflop).to receive(:json_query_dsl?).and_return(false)
+    end
+
+    it_behaves_like 'a simple search'
+    it_behaves_like 'an advanced search'
+  end
+  context 'new query dsl and advanced search' do
+    before do
+      allow(Flipflop).to receive(:view_components_advanced_search?).and_return(true)
+      allow(Flipflop).to receive(:json_query_dsl?).and_return(true)
+    end
+
+    it_behaves_like 'a simple search'
+    it_behaves_like 'an advanced search'
+  end
+end


### PR DESCRIPTION
Allow for left anchor search with json query dsl

- Move left-anchor specific request specs to their own file
- Make left anchor system spec
- Update specs to use new advanced search syntax

Closes #4138