### PR TITLE
[#4175] Extract Item#location method

### DIFF
--- a/app/models/requests/requestable.rb
+++ b/app/models/requests/requestable.rb
@@ -217,11 +217,7 @@ module Requests
     end
 
     def item_location_code
-      if item? && item["location"].present?
-        item['location'].to_s
-      else
-        location_code
-      end
+      item&.location || location_code
     end
 
     def library_code

--- a/app/models/requests/requestable/item.rb
+++ b/app/models/requests/requestable/item.rb
@@ -132,6 +132,11 @@ class Requests::Requestable
       Requests::Config[:recap_partner_locations].keys.include? self["location_code"]
     end
 
+    # The location code (e.g. firestone$pf)
+    def location
+      self[:location]
+    end
+
     private
 
       def available_statuses

--- a/app/models/requests/requestable/null_item.rb
+++ b/app/models/requests/requestable/null_item.rb
@@ -116,5 +116,9 @@ class Requests::Requestable
     def partner_holding?
       false
     end
+
+    def location
+      nil
+    end
   end
 end

--- a/spec/models/requests/requestable/item_spec.rb
+++ b/spec/models/requests/requestable/item_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Requests::Requestable::Item do
+  describe '#location' do
+    it 'returns the item location as a string' do
+      item = described_class.new(
+        { "barcode": "32101093374757", "id": "23579848210006421", "holding_id": "22579848330006421", "copy_number": "1", "status": "Available",
+          "status_label": "Item in place", "status_source": "base_status", "process_type": nil, "on_reserve": "N", "item_type": "Gen",
+          "pickup_location_id": "firestone", "pickup_location_code": "firestone", "location": "firestone$pf", "label": "Firestone Library",
+          "description": "Jul 1904 - Dec 1905 Incl: Index NS Vol 20 - 22 Iss 496 - 574", "enum_display": "Jul 1904 - Dec 1905 Incl: Index",
+          "chron_display": "NS Vol 20 - 22 Iss 496 - 574", "in_temp_library": false }.with_indifferent_access
+      )
+      expect(item.location).to eq 'firestone$pf'
+    end
+    it 'returns nil if no location code is available' do
+      item = described_class.new({ "barcode": "32101093374757" }.with_indifferent_access)
+      expect(item.location).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
This frees the Requestable class of the responsibility of checking the state of the location key in the Item hash; Item can just provide this information directly to Requestable.

Helps with #4175 