### PR TITLE
Remove user_barcode method from Requestable

### DIFF
--- a/app/models/requests/requestable.rb
+++ b/app/models/requests/requestable.rb
@@ -9,7 +9,6 @@ module Requests
     attr_reader :location
     attr_reader :call_number
     attr_reader :title
-    attr_reader :user_barcode
     attr_reader :patron
     attr_reader :services
 
@@ -32,7 +31,6 @@ module Requests
       @location = location
       @services = []
       @patron = patron
-      @user_barcode = patron.barcode
       @call_number = @holding.holding_data['call_number_browse']
       @title = bib[:title_citation_display]&.first
       @pageable = Pageable.new(call_number:, location_code: location_object.code)

--- a/app/models/requests/requestable_decorator.rb
+++ b/app/models/requests/requestable_decorator.rb
@@ -3,7 +3,7 @@ module Requests
   class RequestableDecorator
     delegate :system_id, :services, :charged?, :annex?, :on_reserve?,
              :ask_me?, :aeon_request_url, :temp_loc_other_than_resource_sharing?, :call_number, :eligible_for_library_services?,
-             :holding_library_in_library_only?, :holding_library, :bib, :circulates?, :item_data?, :recap_edd?, :user_barcode, :clancy_available?,
+             :holding_library_in_library_only?, :holding_library, :bib, :circulates?, :item_data?, :recap_edd?, :clancy_available?,
              :holding, :item_location_code, :item?, :item, :partner_holding?, :status, :status_label, :use_restriction?, :library_code, :enum_value, :item_at_clancy?,
              :cron_value, :illiad_request_parameters, :location_label, :aeon?, :patron, :held_at_marquand_library?,
              :ill_eligible?, :scsb_in_library_use?, :pick_up_locations, :on_shelf?, :pending?, :recap?, :recap_pf?, :illiad_request_url, :available?,

--- a/spec/models/requests/request_decorator_spec.rb
+++ b/spec/models/requests/request_decorator_spec.rb
@@ -146,14 +146,14 @@ describe Requests::RequestDecorator, requests: true do
     end
 
     context "on_shelf services with no item data and circulates" do
-      let(:stubbed_questions) { { services: ['on_shelf'], patron:, item_data?: false, circulates?: true, scsb_in_library_use?: false, on_order?: false, in_process?: false, aeon?: false, ill_eligible?: false, user_barcode: '111222', ask_me?: false, recap?: false, annex?: false, clancy_available?: false, held_at_marquand_library?: false, item_at_clancy?: false, library_code: 'abc', eligible_for_library_services?: true } }
+      let(:stubbed_questions) { { services: ['on_shelf'], patron:, item_data?: false, circulates?: true, scsb_in_library_use?: false, on_order?: false, in_process?: false, aeon?: false, ill_eligible?: false, ask_me?: false, recap?: false, annex?: false, clancy_available?: false, held_at_marquand_library?: false, item_at_clancy?: false, library_code: 'abc', eligible_for_library_services?: true } }
       it "submits via form" do
         expect(decorator.any_will_submit_via_form?).to be_truthy
       end
     end
 
     context "on_shelf services with no item data and circulates" do
-      let(:stubbed_questions) { { services: ['on_shelf'], patron:, item_data?: false, circulates?: false, recap_edd?: false, scsb_in_library_use?: false, on_order?: false, in_process?: false, aeon?: false, ill_eligible?: false, user_barcode: '111222', ask_me?: false, recap?: false, annex?: false, clancy_available?: false, item_at_clancy?: false, held_at_marquand_library?: false, eligible_for_library_services?: true } }
+      let(:stubbed_questions) { { services: ['on_shelf'], patron:, item_data?: false, circulates?: false, recap_edd?: false, scsb_in_library_use?: false, on_order?: false, in_process?: false, aeon?: false, ill_eligible?: false, ask_me?: false, recap?: false, annex?: false, clancy_available?: false, item_at_clancy?: false, held_at_marquand_library?: false, eligible_for_library_services?: true } }
       it "does not submit via form" do
         expect(decorator.any_will_submit_via_form?).to be_falsey
       end

--- a/spec/models/requests/requestable_decorator_spec.rb
+++ b/spec/models/requests/requestable_decorator_spec.rb
@@ -525,7 +525,7 @@ describe Requests::RequestableDecorator, requests: true do
     let(:item_flags) { default_stubbed_questions.merge(item_data?: true, circulates?: true, holding_library_in_library_only?: false, on_shelf?: false, recap_edd?: false, scsb_in_library_use?: false, ill_eligible?: false, on_order?: false, in_process?: false, aeon?: false, ask_me?: false) }
     let(:service) { { services: ["on_shelf", "on_shelf_edd"], on_shelf?: true } }
     context "a pickup eligible user" do
-      let(:user_flags) { { user_barcode: '111222333', eligible_for_library_services?: true } }
+      let(:user_flags) { { eligible_for_library_services?: true } }
       context "at a library" do
         let(:location) { { library_code: 'abc' } }
         it 'a book on the shelf will be submitted' do
@@ -623,7 +623,7 @@ describe Requests::RequestableDecorator, requests: true do
       end
     end
     context "an Alma user" do
-      let(:user_flags) { { user_barcode: '111222333', eligible_for_library_services?: true } }
+      let(:user_flags) { { eligible_for_library_services?: true } }
       let(:user) { FactoryBot.build(:alma_patron) }
       context "at an open library" do
         let(:location) { { library_code: 'abc' } }
@@ -685,7 +685,7 @@ describe Requests::RequestableDecorator, requests: true do
     end
 
     context "no item data and does not circulate and ill_eligible" do
-      let(:stubbed_questions) { default_stubbed_questions.merge(item_data?: false, circulates?: false, services: ["on_shelf"], recap_edd?: false, scsb_in_library_use?: false, ill_eligible?: true, patron:, on_order?: false, in_process?: false, user_barcode: '111222', aeon?: false, ask_me?: false, library_code: 'abc') }
+      let(:stubbed_questions) { default_stubbed_questions.merge(item_data?: false, circulates?: false, services: ["on_shelf"], recap_edd?: false, scsb_in_library_use?: false, ill_eligible?: true, patron:, on_order?: false, in_process?: false, aeon?: false, ask_me?: false, library_code: 'abc') }
       it 'will be submitted' do
         expect(decorator.will_submit_via_form?).to be_truthy
       end
@@ -741,7 +741,7 @@ describe Requests::RequestableDecorator, requests: true do
     end
 
     context "no item data and does not circulate and eligible_for_library_services?" do
-      let(:stubbed_questions) { default_stubbed_questions.merge(item_data?: false, circulates?: false, services: ["on_shelf"], recap_edd?: false, scsb_in_library_use?: false, ill_eligible?: false, on_order?: false, in_process?: false, user_barcode: '111222', ask_me?: false, library_code: 'abc', aeon?: false) }
+      let(:stubbed_questions) { default_stubbed_questions.merge(item_data?: false, circulates?: false, services: ["on_shelf"], recap_edd?: false, scsb_in_library_use?: false, ill_eligible?: false, on_order?: false, in_process?: false, ask_me?: false, library_code: 'abc', aeon?: false) }
       it 'will not be submitted' do
         expect(decorator.will_submit_via_form?).to be_falsey
       end
@@ -776,7 +776,7 @@ describe Requests::RequestableDecorator, requests: true do
     end
 
     context "no item data and does not circulate and eligible_for_library_services? and ill_eligible" do
-      let(:stubbed_questions) { default_stubbed_questions.merge(item_data?: false, circulates?: false, services: ["on_shelf"], recap_edd?: false, scsb_in_library_use?: false, ill_eligible?: true, patron:, on_order?: false, in_process?: false, user_barcode: '111222', ask_me?: false, library_code: 'abc', aeon?: false) }
+      let(:stubbed_questions) { default_stubbed_questions.merge(item_data?: false, circulates?: false, services: ["on_shelf"], recap_edd?: false, scsb_in_library_use?: false, ill_eligible?: true, patron:, on_order?: false, in_process?: false, ask_me?: false, library_code: 'abc', aeon?: false) }
       it 'will be submitted' do
         expect(decorator.will_submit_via_form?).to be_truthy
       end


### PR DESCRIPTION
It is not used.  Note that `Requests::Submission` also has a `user_barcode` method; that one is actually used.