### PR TITLE
[#4175] Extract Requestable::Holding class

### DIFF
--- a/app/models/requests/requestable/holding.rb
+++ b/app/models/requests/requestable/holding.rb
@@ -22,7 +22,7 @@ module Requests
       end
 
       def first_mfhd
-        to_h.values.first
+        to_h.values&.first || {}
       end
     end
   end

--- a/app/models/requests/requestable/holding.rb
+++ b/app/models/requests/requestable/holding.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module Requests
+  class Requestable
+    # This class is responsible for answering questions about a
+    # particular holding, based on data from a hash (which is
+    # a parsed holdings_1display solr document field)
+    class Holding
+      def initialize(hash)
+        @hash = hash.with_indifferent_access
+      end
+
+      def to_h
+        @hash
+      end
+
+      def thesis?
+        to_h.key?("thesis") && to_h["thesis"][:location_code] == 'mudd$stacks'
+      end
+
+      def numismatics?
+        to_h.key?("numismatics") && to_h["numismatics"][:location_code] == 'rare$num'
+      end
+
+      def first_mfhd
+        to_h.values.first
+      end
+    end
+  end
+end

--- a/spec/models/requests/requestable/holding_spec.rb
+++ b/spec/models/requests/requestable/holding_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Requests::Requestable::Holding do
+  describe '#thesis?' do
+    it 'returns false for a special collections book' do
+      holding = described_class.new(JSON.parse('{"22654362360006421":{"location_code":"rare$ga","location":"Graphic Arts Collection","library":"Special Collections","call_number":"2012-0145Q","call_number_browse":"2012-0145Q","items":[{"holding_id":"22654362360006421","id":"23654362330006421","status_at_load":"1","barcode":"32101051826913","copy_number":"1"}]}}'))
+      expect(holding.thesis?).to be(false)
+    end
+    it 'returns true for a thesis' do
+      holding = described_class.new(JSON.parse('{"thesis":{"location":"Mudd Manuscript Library","library":"Mudd Manuscript Library","location_code":"mudd$stacks","call_number":"AC102","call_number_browse":"AC102","dspace":true}}'))
+      expect(holding.thesis?).to be(true)
+    end
+  end
+  describe '#numismatics?' do
+    it 'returns false for a special collections book' do
+      holding = described_class.new(JSON.parse('{"22654362360006421":{"location_code":"rare$ga","location":"Graphic Arts Collection","library":"Special Collections","call_number":"2012-0145Q","call_number_browse":"2012-0145Q","items":[{"holding_id":"22654362360006421","id":"23654362330006421","status_at_load":"1","barcode":"32101051826913","copy_number":"1"}]}}'))
+      expect(holding.numismatics?).to be(false)
+    end
+    it 'returns true for a coin' do
+      holding = described_class.new(JSON.parse('{"numismatics":{"location":"Special Collections - Numismatics Collection","library":"Special Collections","location_code":"rare$num","call_number":"Coin 11362","call_number_browse":"Coin 11362"}}'))
+      expect(holding.numismatics?).to be(true)
+    end
+  end
+end

--- a/spec/models/requests/requestable/holding_spec.rb
+++ b/spec/models/requests/requestable/holding_spec.rb
@@ -22,4 +22,16 @@ RSpec.describe Requests::Requestable::Holding do
       expect(holding.numismatics?).to be(true)
     end
   end
+  describe '#first_mfhd' do
+    it 'returns a hash with indifferent access of MFHD data for a special collections book' do
+      holding = described_class.new(JSON.parse('{"22654362360006421":{"location_code":"rare$ga","location":"Graphic Arts Collection","library":"Special Collections","call_number":"2012-0145Q","call_number_browse":"2012-0145Q","items":[{"holding_id":"22654362360006421","id":"23654362330006421","status_at_load":"1","barcode":"32101051826913","copy_number":"1"}]}}'))
+      expect(holding.first_mfhd['location_code']).to eq('rare$ga')
+      expect(holding.first_mfhd[:call_number_browse]).to eq('2012-0145Q')
+    end
+    it 'returns an empty hash when no data is available' do
+      holding = described_class.new(JSON.parse('{"22654362360006421":null'))
+      expect(holding.first_mfhd).to eq({})
+      expect(holding.first_mfhd['location_code']).to be_nil
+    end
+  end
 end

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -562,7 +562,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
     let(:user) { FactoryBot.build(:user) }
     let(:item) { { status_label: "Available", location_code: "scsbnypl" }.with_indifferent_access }
     let(:location) { { "holding_library" => { "code" => "marquand" }, "library" => { "code" => "marquand" } } }
-    let(:requestable) { described_class.new(bib: {}, holding: [{ 1 => { 'call_number_browse': 'blah' } }], location:, patron:, item:) }
+    let(:requestable) { described_class.new(bib: {}, holding: { 1 => { 'call_number_browse': 'blah' } }, location:, patron:, item:) }
 
     describe '#site' do
       it 'returns a Marquand site param' do


### PR DESCRIPTION
Rather than passing around the holding as a hash throughout the application, this commit begins an incremental refactor to pass around an object that can answer questions about a holding from the `holdings_1display`. This will eventually mean that other classes won't need to know the exact internal structure of the holding hash, they can just ask `Requestable::Holding` for that information.

For now, though, this is just an incremental step, extracting a few methods from `Requestable` into `Requestable::Holding`, and using the hash elsewhere in the application.

This reduces the reek count in `Requestable` by 2.

Helps with #4175 