### PR TITLE
Remove unneeded attributes from Request model

### DIFF
--- a/app/models/requests/request.rb
+++ b/app/models/requests/request.rb
@@ -3,8 +3,6 @@ require 'faraday'
 
 module Requests
   class Request
-    attr_accessor :email
-    attr_accessor :user_name
     attr_reader :system_id
     attr_reader :source
     attr_reader :mfhd


### PR DESCRIPTION
Neither email nor user_name seem to be required attributes for the Request

Closes #4204