### PR TITLE
Refactor two methods out of Requests::Router

### DIFF
--- a/app/models/requests/router.rb
+++ b/app/models/requests/router.rb
@@ -62,20 +62,19 @@ module Requests
           ['annex', 'on_shelf_edd']
         elsif requestable.recap? || requestable.recap_pf?
           calculate_recap_services
-        elsif requestable.held_at_marquand_library?
-          calculate_marquand_services
         else
-          calculate_on_shelf_services
+          [
+            ServiceEligibility::OnShelfDigitize.new(requestable:, user:),
+            ServiceEligibility::OnShelfPickup.new(requestable:, user:),
+            ServiceEligibility::ClancyUnavailable.new(user:, requestable:),
+            ServiceEligibility::ClancyInLibrary.new(user:, requestable:),
+            ServiceEligibility::ClancyEdd.new(user:, requestable:),
+            ServiceEligibility::MarquandInLibrary.new(user:, requestable:),
+            ServiceEligibility::MarquandEdd.new(user:, requestable:)
+          ].select(&:eligible?).map(&:to_s)
         end
       end
       # rubocop:enable Metrics/MethodLength
-
-      def calculate_on_shelf_services
-        [
-          ServiceEligibility::OnShelfDigitize.new(requestable:, user:),
-          ServiceEligibility::OnShelfPickup.new(requestable:, user:)
-        ].select(&:eligible?).map(&:to_s)
-      end
 
       def calculate_recap_services
         if !requestable.item_data?
@@ -99,16 +98,6 @@ module Requests
         else
           []
         end
-      end
-
-      def calculate_marquand_services
-        [
-          ServiceEligibility::ClancyUnavailable.new(user:, requestable:),
-          ServiceEligibility::ClancyInLibrary.new(user:, requestable:),
-          ServiceEligibility::ClancyEdd.new(user:, requestable:),
-          ServiceEligibility::MarquandInLibrary.new(user:, requestable:),
-          ServiceEligibility::MarquandEdd.new(user:, requestable:)
-        ].select(&:eligible?).map(&:to_s)
       end
 
       def auth_user?

--- a/spec/models/requests/router_spec.rb
+++ b/spec/models/requests/router_spec.rb
@@ -51,7 +51,8 @@ describe Requests::Router, vcr: { cassette_name: 'requests_router', record: :non
           preservation?: false, annex?: false,
           recap?: false, held_at_marquand_library?: false,
           item_data?: false, recap_edd?: false, scsb_in_library_use?: false, item:,
-          library_code: 'ABC', eligible_for_library_services?: true }
+          library_code: 'ABC', eligible_for_library_services?: true,
+          item_at_clancy?: false }
       end
       let(:requestable) { instance_double(Requests::Requestable, stubbed_questions) }
 


### PR DESCRIPTION
These methods both looked through an array of eligibility objects and selected the eligible? ones. This commit combines the two arrays.