### PR TITLE
[#4175] Limit the mutability of Requestable's services array

### DIFF
--- a/app/models/requests/requestable.rb
+++ b/app/models/requests/requestable.rb
@@ -10,7 +10,7 @@ module Requests
     attr_reader :title
     attr_reader :user_barcode
     attr_reader :patron
-    attr_accessor :services
+    attr_reader :services
 
     delegate :pageable_loc?, to: :@pageable
     delegate :map_url, to: :@mappable
@@ -261,6 +261,10 @@ module Requests
 
     def resource_shared?
       library_code == "RES_SHARE"
+    end
+
+    def replace_existing_services(new_services)
+      @services = new_services
     end
 
     private

--- a/app/models/requests/requestable_decorator.rb
+++ b/app/models/requests/requestable_decorator.rb
@@ -91,7 +91,7 @@ module Requests
 
     def create_fill_in_requestable
       fill_in_req = Requestable.new(bib:, holding:, item: nil, location:, patron:)
-      fill_in_req.services = services
+      fill_in_req.replace_existing_services services
       RequestableDecorator.new(fill_in_req, view_context)
     end
 

--- a/app/models/requests/router.rb
+++ b/app/models/requests/router.rb
@@ -31,7 +31,7 @@ module Requests
     # cas - all services
 
     def routed_request
-      requestable.services = calculate_services
+      requestable.replace_existing_services calculate_services
       requestable
     end
 

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -26,6 +26,16 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
       end
     end
 
+    describe '#replace_existing_services' do
+      it 'provides an option for other classes to modify the list of services' do
+        expect(requestable.services).to contain_exactly("on_shelf", "on_shelf_edd")
+
+        requestable.replace_existing_services(['online'])
+
+        expect(requestable.services).to contain_exactly("online")
+      end
+    end
+
     describe '#location_label' do
       it 'has a location label' do
         expect(requestable.location_label).to eq('Firestone Library - Stacks')


### PR DESCRIPTION
Prior to this commit, the `@services` variable of the `Requestable` class had an `attr_accessor`, so other classes could make any changes they wanted to the array.

This commit adds an explicit writer method, so that other classes don't need to be so familiar with the internal workings of `Requestable`, and can only mutate `@services` in one way (totally replacing it with a new array).

Resolves one reek warning, and helps with #4175