### PR TITLE
Capybara improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,8 +119,6 @@ jobs:
           name: Index Test Data
           command: bundle exec rake pulsearch:solr:index
       - ruby/rspec-test
-      - store_test_results:
-          path: ~/rspec
       # Store capybara screenshots if there are failing system tests
       - store_artifacts:
           path:  ~/orangelight/tmp/capybara/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,9 @@ jobs:
       - ruby/rspec-test
       - store_test_results:
           path: ~/rspec
+      # Store capybara screenshots if there are failing system tests
+      - store_artifacts:
+          path:  ~/orangelight/tmp/capybara/
 
   js_tests:
       executor: basic-executor

--- a/spec/support/capybara_selenium.rb
+++ b/spec/support/capybara_selenium.rb
@@ -6,7 +6,7 @@ require "selenium-webdriver"
 
 Capybara.register_driver(:selenium) do |app|
   browser_options = ::Selenium::WebDriver::Chrome::Options.new
-  browser_options.args << "--headless"
+  browser_options.args << "--headless" unless ENV['RUN_IN_BROWSER']
   browser_options.args << "--disable-gpu"
   browser_options.args << "--disable-setuid-sandbox"
   browser_options.args << "--window-size=1920,1200"


### PR DESCRIPTION
- Make RUN_IN_BROWSER behavior consistent between feature and system specs
- When system test using javascript fails, save the screenshot where folks can see it (may help with debugging intermittent CI failures in future)
  - I dropped the commit, but created a purposefully failing system test using javascript, so that it could make a screenshot, which you can see in the [artifacts from this CI run](https://app.circleci.com/pipelines/github/pulibrary/orangelight/4907/workflows/1609144f-455f-43f3-a9f2-cf6686cffab1/jobs/18033/artifacts) (should only be available for 30 days) 