### PR TITLE
[#3387] Remove Blacklight::SearchFields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -464,9 +464,6 @@ class CatalogController < ApplicationController
     ## Provenance
     config.add_show_field 'numismatic_provenance_s', label: 'Provenance'
 
-    #     "fielded" search configuration. Used by pulldown among other places.
-    #     For supported keys in hash, see rdoc for Blacklight::SearchFields
-
     #     Search fields will inherit the :qt solr request handler from
     #     config[:default_solr_parameters], OR can specify a different one
     #     with a :qt key/value. Below examples inherit, except for subject

--- a/spec/helpers/advanced_label_spec.rb
+++ b/spec/helpers/advanced_label_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 RSpec.describe BlacklightHelper do
   class MockConfig
-    include Blacklight::SearchFields
     include AdvancedHelper
   end
 


### PR DESCRIPTION
This module is deprecated in Blacklight 7 and removed in Blacklight 8.

We only use it when setting up a test case, and the test still passes without it.  Also, remove a comment that refers to this module.

Helps with #3387 