### PR TITLE
Refactor AeonURL

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -191,7 +191,6 @@ detectors:
     - Requests::Form#off_site?
     - Requests::Form#serial?
     - Requests::Form#status_label
-    - Requests::FullPatron#log_errors
     - Requests::Illiad#au_params
     - Requests::Illiad#genere
     - Requests::Illiad#get_identifier
@@ -207,9 +206,9 @@ detectors:
     - Requests::IlliadMetadata::ArticleExpress#map_metdata
     - Requests::IlliadMetadata::ArticleExpress#volume_number
     - Requests::IlliadTransactionClient#create_request
-    - Requests::Location#sort_pick_ups
     - Requests::Item#copy_value
     - Requests::Item#status
+    - Requests::Location#sort_pick_ups
     - Requests::Requestable#pick_up_locations
     - Requests::Requestable#scsb_pick_up_override
     - Requests::RequestableDecorator#libcal_url
@@ -374,8 +373,8 @@ detectors:
     - Blacklight::Marc::BookCtxBuilder
     - Requests::Form
     - Requests::Illiad
-    - Requests::NonAlmaAeonUrl
     - Requests::Item
+    - Requests::NonAlmaAeonUrl
     - Requests::Submission
     - Requests::Submissions::Clancy
     - Requests::Submissions::ClancyEdd
@@ -467,10 +466,10 @@ detectors:
     - Requests::IlliadMetadata::Loan
     - Requests::IlliadMetadata::Metadata
     - Requests::IlliadTransactionClient
-    - Requests::Libcal
-    - Requests::Patron
     - Requests::Item
-    - Requests::Requestable::NullItem
+    - Requests::Libcal
+    - Requests::NullItem
+    - Requests::Patron
     - Requests::RequestableDecorator
     - Requests::SelectedItemsValidator
     - Requests::ServiceEligibility::AbstractOnShelf
@@ -506,6 +505,7 @@ detectors:
     - Orangelight::SubjectsOrNotesProcessor
     - AdvancedSearchConstraint
     - Bibdata
+    - Bibdata::EmptyResponseError
     - Bibdata::ForbiddenError
     - Bibdata::PerSecondThresholdError
     - Bibdata::ResourceNotFoundError
@@ -693,10 +693,10 @@ detectors:
     - Requests::AeonUrl
     - Requests::Form
     - Requests::FormDecorator
-    - Requests::Location
-    - Requests::Patron
     - Requests::Item
-    - Requests::Requestable::NullItem
+    - Requests::Location
+    - Requests::NullItem
+    - Requests::Patron
     - Requests::Requestable
     - Requests::RequestableDecorator
     - Requests::Submission
@@ -792,9 +792,6 @@ detectors:
     - Requests::Form#build_requestable_with_items
     - Requests::Form#route_requests
     - Requests::FormDecorator#any_fill_in_eligible?
-    - Requests::FullPatron#bibdata_response
-    - Requests::FullPatron#log_errors
-    - Requests::FullPatron#patron_hash
     - Requests::Illiad#get_identifier
     - Requests::Illiad#map_metdata
     - Requests::IlliadClient#get_json_response

--- a/.reek.yml
+++ b/.reek.yml
@@ -208,8 +208,8 @@ detectors:
     - Requests::IlliadMetadata::ArticleExpress#volume_number
     - Requests::IlliadTransactionClient#create_request
     - Requests::Location#sort_pick_ups
-    - Requests::Requestable::Item#copy_value
-    - Requests::Requestable::Item#status
+    - Requests::Item#copy_value
+    - Requests::Item#status
     - Requests::Requestable#pick_up_locations
     - Requests::Requestable#scsb_pick_up_override
     - Requests::RequestableDecorator#libcal_url
@@ -375,7 +375,7 @@ detectors:
     - Requests::Form
     - Requests::Illiad
     - Requests::NonAlmaAeonUrl
-    - Requests::Requestable::Item
+    - Requests::Item
     - Requests::Submission
     - Requests::Submissions::Clancy
     - Requests::Submissions::ClancyEdd
@@ -469,7 +469,7 @@ detectors:
     - Requests::IlliadTransactionClient
     - Requests::Libcal
     - Requests::Patron
-    - Requests::Requestable::Item
+    - Requests::Item
     - Requests::Requestable::NullItem
     - Requests::RequestableDecorator
     - Requests::SelectedItemsValidator
@@ -695,7 +695,7 @@ detectors:
     - Requests::FormDecorator
     - Requests::Location
     - Requests::Patron
-    - Requests::Requestable::Item
+    - Requests::Item
     - Requests::Requestable::NullItem
     - Requests::Requestable
     - Requests::RequestableDecorator
@@ -992,8 +992,8 @@ detectors:
     - Requests::IlliadMetadata::Loan#volume_number
     - Requests::IlliadTransactionClient#disavowed_illiad_patron?
     - Requests::IlliadTransactionClient#validate_illiad_patron
-    - Requests::Requestable::Item#available_statuses
-    - Requests::Requestable::Item#unavailable_statuses
+    - Requests::Item#available_statuses
+    - Requests::Item#unavailable_statuses
     - Requests::SelectedItemsValidator#validate_delivery_mode
     - Requests::SelectedItemsValidator#validate_item_id
     - Requests::SelectedItemsValidator#validate_pick_up_location

--- a/app/models/requests/aeon_url.rb
+++ b/app/models/requests/aeon_url.rb
@@ -27,8 +27,8 @@ module Requests
         ctx = @document.to_ctx
         if item.present?
           ctx.referent.set_metadata('iteminfo5', item['id']&.to_s)
-          if enum_value.present?
-            ctx.referent.set_metadata('volume', enum_value)
+          if item.enum_value.present?
+            ctx.referent.set_metadata('volume', item.enum_value)
             ctx.referent.set_metadata('issue', item[:chron_display]) if item[:chron_display].present?
           else
             ctx.referent.set_metadata('volume', holding['location_has']&.first)
@@ -46,7 +46,7 @@ module Requests
           Location: shelf_location_code,
           SubLocation: sub_location,
           ItemInfo1: I18n.t("requests.aeon.access_statement"),
-          ItemNumber: item&.fetch('barcode', nil)
+          ItemNumber: item&.barcode
         }.compact
       end
 
@@ -54,20 +54,18 @@ module Requests
         @holding ||= @document.holdings_all_display.values.first
       end
 
-      def enum_value
-        [item['enum_display'], item['enumeration']].join(" ").strip
-      end
-
       def item
-        @item ||= item_from_holding || item_from_document
+        @item ||= item_from_holding || item_from_document || Item.new({})
       end
 
       def item_from_holding
-        holding&.fetch('items', nil)&.first
+        item_hash = holding&.fetch('items', nil)&.first
+        Item.new(item_hash.with_indifferent_access) if item_hash
       end
 
       def item_from_document
-        @document.holdings_all_display.values.first&.fetch('items', nil)&.first
+        item_hash = @document.holdings_all_display.values.first&.fetch('items', nil)&.first
+        Item.new(item_hash.with_indifferent_access) if item_hash
       end
 
       def at_marquand?

--- a/app/models/requests/aeon_url.rb
+++ b/app/models/requests/aeon_url.rb
@@ -59,14 +59,14 @@ module Requests
       end
 
       def item
-        @item ||= barcode_from_holding || barcode_from_document
+        @item ||= item_from_holding || item_from_document
       end
 
-      def barcode_from_holding
+      def item_from_holding
         holding&.fetch('items', nil)&.first
       end
 
-      def barcode_from_document
+      def item_from_document
         @document.holdings_all_display.values.first&.fetch('items', nil)&.first
       end
 

--- a/app/models/requests/aeon_url.rb
+++ b/app/models/requests/aeon_url.rb
@@ -4,7 +4,7 @@ module Requests
   class AeonUrl
     # @param document [SolrDocument]
     # @param holding [Hash]
-    # @param item [Requests::Requestable::Item]
+    # @param item [Requests::Item]
     def initialize(document:, holding: nil, item: nil)
       @document = document
       @holding = holding.values.first if holding

--- a/app/models/requests/item.rb
+++ b/app/models/requests/item.rb
@@ -110,7 +110,7 @@ module Requests
     end
 
     def partner_holding?
-      Requests.config[:recap_partner_locations].keys.include? self["location_code"]
+      Requests.config[:recap_partner_locations].key?(self["location_code"])
     end
 
     # The location code (e.g. firestone$pf)

--- a/app/models/requests/item.rb
+++ b/app/models/requests/item.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class Requests::Requestable
+module Requests
   class Item < SimpleDelegator
     def pick_up_location_code
       self['pickup_location_code'] || ""

--- a/app/models/requests/null_item.rb
+++ b/app/models/requests/null_item.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-class Requests::Requestable
-  class NullItem < Requests::Requestable::Item
+module Requests
+  class NullItem < Requests::Item
     def nil?
       true
     end

--- a/spec/helpers/requests/application_helper_spec.rb
+++ b/spec/helpers/requests/application_helper_spec.rb
@@ -219,7 +219,7 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
     end
 
     context "no services enum" do
-      let(:stubbed_questions) { { no_services?: true, preferred_request_id: '123', title: 'My Title', item: Requests::Requestable::Item.new({ enum_display: "abc123" }.with_indifferent_access) } }
+      let(:stubbed_questions) { { no_services?: true, preferred_request_id: '123', title: 'My Title', item: Requests::Item.new({ enum_display: "abc123" }.with_indifferent_access) } }
       it 'a message for lewis' do
         expect(helper.show_service_options(requestable, 'acb')).to eq \
           "<div class=\"sr-only\">My Title abc123 Item is not requestable.</div>" \
@@ -330,35 +330,35 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
     let(:requestable) { instance_double(Requests::RequestableDecorator, stubbed_questions) }
 
     context "no services" do
-      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Requestable::Item.new({ 'id' => "aaabbb" }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
+      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Item.new({ 'id' => "aaabbb" }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
       it 'shows hidden fields' do
         expect(helper.hidden_fields_item(requestable)).to eq '<input type="hidden" name="requestable[][bibid]" id="requestable_bibid_aaabbb" value="abc123" autocomplete="off" /><input type="hidden" name="requestable[][mfhd]" id="requestable_mfhd_aaabbb" value="mfhd1" autocomplete="off" /><input type="hidden" name="requestable[][location_code]" id="requestable_location_aaabbb" value="" autocomplete="off" /><input type="hidden" name="requestable[][item_id]" id="requestable_item_id_aaabbb" value="aaabbb" autocomplete="off" /><input type="hidden" name="requestable[][copy_number]" id="requestable_copy_number_aaabbb" value="" autocomplete="off" /><input type="hidden" name="requestable[][status]" id="requestable_status_aaabbb" value="" autocomplete="off" />'
       end
     end
 
     context "with item location" do
-      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Requestable::Item.new({ 'id' => "aaabbb", 'location' => 'place' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: 'place' } }
+      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Item.new({ 'id' => "aaabbb", 'location' => 'place' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: 'place' } }
       it 'shows hidden fields' do
         expect(helper.hidden_fields_item(requestable)).to include '<input type="hidden" name="requestable[][location_code]" id="requestable_location_aaabbb" value="place" autocomplete="off" />'
       end
     end
 
     context "with item barcode" do
-      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Requestable::Item.new({ 'id' => "aaabbb", 'barcode' => '111222333' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
+      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Item.new({ 'id' => "aaabbb", 'barcode' => '111222333' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
       it 'shows hidden fields' do
         expect(helper.hidden_fields_item(requestable)).to include '<input type="hidden" name="requestable[][barcode]" id="requestable_barcode_aaabbb" value="111222333" autocomplete="off" />'
       end
     end
 
     context "with item enum" do
-      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Requestable::Item.new({ 'id' => "aaabbb", 'enum_display' => 'vvv' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
+      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Item.new({ 'id' => "aaabbb", 'enum_display' => 'vvv' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
       it 'shows hidden fields' do
         expect(helper.hidden_fields_item(requestable)).to include '<input type="hidden" name="requestable[][enum]" id="requestable_enum_aaabbb" value="vvv" autocomplete="off" />'
       end
     end
 
     context "with item enumeration" do
-      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Requestable::Item.new({ id: "aaabbb", enumeration: 'sss', copy_number: '0', enum_display: 'v.2' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
+      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Item.new({ id: "aaabbb", enumeration: 'sss', copy_number: '0', enum_display: 'v.2' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
       it 'shows hidden fields' do
         expect(helper.hidden_fields_item(requestable)).to include '<input type="hidden" name="requestable[][bibid]" id="requestable_bibid_aaabbb" value="abc123" autocomplete="off" />'
       end
@@ -368,7 +368,7 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
     end
 
     context "with item description" do
-      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Requestable::Item.new({ id: "aaabbb", description: 'v2 sss', copy_number: '0' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
+      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Item.new({ id: "aaabbb", description: 'v2 sss', copy_number: '0' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
       it 'shows hidden fields' do
         expect(helper.hidden_fields_item(requestable)).to include '<input type="hidden" name="requestable[][bibid]" id="requestable_bibid_aaabbb" value="abc123" autocomplete="off" />'
       end
@@ -378,7 +378,7 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
     end
 
     context "with item description and copy" do
-      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Requestable::Item.new({ id: "aaabbb", description: 'v2 sss', copy_number: '2' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
+      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Item.new({ id: "aaabbb", description: 'v2 sss', copy_number: '2' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
       it 'shows hidden fields' do
         expect(helper.hidden_fields_item(requestable)).to include '<input type="hidden" name="requestable[][bibid]" id="requestable_bibid_aaabbb" value="abc123" autocomplete="off" />'
       end
@@ -389,14 +389,14 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
 
     context "with holding call number" do
       let(:holding) { Requests::Holding.new(mfhd_id: "1594697", holding_data: { "location" => "Firestone Library", "library" => "Firestone Library", "location_code" => "f", "copy_number" => "0", "call_number" => "6251.9765", "call_number_browse" => "6251.9765" }) }
-      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Requestable::Item.new({ 'id' => "aaabbb" }.with_indifferent_access), holding:, location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
+      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Item.new({ 'id' => "aaabbb" }.with_indifferent_access), holding:, location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
       it 'shows hidden fields' do
         expect(helper.hidden_fields_item(requestable)).to include '<input type="hidden" name="requestable[][call_number]" id="requestable_call_number_aaabbb" value="6251.9765" autocomplete="off" />'
       end
     end
 
     context "scsb item" do
-      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Requestable::Item.new({ 'id' => "aaabbb" }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: true, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
+      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Item.new({ 'id' => "aaabbb" }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: true, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
       it 'shows hidden fields' do
         expect(helper.hidden_fields_item(requestable)).to eq '<input type="hidden" name="requestable[][bibid]" id="requestable_bibid_aaabbb" value="abc123" autocomplete="off" /><input type="hidden" name="requestable[][mfhd]" id="requestable_mfhd_aaabbb" value="mfhd1" autocomplete="off" /><input type="hidden" name="requestable[][location_code]" id="requestable_location_aaabbb" value="" autocomplete="off" /><input type="hidden" name="requestable[][item_id]" id="requestable_item_id_aaabbb" value="aaabbb" autocomplete="off" /><input type="hidden" name="requestable[][copy_number]" id="requestable_copy_number_aaabbb" value="" autocomplete="off" /><input type="hidden" name="requestable[][status]" id="requestable_status_aaabbb" value="" autocomplete="off" /><input type="hidden" name="requestable[][cgd]" id="requestable_cgd_aaabbb" value="" autocomplete="off" /><input type="hidden" name="requestable[][cc]" id="requestable_collection_code_aaabbb" value="" autocomplete="off" /><input type="hidden" name="requestable[][use_statement]" id="requestable_use_statement_aaabbb" value="" autocomplete="off" />'
       end

--- a/spec/models/requests/aeon_url_spec.rb
+++ b/spec/models/requests/aeon_url_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Requests::AeonUrl, requests: true do
   end
   context 'when a specific item is passed in' do
     subject do
-      item = Requests::Requestable::Item.new({ "barcode" => "32101071302192", "id" => "23667098960006421", "holding_id" => "22667098990006421", "copy_number" => "1", "status" => "Available", "status_label" => "Item in place", "status_source" => "base_status", "process_type" => nil, "on_reserve" => "N", "item_type" => "Closed", "pickup_location_id" => "rare", "pickup_location_code" => "rare", "location" => "rare$ctsn", "label" => "Special Collections - Cotsen Children's Library", "description" => "Vol 1: no. 1 - 4 Jan 2013 - Oct 2013", "enum_display" => "Vol 1: no. 1 - 4", "chron_display" => "Jan 2013 - Oct 2013", "in_temp_library" => false })
+      item = Requests::Item.new({ "barcode" => "32101071302192", "id" => "23667098960006421", "holding_id" => "22667098990006421", "copy_number" => "1", "status" => "Available", "status_label" => "Item in place", "status_source" => "base_status", "process_type" => nil, "on_reserve" => "N", "item_type" => "Closed", "pickup_location_id" => "rare", "pickup_location_code" => "rare", "location" => "rare$ctsn", "label" => "Special Collections - Cotsen Children's Library", "description" => "Vol 1: no. 1 - 4 Jan 2013 - Oct 2013", "enum_display" => "Vol 1: no. 1 - 4", "chron_display" => "Jan 2013 - Oct 2013", "in_temp_library" => false })
       described_class.new(document:, item:).to_s
     end
     it('takes the barcode from the item') do

--- a/spec/models/requests/aeon_url_spec.rb
+++ b/spec/models/requests/aeon_url_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Requests::AeonUrl, requests: true do
   end
   context 'when a specific item is passed in' do
     subject do
-      item = Requests::Item.new({ "barcode" => "32101071302192", "id" => "23667098960006421", "holding_id" => "22667098990006421", "copy_number" => "1", "status" => "Available", "status_label" => "Item in place", "status_source" => "base_status", "process_type" => nil, "on_reserve" => "N", "item_type" => "Closed", "pickup_location_id" => "rare", "pickup_location_code" => "rare", "location" => "rare$ctsn", "label" => "Special Collections - Cotsen Children's Library", "description" => "Vol 1: no. 1 - 4 Jan 2013 - Oct 2013", "enum_display" => "Vol 1: no. 1 - 4", "chron_display" => "Jan 2013 - Oct 2013", "in_temp_library" => false })
+      item = Requests::Item.new({ "barcode" => "32101071302192", "id" => "23667098960006421", "holding_id" => "22667098990006421", "copy_number" => "1", "status" => "Available", "status_label" => "Item in place", "status_source" => "base_status", "process_type" => nil, "on_reserve" => "N", "item_type" => "Closed", "pickup_location_id" => "rare", "pickup_location_code" => "rare", "location" => "rare$ctsn", "label" => "Special Collections - Cotsen Children's Library", "description" => "Vol 1: no. 1 - 4 Jan 2013 - Oct 2013", "enum_display" => "Vol 1: no. 1 - 4", "chron_display" => "Jan 2013 - Oct 2013", "in_temp_library" => false }.with_indifferent_access)
       described_class.new(document:, item:).to_s
     end
     it('takes the barcode from the item') do

--- a/spec/models/requests/requestable/item_spec.rb
+++ b/spec/models/requests/requestable/item_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Requests::Requestable::Item, requests: true do
+RSpec.describe Requests::Item, requests: true do
   describe '#location' do
     it 'returns the item location as a string' do
       item = described_class.new(


### PR DESCRIPTION
In preparation for work on pulibrary/bibdata#1827

- Stop nesting `Item` under `Requests::Requestable`, since it didn't autoload properly for use in `AeonUrl` while it was there.
- Consistently use the `Requests::Item` class within `AeonUrl`.  Before this PR, `item` could be either a `Hash` or a `Requests::Item`
- Use the existing `enum_value` and `barcode` methods from `Requests::Item`, rather than reimplementing that logic in `AeonUrl`