### PR TITLE
Uncomment and delete tests to reflect that campus is now open

### DIFF
--- a/spec/models/requests/request_spec.rb
+++ b/spec/models/requests/request_spec.rb
@@ -826,16 +826,10 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :non
         expect(request.requestable.size).to be >= 1
       end
 
-      # TODO: Remove when campus has re-opened
-      # it "is not eligible for recap services during campus closure" do
-      #   expect(request.requestable.last.services.include?('recap')).to be_true
-      # end
-
-      # TODO: Activate test when campus has re-opened
-      # it "is eligible for recap services with circulating items" do
-      #   expect(request.requestable.first.services.include?('recap')).to be_truthy
-      #   expect(request.requestable.first.scsb_in_library_use?).to be_falsey
-      # end
+      it "is eligible for recap services with circulating items" do
+        expect(request.requestable.first.services.include?('recap')).to be_truthy
+        expect(request.requestable.first.scsb_in_library_use?).to be_falsey
+      end
 
       it "is eligible for recap_edd services" do
         expect(request.requestable.first.services.include?('recap_edd')).to be_truthy


### PR DESCRIPTION
One of these tests said to uncomment it when campus is open post-COVID, another said to delete it when campus is open.  This commit does so.