### PR TITLE
Use new tower template for continuous deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ jobs:
     steps:
       - run:
           name: Deploy to Staging
-          command: "curl -k \"https://ansible-tower.princeton.edu/api/v2/job_templates/13/launch/\" --header \"Content-Type: application/json\" --header \"Authorization: Bearer $TOWER_TOKEN\" -d '{\"credential_passwords\":{},\"extra_vars\":{\"repo_name\":\"orangelight\",\"branch_name\":\"main\",\"runtime_env\":\"staging\",\"slack_alerts_channel\":\"ansible-alerts\"}}'"
+          command: "curl -k \"https://ansible-tower.princeton.edu/api/v2/job_templates/57/launch/\" --header \"Content-Type: application/json\" --header \"Authorization: Bearer $TOWER_TOKEN\" -d '{\"credential_passwords\":{},\"extra_vars\":{\"repo_name\":\"orangelight\",\"branch_name\":\"main\",\"runtime_env\":\"staging\",\"slack_alerts_channel\":\"ansible-alerts\"}}'"
 
 workflows:
   build_accept:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,7 +203,7 @@ jobs:
     steps:
       - run:
           name: Deploy to Staging
-          command: "curl -k \"https://ansible-tower.princeton.edu/api/v2/job_templates/57/launch/\" --header \"Content-Type: application/json\" --header \"Authorization: Bearer $TOWER_TOKEN\" -d '{\"credential_passwords\":{},\"extra_vars\":{\"repo_name\":\"orangelight\",\"branch_name\":\"main\",\"runtime_env\":\"staging\",\"slack_alerts_channel\":\"ansible-alerts\"}}'"
+          command: "curl -k \"https://ansible-tower.princeton.edu/api/v2/job_templates/57/launch/\" --header \"Content-Type: application/json\" --header \"Authorization: Bearer $TOWER_TOKEN\" -d '{\"credential_passwords\":{},\"extra_vars\":{\"repo_name\":\"orangelight\",\"runtime_env\":\"staging\",\"slack_alerts_channel\":\"ansible-alerts\"}}'"
 
 workflows:
   build_accept:


### PR DESCRIPTION
In order to enhance security, we are using a template that only runs on the main branch of princeton ansible and deploys only the main branch of orangelight for continuous deployment.