### PR TITLE
Refactor Recap eligibility checks from requests Router

### DIFF
--- a/app/models/requests/router.rb
+++ b/app/models/requests/router.rb
@@ -60,8 +60,6 @@ module Requests
           ['on_order']
         elsif requestable.annex?
           ['annex', 'on_shelf_edd']
-        elsif requestable.recap?
-          calculate_recap_services
         else
           [
             ServiceEligibility::OnShelfDigitize.new(requestable:, user:),
@@ -70,21 +68,16 @@ module Requests
             ServiceEligibility::ClancyInLibrary.new(user:, requestable:),
             ServiceEligibility::ClancyEdd.new(user:, requestable:),
             ServiceEligibility::MarquandInLibrary.new(user:, requestable:),
-            ServiceEligibility::MarquandEdd.new(user:, requestable:)
+            ServiceEligibility::MarquandEdd.new(user:, requestable:),
+            ServiceEligibility::Recap::NoItems.new(requestable:, user:),
+            ServiceEligibility::Recap::InLibrary.new(requestable:, user:),
+            ServiceEligibility::Recap::AskMe.new(requestable:, user:),
+            ServiceEligibility::Recap::Digitize.new(requestable:, user:),
+            ServiceEligibility::Recap::Pickup.new(requestable:, user:)
           ].select(&:eligible?).map(&:to_s)
         end
       end
       # rubocop:enable Metrics/MethodLength
-
-      def calculate_recap_services
-        [
-          ServiceEligibility::Recap::NoItems.new(requestable:, user:),
-          ServiceEligibility::Recap::InLibrary.new(requestable:, user:),
-          ServiceEligibility::Recap::AskMe.new(requestable:, user:),
-          ServiceEligibility::Recap::Digitize.new(requestable:, user:),
-          ServiceEligibility::Recap::Pickup.new(requestable:, user:)
-        ].select(&:eligible?).map(&:to_s)
-      end
 
       def calculate_unavailable_services
         ill_eligibility = ServiceEligibility::ILL.new(requestable:, user:, any_loanable:)

--- a/app/models/requests/router.rb
+++ b/app/models/requests/router.rb
@@ -78,9 +78,9 @@ module Requests
 
       def calculate_recap_services
         [
-          ServiceEligibility::Recap::NoItems.new(requestable:),
-          ServiceEligibility::Recap::InLibrary.new(requestable:),
-          ServiceEligibility::Recap::AskMe.new(requestable:),
+          ServiceEligibility::Recap::NoItems.new(requestable:, user:),
+          ServiceEligibility::Recap::InLibrary.new(requestable:, user:),
+          ServiceEligibility::Recap::AskMe.new(requestable:, user:),
           ServiceEligibility::Recap::Digitize.new(requestable:, user:),
           ServiceEligibility::Recap::Pickup.new(requestable:, user:)
         ].select(&:eligible?).map(&:to_s)

--- a/app/models/requests/service_eligibility/recap/abstract_recap.rb
+++ b/app/models/requests/service_eligibility/recap/abstract_recap.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Requests
   module ServiceEligibility
     module Recap

--- a/app/models/requests/service_eligibility/recap/abstract_recap.rb
+++ b/app/models/requests/service_eligibility/recap/abstract_recap.rb
@@ -1,0 +1,29 @@
+module Requests
+  module ServiceEligibility
+    module Recap
+      # Abstract class for other recap classes to inherit from
+      class AbstractRecap
+        def initialize(requestable:, user:)
+          @requestable = requestable
+          @user = user
+        end
+
+        def to_s
+          raise "Please implement to_s in the subclass"
+        end
+
+        protected
+
+          def requestable_eligible?
+            raise "Please implement requestable_eligible? in the subclass"
+          end
+
+          def user_eligible?
+            user.cas_provider? || user.alma_provider?
+          end
+
+          attr_reader :requestable, :user
+      end
+    end
+  end
+end

--- a/app/models/requests/service_eligibility/recap/ask_me.rb
+++ b/app/models/requests/service_eligibility/recap/ask_me.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+module Requests
+  module ServiceEligibility
+    module Recap
+      # ask_me - catchall service if the item isn't eligible for anything else.
+      class AskMe
+        def initialize(requestable:)
+          @requestable = requestable
+        end
+
+        def eligible?
+          requestable_eligible? && patron_eligible?
+        end
+
+        def to_s
+          'ask_me'
+        end
+
+        private
+
+          def requestable_eligible?
+            return false unless requestable.recap?
+
+            requestable.scsb_in_library_use?
+          end
+
+          # The patron is eligible for this service
+          # if they are *not* eligible for library services in general
+          def patron_eligible?
+            !requestable.eligible_for_library_services?
+          end
+
+          attr_reader :requestable
+      end
+    end
+  end
+end

--- a/app/models/requests/service_eligibility/recap/ask_me.rb
+++ b/app/models/requests/service_eligibility/recap/ask_me.rb
@@ -3,13 +3,9 @@ module Requests
   module ServiceEligibility
     module Recap
       # ask_me - catchall service if the item isn't eligible for anything else.
-      class AskMe
-        def initialize(requestable:)
-          @requestable = requestable
-        end
-
+      class AskMe < AbstractRecap
         def eligible?
-          requestable_eligible? && patron_eligible?
+          requestable_eligible? && user_eligible? && patron_eligible?
         end
 
         def to_s
@@ -29,8 +25,6 @@ module Requests
           def patron_eligible?
             !requestable.eligible_for_library_services?
           end
-
-          attr_reader :requestable
       end
     end
   end

--- a/app/models/requests/service_eligibility/recap/digitize.rb
+++ b/app/models/requests/service_eligibility/recap/digitize.rb
@@ -3,12 +3,7 @@ module Requests
   module ServiceEligibility
     module Recap
       # recap_edd - material is stored in a recap location that permits digitization
-      class Digitize
-        def initialize(requestable:, user:)
-          @requestable = requestable
-          @user = user
-        end
-
+      class Digitize < AbstractRecap
         def eligible?
           requestable_eligible? && user_eligible?
         end
@@ -27,12 +22,6 @@ module Requests
               requestable.item_data? &&
               !requestable.scsb_in_library_use?
           end
-
-          def user_eligible?
-            user.cas_provider? || user.alma_provider?
-          end
-
-          attr_reader :requestable, :user
       end
     end
   end

--- a/app/models/requests/service_eligibility/recap/digitize.rb
+++ b/app/models/requests/service_eligibility/recap/digitize.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+module Requests
+  module ServiceEligibility
+    module Recap
+      # recap_edd - material is stored in a recap location that permits digitization
+      class Digitize
+        def initialize(requestable:, user:)
+          @requestable = requestable
+          @user = user
+        end
+
+        def eligible?
+          requestable_eligible? && user_eligible?
+        end
+
+        def to_s
+          'recap_edd'
+        end
+
+        private
+
+          def requestable_eligible?
+            return false unless requestable.recap?
+
+            !requestable.recap_pf? &&
+              requestable.recap_edd? &&
+              requestable.item_data? &&
+              !requestable.scsb_in_library_use?
+          end
+
+          def user_eligible?
+            user.cas_provider? || user.alma_provider?
+          end
+
+          attr_reader :requestable, :user
+      end
+    end
+  end
+end

--- a/app/models/requests/service_eligibility/recap/in_library.rb
+++ b/app/models/requests/service_eligibility/recap/in_library.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+module Requests
+  module ServiceEligibility
+    module Recap
+      # recap_in_library - material is stored at recap; can be paged to campus, but does not circulate
+      class InLibrary
+        def initialize(requestable:)
+          @requestable = requestable
+        end
+
+        def eligible?
+          requestable_eligible?
+        end
+
+        def to_s
+          'recap_in_library'
+        end
+
+        private
+
+          def requestable_eligible?
+            return false unless requestable.recap?
+
+            (requestable.scsb_in_library_use? && requestable.item[:collection_code] != "MR") ||
+              (!requestable.circulates? && !requestable.recap_edd?) ||
+              requestable.recap_pf?
+          end
+
+          attr_reader :requestable
+      end
+    end
+  end
+end

--- a/app/models/requests/service_eligibility/recap/in_library.rb
+++ b/app/models/requests/service_eligibility/recap/in_library.rb
@@ -3,13 +3,9 @@ module Requests
   module ServiceEligibility
     module Recap
       # recap_in_library - material is stored at recap; can be paged to campus, but does not circulate
-      class InLibrary
-        def initialize(requestable:)
-          @requestable = requestable
-        end
-
+      class InLibrary < AbstractRecap
         def eligible?
-          requestable_eligible?
+          requestable_eligible? && user_eligible?
         end
 
         def to_s
@@ -25,8 +21,6 @@ module Requests
               (!requestable.circulates? && !requestable.recap_edd?) ||
               requestable.recap_pf?
           end
-
-          attr_reader :requestable
       end
     end
   end

--- a/app/models/requests/service_eligibility/recap/no_items.rb
+++ b/app/models/requests/service_eligibility/recap/no_items.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+module Requests
+  module ServiceEligibility
+    module Recap
+      # recap_no_items - material in a recap location with no item record data
+      class NoItems
+        def initialize(requestable:)
+          @requestable = requestable
+        end
+
+        def eligible?
+          requestable_eligible?
+        end
+
+        def to_s
+          'recap_no_items'
+        end
+
+        private
+
+          def requestable_eligible?
+            return false unless requestable.recap?
+
+            !requestable.item_data?
+          end
+
+          attr_reader :requestable
+      end
+    end
+  end
+end

--- a/app/models/requests/service_eligibility/recap/no_items.rb
+++ b/app/models/requests/service_eligibility/recap/no_items.rb
@@ -3,13 +3,9 @@ module Requests
   module ServiceEligibility
     module Recap
       # recap_no_items - material in a recap location with no item record data
-      class NoItems
-        def initialize(requestable:)
-          @requestable = requestable
-        end
-
+      class NoItems < AbstractRecap
         def eligible?
-          requestable_eligible?
+          requestable_eligible? && user_eligible?
         end
 
         def to_s
@@ -23,8 +19,6 @@ module Requests
 
             !requestable.item_data?
           end
-
-          attr_reader :requestable
       end
     end
   end

--- a/app/models/requests/service_eligibility/recap/pickup.rb
+++ b/app/models/requests/service_eligibility/recap/pickup.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+module Requests
+  module ServiceEligibility
+    module Recap
+      # recap - material is stored at recap; can be paged to campus and circulates
+      class Pickup
+        def initialize(requestable:, user:)
+          @requestable = requestable
+          @user = user
+        end
+
+        def eligible?
+          requestable_eligible? && user_eligible? && patron_eligible?
+        end
+
+        def to_s
+          'recap'
+        end
+
+        private
+
+          def requestable_eligible?
+            return false unless requestable.recap?
+            requestable.item_data? &&
+              !requestable.recap_pf? &&
+              !requestable.holding_library_in_library_only? &&
+              !(!requestable.circulates? && !requestable.recap_edd?) &&
+              !(requestable.scsb_in_library_use? && requestable.item[:collection_code] != "MR")
+          end
+
+          def user_eligible?
+            user.cas_provider? || user.alma_provider?
+          end
+
+          def patron_eligible?
+            requestable.eligible_for_library_services?
+          end
+
+          attr_reader :requestable, :user
+      end
+    end
+  end
+end

--- a/app/models/requests/service_eligibility/recap/pickup.rb
+++ b/app/models/requests/service_eligibility/recap/pickup.rb
@@ -3,12 +3,7 @@ module Requests
   module ServiceEligibility
     module Recap
       # recap - material is stored at recap; can be paged to campus and circulates
-      class Pickup
-        def initialize(requestable:, user:)
-          @requestable = requestable
-          @user = user
-        end
-
+      class Pickup < AbstractRecap
         def eligible?
           requestable_eligible? && user_eligible? && patron_eligible?
         end
@@ -28,15 +23,9 @@ module Requests
               !(requestable.scsb_in_library_use? && requestable.item[:collection_code] != "MR")
           end
 
-          def user_eligible?
-            user.cas_provider? || user.alma_provider?
-          end
-
           def patron_eligible?
             requestable.eligible_for_library_services?
           end
-
-          attr_reader :requestable, :user
       end
     end
   end

--- a/spec/models/requests/service_eligibility/recap/ask_me_spec.rb
+++ b/spec/models/requests/service_eligibility/recap/ask_me_spec.rb
@@ -2,6 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Requests::ServiceEligibility::Recap::AskMe, requests: true do
+  let(:user) { FactoryBot.create(:user) }
   describe '#eligible?' do
     it 'returns true if all criteria are met' do
       requestable = instance_double(Requests::Requestable)
@@ -10,7 +11,7 @@ RSpec.describe Requests::ServiceEligibility::Recap::AskMe, requests: true do
         scsb_in_library_use?: true,
         eligible_for_library_services?: false
       )
-      eligibility = described_class.new(requestable:)
+      eligibility = described_class.new(requestable:, user:)
 
       expect(eligibility.eligible?).to be(true)
     end
@@ -22,7 +23,7 @@ RSpec.describe Requests::ServiceEligibility::Recap::AskMe, requests: true do
         scsb_in_library_use?: true,
         eligible_for_library_services?: true
       )
-      eligibility = described_class.new(requestable:)
+      eligibility = described_class.new(requestable:, user:)
 
       expect(eligibility.eligible?).to be(false)
     end

--- a/spec/models/requests/service_eligibility/recap/ask_me_spec.rb
+++ b/spec/models/requests/service_eligibility/recap/ask_me_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Requests::ServiceEligibility::Recap::AskMe, requests: true do
+  describe '#eligible?' do
+    it 'returns true if all criteria are met' do
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+        recap?: true,
+        scsb_in_library_use?: true,
+        eligible_for_library_services?: false
+      )
+      eligibility = described_class.new(requestable:)
+
+      expect(eligibility.eligible?).to be(true)
+    end
+
+    it 'returns false if criteria are not met' do
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+        recap?: true,
+        scsb_in_library_use?: true,
+        eligible_for_library_services?: true
+      )
+      eligibility = described_class.new(requestable:)
+
+      expect(eligibility.eligible?).to be(false)
+    end
+  end
+end

--- a/spec/models/requests/service_eligibility/recap/digitize_spec.rb
+++ b/spec/models/requests/service_eligibility/recap/digitize_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Requests::ServiceEligibility::Recap::Digitize, requests: true do
+  describe '#eligible?' do
+    it 'returns true if all criteria are met' do
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+        recap?: true,
+        recap_pf?: false,
+        recap_edd?: true,
+        item_data?: true,
+        scsb_in_library_use?: false
+      )
+      eligibility = described_class.new(requestable:, user: FactoryBot.create(:user))
+
+      expect(eligibility.eligible?).to be(true)
+    end
+
+    it 'returns false if criteria are not met' do
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+        recap?: true,
+        recap_pf?: false,
+        recap_edd?: false
+      )
+      eligibility = described_class.new(requestable:, user: FactoryBot.create(:user))
+
+      expect(eligibility.eligible?).to be(false)
+    end
+  end
+end

--- a/spec/models/requests/service_eligibility/recap/in_library_spec.rb
+++ b/spec/models/requests/service_eligibility/recap/in_library_spec.rb
@@ -2,6 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Requests::ServiceEligibility::Recap::InLibrary, requests: true do
+  let(:user) { FactoryBot.create(:user) }
   describe '#eligible?' do
     it 'returns true if all criteria are met' do
       requestable = instance_double(Requests::Requestable)
@@ -13,7 +14,7 @@ RSpec.describe Requests::ServiceEligibility::Recap::InLibrary, requests: true do
         recap_edd?: true,
         recap_pf?: true
       )
-      eligibility = described_class.new(requestable:)
+      eligibility = described_class.new(requestable:, user:)
 
       expect(eligibility.eligible?).to be(true)
     end
@@ -28,7 +29,7 @@ RSpec.describe Requests::ServiceEligibility::Recap::InLibrary, requests: true do
         recap_edd?: true,
         recap_pf?: false
       )
-      eligibility = described_class.new(requestable:)
+      eligibility = described_class.new(requestable:, user:)
 
       expect(eligibility.eligible?).to be(false)
     end

--- a/spec/models/requests/service_eligibility/recap/in_library_spec.rb
+++ b/spec/models/requests/service_eligibility/recap/in_library_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Requests::ServiceEligibility::Recap::InLibrary, requests: true do
+  describe '#eligible?' do
+    it 'returns true if all criteria are met' do
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+        recap?: true,
+        scsb_in_library_use?: true,
+        item: { collection_code: "not_MR" },
+        circulates?: false,
+        recap_edd?: true,
+        recap_pf?: true
+      )
+      eligibility = described_class.new(requestable:)
+
+      expect(eligibility.eligible?).to be(true)
+    end
+
+    it 'returns false if criteria are not met' do
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+        recap?: true,
+        scsb_in_library_use?: true,
+        item: { collection_code: "MR" },
+        circulates?: false,
+        recap_edd?: true,
+        recap_pf?: false
+      )
+      eligibility = described_class.new(requestable:)
+
+      expect(eligibility.eligible?).to be(false)
+    end
+  end
+end

--- a/spec/models/requests/service_eligibility/recap/no_items_spec.rb
+++ b/spec/models/requests/service_eligibility/recap/no_items_spec.rb
@@ -2,6 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe Requests::ServiceEligibility::Recap::NoItems, requests: true do
+  let(:user) { FactoryBot.create(:user) }
   describe '#eligible?' do
     it 'returns true if all criteria are met' do
       requestable = instance_double(Requests::Requestable)
@@ -10,7 +11,7 @@ RSpec.describe Requests::ServiceEligibility::Recap::NoItems, requests: true do
         recap?: true,
         recap_pf?: false
       )
-      eligibility = described_class.new(requestable:)
+      eligibility = described_class.new(requestable:, user:)
 
       expect(eligibility.eligible?).to be(true)
     end
@@ -22,7 +23,7 @@ RSpec.describe Requests::ServiceEligibility::Recap::NoItems, requests: true do
         recap?: true,
         recap_pf?: false
       )
-      eligibility = described_class.new(requestable:)
+      eligibility = described_class.new(requestable:, user:)
 
       expect(eligibility.eligible?).to be(false)
     end

--- a/spec/models/requests/service_eligibility/recap/no_items_spec.rb
+++ b/spec/models/requests/service_eligibility/recap/no_items_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Requests::ServiceEligibility::Recap::NoItems, requests: true do
+  describe '#eligible?' do
+    it 'returns true if all criteria are met' do
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+        item_data?: false,
+        recap?: true,
+        recap_pf?: false
+      )
+      eligibility = described_class.new(requestable:)
+
+      expect(eligibility.eligible?).to be(true)
+    end
+
+    it 'returns false if criteria are not met' do
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+        item_data?: true,
+        recap?: true,
+        recap_pf?: false
+      )
+      eligibility = described_class.new(requestable:)
+
+      expect(eligibility.eligible?).to be(false)
+    end
+  end
+end

--- a/spec/models/requests/service_eligibility/recap/pickup_spec.rb
+++ b/spec/models/requests/service_eligibility/recap/pickup_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Requests::ServiceEligibility::Recap::Pickup, requests: true do
+  describe '#eligible?' do
+    it 'returns true if all criteria are met' do
+      user = FactoryBot.build(:valid_princeton_patron)
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+        recap?: true,
+        recap_pf?: false,
+        holding_library_in_library_only?: false,
+        circulates?: true,
+        eligible_for_library_services?: true,
+        item_data?: true,
+        scsb_in_library_use?: false
+      )
+      eligibility = described_class.new(requestable:, user:)
+
+      expect(eligibility.eligible?).to be(true)
+    end
+
+    it 'returns false if criteria are not met' do
+      user = FactoryBot.build(:valid_princeton_patron)
+
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+        recap?: true,
+        recap_pf?: false,
+        holding_library_in_library_only?: true,
+        circulates?: false,
+        eligible_for_library_services?: false,
+        item_data?: true
+      )
+      eligibility = described_class.new(requestable:, user:)
+
+      expect(eligibility.eligible?).to be(false)
+    end
+  end
+end

--- a/spec/models/requests/service_eligibility/recap/pickup_spec.rb
+++ b/spec/models/requests/service_eligibility/recap/pickup_spec.rb
@@ -2,9 +2,9 @@
 require 'rails_helper'
 
 RSpec.describe Requests::ServiceEligibility::Recap::Pickup, requests: true do
+  let(:user) { FactoryBot.create(:user) }
   describe '#eligible?' do
     it 'returns true if all criteria are met' do
-      user = FactoryBot.build(:valid_princeton_patron)
       requestable = instance_double(Requests::Requestable)
       allow(requestable).to receive_messages(
         recap?: true,
@@ -21,8 +21,6 @@ RSpec.describe Requests::ServiceEligibility::Recap::Pickup, requests: true do
     end
 
     it 'returns false if criteria are not met' do
-      user = FactoryBot.build(:valid_princeton_patron)
-
       requestable = instance_double(Requests::Requestable)
       allow(requestable).to receive_messages(
         recap?: true,


### PR DESCRIPTION
There are no cases where `recap?` would be false and `recap_pf?` would be true, so remove that check

Add the `return false unless requestable.recap?` to class so that the `requestable_eligible?` method will be accurate no matter where you call it from (rather than assuming it's being called from its present logical branch)

Closes #4250
Closes #4251
Closes #4252
Closes #4253
Closes #4255