### PR TITLE
[#3387] Remove Blacklight::Facet from test helpers

### DIFF
--- a/spec/support/controller_level_helpers.rb
+++ b/spec/support/controller_level_helpers.rb
@@ -2,8 +2,6 @@
 
 module ControllerLevelHelpers
   module ControllerViewHelpers
-    include Blacklight::Facet
-
     def search_state
       @search_state ||= Blacklight::SearchState.new(params, blacklight_config)
     end


### PR DESCRIPTION
It is deprecated, and no longer available in Blacklight 8.  I'm unable to run view specs with version 8 of blacklight with this `include` in place.