### PR TITLE
[#4299] Requests::Holding#to_h should have the actual MFHD id as the hash key, rather than the literal symbol :mfhd_id

### DIFF
--- a/app/models/requests/holding.rb
+++ b/app/models/requests/holding.rb
@@ -13,7 +13,7 @@ module Requests
     attr_reader :holding_data, :mfhd_id
 
     def to_h
-      { mfhd_id: holding_data }
+      Hash[mfhd_id, holding_data].with_indifferent_access
     end
   end
 end

--- a/spec/models/requests/holding_spec.rb
+++ b/spec/models/requests/holding_spec.rb
@@ -20,4 +20,29 @@ RSpec.describe Requests::Holding, requests: true do
       expect(holding.holding_data['location_code']).to be_nil
     end
   end
+  describe '#to_h' do
+    it 'returns a hash with the mfhd_id as the key' do
+      holding = described_class.new(
+        mfhd_id: "22654362360006421",
+        holding_data: JSON.parse('{"location_code":"rare$ga","location":"Graphic Arts Collection","library":"Special Collections","call_number":"2012-0145Q","call_number_browse":"2012-0145Q","items":[{"holding_id":"22654362360006421","id":"23654362330006421","status_at_load":"1","barcode":"32101051826913","copy_number":"1"}]}')
+      )
+      expect(holding.to_h).to eq({
+                                   "22654362360006421" => { "location_code" => "rare$ga", "location" => "Graphic Arts Collection", "library" => "Special Collections", "call_number" => "2012-0145Q", "call_number_browse" => "2012-0145Q", "items" => [{ "holding_id" => "22654362360006421", "id" => "23654362330006421", "status_at_load" => "1", "barcode" => "32101051826913", "copy_number" => "1" }] }
+                                 })
+    end
+    it 'can access the data with a symbol key' do
+      holding = described_class.new(
+        mfhd_id: "22654362360006421",
+        holding_data: JSON.parse('{"location_code":"rare$ga","location":"Graphic Arts Collection","library":"Special Collections","call_number":"2012-0145Q","call_number_browse":"2012-0145Q","items":[{"holding_id":"22654362360006421","id":"23654362330006421","status_at_load":"1","barcode":"32101051826913","copy_number":"1"}]}')
+      )
+      expect(holding.to_h[:'22654362360006421'][:location_code]).to eq 'rare$ga'
+    end
+    it 'can access the data with a string key' do
+      holding = described_class.new(
+        mfhd_id: "22654362360006421",
+        holding_data: JSON.parse('{"location_code":"rare$ga","location":"Graphic Arts Collection","library":"Special Collections","call_number":"2012-0145Q","call_number_browse":"2012-0145Q","items":[{"holding_id":"22654362360006421","id":"23654362330006421","status_at_load":"1","barcode":"32101051826913","copy_number":"1"}]}')
+      )
+      expect(holding.to_h['22654362360006421']['location_code']).to eq 'rare$ga'
+    end
+  end
 end


### PR DESCRIPTION
closes #4299 