### PR TITLE
[#4270] Remove the unused openurl_ctx_kev method from requests

### DIFF
--- a/.debride_allowlist.txt
+++ b/.debride_allowlist.txt
@@ -54,4 +54,3 @@ sent
 # additional_validation!
 # recap_partner_location_codes
 # pageable_loc?
-# openurl_ctx_kev

--- a/app/models/requests/request.rb
+++ b/app/models/requests/request.rb
@@ -16,7 +16,7 @@ module Requests
     attr_reader :items
     attr_reader :pick_ups
     alias default_pick_ups pick_ups
-    delegate :ctx, :openurl_ctx_kev, to: :@ctx_obj
+    delegate :ctx, to: :@ctx_obj
     delegate :eligible_for_library_services?, to: :patron
 
     include Requests::Bibdata

--- a/app/models/requests/solr_open_url_context.rb
+++ b/app/models/requests/solr_open_url_context.rb
@@ -12,9 +12,5 @@ module Requests
       # essential for ILLiad requests
       @ctx.referent.set_metadata('date', solr_doc['pub_date_display'].first) if @ctx.referent.format == 'journal' && solr_doc['pub_date_display'].present?
     end
-
-    def openurl_ctx_kev
-      ctx.kev
-    end
   end
 end

--- a/spec/models/requests/request_spec.rb
+++ b/spec/models/requests/request_spec.rb
@@ -111,15 +111,6 @@ describe Requests::Request, vcr: { cassette_name: 'request_models', record: :non
       end
     end
 
-    describe '#openurl_ctx_kev' do
-      it 'returns an encoded query string' do
-        expect(request_with_holding_item.openurl_ctx_kev).to be_a(String)
-        request_with_holding_item.ctx.referent.identifiers.each do |identifier|
-          expect(request_with_holding_item.openurl_ctx_kev).to include(CGI.escape(identifier))
-        end
-      end
-    end
-
     describe "#requestable" do
       it "has a list of requestable objects" do
         expect(request_with_holding_item.requestable).to be_truthy


### PR DESCRIPTION
Note that other parts of orangelight continue to use a similarly named method: export_as_openurl_ctx_kev

closes #4270 