### PR TITLE
[#4258] Extract the clancy_unavailable eligibility checks from the requests Router into its own class

### DIFF
--- a/app/models/requests/router.rb
+++ b/app/models/requests/router.rb
@@ -104,8 +104,9 @@ module Requests
       end
 
       def calculate_marquand_services
-        if requestable.item_at_clancy? && !requestable.clancy_available?
-          ['clancy_unavailable']
+        clancy_unavailable = ServiceEligibility::ClancyUnavailable.new(user:, requestable:)
+        if clancy_unavailable.eligible?
+          [clancy_unavailable.to_s]
         elsif requestable.clancy_available?
           ['clancy_in_library', 'clancy_edd']
         else

--- a/app/models/requests/service_eligibility/clancy_unavailable.rb
+++ b/app/models/requests/service_eligibility/clancy_unavailable.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+module Requests
+  module ServiceEligibility
+    class ClancyUnavailable
+      def initialize(requestable:, user:)
+        @requestable = requestable
+        @user = user
+      end
+
+      def to_s
+        'clancy_unavailable'
+      end
+
+      def eligible?
+        requestable_eligible? && user_eligible?
+      end
+
+    private
+
+      def user_eligible?
+        user.cas_provider? || user.alma_provider?
+      end
+
+      def requestable_eligible?
+        requestable.item_at_clancy? && !requestable.clancy_available? &&
+          requestable.held_at_marquand_library? &&
+          !(requestable.recap? || requestable.recap_pf?) &&
+          !requestable.annex? &&
+          !requestable.on_order? &&
+          !requestable.in_process? &&
+          !requestable.charged? &&
+          (requestable.alma_managed? || requestable.partner_holding?) &&
+          !requestable.aeon?
+      end
+      attr_reader :requestable, :user
+    end
+  end
+end

--- a/spec/models/requests/service_eligibility/clancy_unavailable_spec.rb
+++ b/spec/models/requests/service_eligibility/clancy_unavailable_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Requests::ServiceEligibility::ClancyUnavailable do
+  describe '#eligible?' do
+    it 'returns true if all criteria are met' do
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+          alma_managed?: true,
+          held_at_marquand_library?: true,
+          item_at_clancy?: true,
+          clancy_available?: false,
+          aeon?: false,
+          charged?: false,
+          in_process?: false,
+          on_order?: false,
+          annex?: false,
+          recap?: false,
+          recap_pf?: false
+        )
+      eligibility = described_class.new(requestable:, user: FactoryBot.create(:user))
+
+      expect(eligibility.eligible?).to be(true)
+    end
+    it 'returns false if the clancy item is available' do
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+          clancy_available?: true,
+          alma_managed?: true,
+          held_at_marquand_library?: true,
+          item_at_clancy?: true,
+          aeon?: false,
+          charged?: false,
+          in_process?: false,
+          on_order?: false,
+          annex?: false,
+          recap?: false,
+          recap_pf?: false
+        )
+      eligibility = described_class.new(requestable:, user: FactoryBot.create(:user))
+
+      expect(eligibility.eligible?).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
closes #4258