### PR TITLE
Refactor FullPatron to use existing Bibdata Service

### DIFF
--- a/app/controllers/account_controller.rb
+++ b/app/controllers/account_controller.rb
@@ -87,6 +87,6 @@ class AccountController < ApplicationController
   private
 
     def current_patron(user)
-      Bibdata.get_patron(user)
+      Bibdata.get_patron(user, ldap: false)
     end
 end

--- a/app/models/requests/full_patron.rb
+++ b/app/models/requests/full_patron.rb
@@ -2,58 +2,9 @@
 module Requests
   # FullPatron pulls all available data from both Alma and LDAP via Bibdata
   class FullPatron
-    attr_reader :hash, :errors
-    def initialize(uid:)
-      @errors = []
-      @uid = uid
-      @hash = patron_hash
+    attr_reader :hash
+    def initialize(user: nil)
+      @hash = ::Bibdata.get_patron(user, ldap: true)
     end
-
-    private
-
-      def request_uri
-        "#{Requests.config[:bibdata_base]}/patron/#{uid}?ldap=true"
-      end
-
-      def bibdata_response
-        response = Faraday.get(request_uri)
-        log_errors(response)
-        return response if [500, 429, 404, 403].exclude?(response.status) && response.body.present?
-
-        nil
-      rescue Faraday::ConnectionFailed
-        Rails.logger.error("Unable to connect to #{request_uri}")
-        nil
-      end
-
-      def log_errors(response)
-        case response.status
-        when 500
-          Rails.logger.error('Error Patron Data Service.')
-        when 429
-          error_message = "The maximum number of HTTP requests per second for the Alma API has been exceeded."
-          Rails.logger.error(error_message)
-          errors << error_message
-        when 404
-          Rails.logger.error("404 Patron #{uid} cannot be found in the Patron Data Service.")
-        when 403
-          Rails.logger.error("403 Not Authorized to Connect to Patron Data Service at #{request_uri} for patron ID #{uid}")
-        else
-          Rails.logger.error("#{request_uri} returned an empty patron response") if response.body.empty?
-        end
-      end
-
-      # Patron hash based on the Bibdata patron API, which combines Alma and LDAP responses
-      def patron_hash
-        @api_response = bibdata_response
-        return if api_response.blank?
-        response_body = api_response.body
-        JSON.parse(response_body).with_indifferent_access
-      rescue JSON::ParserError
-        Rails.logger.error("#{request_uri} returned an invalid patron response: #{response_body}")
-        false
-      end
-
-      attr_reader :api_response, :uid
   end
 end

--- a/app/models/requests/patron.rb
+++ b/app/models/requests/patron.rb
@@ -104,9 +104,7 @@ module Requests
         if alma_provider?
           AlmaPatron.new(uid:).hash
         else
-          full_patron = FullPatron.new(uid:)
-          errors.concat(full_patron.errors)
-          full_patron.hash
+          FullPatron.new(user:).hash
         end
       end
   end

--- a/app/services/bibdata.rb
+++ b/app/services/bibdata.rb
@@ -6,14 +6,16 @@ class Bibdata
   class PerSecondThresholdError < StandardError; end
   class ResourceNotFoundError < StandardError; end
   class ForbiddenError < StandardError; end
+  class EmptyResponseError < StandardError; end
 
   class << self
     # rubocop:disable Metrics/MethodLength
     # ignore rubocop warnings; complexity and length step from error checking.
-    def get_patron(user)
+    def get_patron(user, ldap:)
       return unless user.uid
 
-      api_response = api_request_patron(id: user.uid)
+      patron_uri = patron_uri(id: user.uid, ldap:)
+      api_response = api_request_patron(patron_uri:)
 
       build_api_patron(api_response:, user:)
     rescue ServerError
@@ -30,6 +32,9 @@ class Bibdata
       nil
     rescue Faraday::ConnectionFailed
       Rails.logger.error("Unable to connect to #{api_base_uri}")
+      nil
+    rescue EmptyResponseError
+      Rails.logger.error("#{patron_uri} returned an empty patron response")
       nil
     end
 
@@ -53,8 +58,8 @@ class Bibdata
         Requests.config['bibdata_base']
       end
 
-      def api_request_patron(id:)
-        api_response = Faraday.get("#{api_base_uri}/patron/#{id}")
+      def api_request_patron(patron_uri:)
+        api_response = Faraday.get(patron_uri)
 
         case api_response.status
         when 500
@@ -65,17 +70,26 @@ class Bibdata
           raise(ResourceNotFoundError)
         when 403
           raise(ForbiddenError)
+        else
+          raise(EmptyResponseError) if api_response.body.empty?
         end
 
         api_response
       end
 
+      def patron_uri(id:, ldap:)
+        "#{api_base_uri}/patron/#{id}?ldap=#{ldap}"
+      end
+
       def build_api_patron(api_response:, user:)
-        base_patron_json = JSON.parse(api_response.body)
+        response_body = api_response.body
+        base_patron_json = JSON.parse(response_body)
         patron_json = base_patron_json.merge(
           valid: user.valid?
         )
         patron_json.with_indifferent_access
+      rescue JSON::ParserError
+        Rails.logger.error("#{api_response.env.url} returned an invalid patron response: #{response_body}")
       end
 
       def sorted_locations(response)

--- a/spec/controllers/account_controller_spec.rb
+++ b/spec/controllers/account_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe AccountController do
 
     before do
       sign_in(valid_user)
-      valid_patron_record_uri = "#{Requests.config['bibdata_base']}/patron/#{valid_user.uid}"
+      valid_patron_record_uri = "#{Requests.config['bibdata_base']}/patron/#{valid_user.uid}?ldap=false"
       stub_request(:get, valid_patron_record_uri)
         .to_return(status: 200, body: valid_patron_response, headers: {})
     end
@@ -86,7 +86,7 @@ RSpec.describe AccountController do
 
     before do
       sign_in(valid_user)
-      valid_patron_record_uri = "#{Requests.config['bibdata_base']}/patron/#{valid_user.uid}"
+      valid_patron_record_uri = "#{Requests.config['bibdata_base']}/patron/#{valid_user.uid}?ldap=false"
       cancel_ill_requests_uri = "#{Requests.config[:illiad_api_base]}/ILLiadWebPlatform/transaction/#{params_cancel_requests[0]}/route"
       stub_request(:get, valid_patron_record_uri)
         .to_return(status: 200, body: valid_patron_response, headers: {})
@@ -128,7 +128,7 @@ RSpec.describe AccountController do
     let(:unauthorized_user) { FactoryBot.create(:unauthorized_princeton_patron) }
 
     it 'returns Princeton Patron Account Data using a persisted User Model' do
-      valid_patron_record_uri = "#{Requests.config['bibdata_base']}/patron/#{valid_user.uid}"
+      valid_patron_record_uri = "#{Requests.config['bibdata_base']}/patron/#{valid_user.uid}?ldap=false"
       stub_request(:get, valid_patron_record_uri)
         .to_return(status: 200, body: valid_patron_response, headers: {})
 

--- a/spec/mailers/requests/request_mailer_spec.rb
+++ b/spec/mailers/requests/request_mailer_spec.rb
@@ -9,7 +9,7 @@ describe Requests::RequestMailer, type: :mailer, vcr: { cassette_name: 'mailer',
 
   let(:user_info) do
     stub_request(:get, "#{Requests.config[:bibdata_base]}/patron/foo?ldap=true").to_return(status: 200, body: valid_patron_response, headers: {})
-    user = instance_double(User, guest?: false, uid: 'foo', alma_provider?: false)
+    user = instance_double(User, guest?: false, uid: 'foo', alma_provider?: false, valid?: true)
     Requests::Patron.new(user:)
   end
 

--- a/spec/models/requests/full_patron_spec.rb
+++ b/spec/models/requests/full_patron_spec.rb
@@ -2,24 +2,22 @@
 require 'rails_helper'
 
 RSpec.describe Requests::FullPatron, requests: true do
+  let(:user) { FactoryBot.create(:user, uid: 'abc123') }
+
   it 'can be instantiated' do
-    expect(described_class.new(uid: 'string')).to be
+    expect(described_class.new(user:)).to be
   end
 
   context 'with a patron' do
-    let(:patron) { described_class.new(uid: 'abc123') }
+    let(:patron) { described_class.new(user:) }
     let(:valid_patron_response) { fixture('/bibdata_patron_response.json') }
     let(:bibdata_mock) do
       stub_request(:get, "#{Requests.config[:bibdata_base]}/patron/abc123?ldap=true")
         .to_return(status: 200, body: valid_patron_response, headers: {})
     end
 
-    it 'has access to errors' do
-      expect(patron.errors).to match_array([])
-    end
-
     it 'makes a call to bibdata' do
-      described_class.new(uid: 'abc123')
+      described_class.new(user:)
       expect(bibdata_mock).to have_been_requested
     end
   end

--- a/spec/models/requests/patron_spec.rb
+++ b/spec/models/requests/patron_spec.rb
@@ -16,7 +16,7 @@ describe Requests::Patron, requests: true do
   let(:guest?) { false }
   let(:provider) { nil }
   let(:user) do
-    instance_double(User, guest?: guest?, uid:, alma_provider?: false, provider:)
+    instance_double(User, guest?: guest?, uid:, alma_provider?: false, provider:, valid?: true)
   end
   let(:bibdata_uri) { Requests.config[:bibdata_base] }
   let(:valid_patron_response) { fixture('/bibdata_patron_response.json') }
@@ -124,8 +124,8 @@ describe Requests::Patron, requests: true do
         )
       end
 
-      it 'logs errors for the patron' do
-        expect(patron.errors).to include("The maximum number of HTTP requests per second for the Alma API has been exceeded.")
+      it 'raises an error' do
+        expect { patron.errors }.to raise_error(Bibdata::PerSecondThresholdError)
       end
     end
   end
@@ -138,7 +138,7 @@ describe Requests::Patron, requests: true do
     it 'logs the error' do
       allow(Rails.logger).to receive(:error)
       described_class.new(user:)
-      expect(Rails.logger).to have_received(:error).with("Unable to connect to #{bibdata_uri}/patron/foo?ldap=true")
+      expect(Rails.logger).to have_received(:error).with("Unable to connect to #{bibdata_uri}")
     end
   end
   context 'when bibdata passes on an html response' do

--- a/spec/requests/accounts_spec.rb
+++ b/spec/requests/accounts_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe AccountController do
                  })
     stub_request(:get, current_illiad_user_uri)
       .to_return(status: 200, body: verify_user_response)
-    valid_patron_record_uri = "#{Requests.config['bibdata_base']}/patron/#{valid_user.uid}"
+    valid_patron_record_uri = "#{Requests.config['bibdata_base']}/patron/#{valid_user.uid}?ldap=false"
     stub_request(:get, valid_patron_record_uri)
       .to_return(status: 200, body: valid_patron_response, headers: {})
   end

--- a/spec/services/bibdata_spec.rb
+++ b/spec/services/bibdata_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Bibdata do
   end
 
   describe '.get_patron' do
-    subject(:patron) { described_class.get_patron(patron_user) }
+    subject(:patron) { described_class.get_patron(patron_user, ldap: false) }
 
     let(:patron_user) { User.create(username: "bbird", uid: "bbird") }
     let(:patron_valid) { patron_user.valid? }


### PR DESCRIPTION
Dries up code significantly

The only functional change is that it does not display a flash message to a user specifying the Alma API as the issue with their login when that occurs - I cannot think why this level of specificity would be helpful to the user, but I could be missing something!