### PR TITLE
Rename bibdata-staging.princeton.edu to bibdata-staging.lib.princeton.edu

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,13 +47,13 @@ commands:
       # Restore bundle cache
       - restore_cache:
           keys:
-          - orangelight-v2-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
+          - orangelight-v3-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
       # Bundle install dependencies
       - run:
           name: Install dependencies
           command: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs 4 --retry 3
       - save_cache:
-          key: orangelight-v2-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
+          key: orangelight-v3-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
           paths:
             - ./vendor/bundle
 
@@ -71,13 +71,13 @@ jobs:
       - restore_cache:
           name: Restore cached dependencies
           keys:
-            - orangelight-v2-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
+            - orangelight-v3-{{ checksum "Gemfile.lock" }}-{{ checksum "yarn.lock" }}
       - run:
           name: Yarn Install
           command: yarn install --frozen-lockfile
       - save_cache:
           name: Save Yarn cache
-          key: orangelight-v2-yarn-{{ checksum "yarn.lock" }}
+          key: orangelight-v3-yarn-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,33 +133,33 @@ jobs:
             command: bundle exec yarn test
         - store_test_results:
             path: ~/rspec
-
-  lighthouse:
-    executor: orangelight-executor
-    steps:
-      - attach_workspace:
-          at: '~/orangelight'
-      - setup-bundler-and-node
-      - run:
-          name: Wait for DB
-          command: dockerize -wait tcp://localhost:5432 -timeout 1m
-      - run: sudo apt install postgresql-client
-      - run:
-          name: Database setup
-          command: bundle exec rake db:setup
-      - run:
-          name: Load config into solr
-          command: |
-            cd solr/conf
-            zip -1 -r solr_config.zip ./*
-            curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://solr:SolrRocks@127.0.0.1:8983/solr/admin/configs?action=UPLOAD&name=orangelight"
-            curl -H 'Content-type: application/json' http://solr:SolrRocks@127.0.0.1:8983/api/collections/  -d '{create: {name: orangelight-core-test, config: orangelight, numShards: 1}}'
-      - run:
-          name: Index Test Data
-          command: bundle exec rake pulsearch:solr:index
-      - browser-tools/install-chrome
-      - run: sudo npm install -g @lhci/cli@0.14.x
-      - run: lhci autorun
+  # See github ticket: https://github.com/pulibrary/orangelight/issues/4359
+  # lighthouse:
+  #   executor: orangelight-executor
+  #   steps:
+  #     - attach_workspace:
+  #         at: '~/orangelight'
+  #     - setup-bundler-and-node
+  #     - run:
+  #         name: Wait for DB
+  #         command: dockerize -wait tcp://localhost:5432 -timeout 1m
+  #     - run: sudo apt install postgresql-client
+  #     - run:
+  #         name: Database setup
+  #         command: bundle exec rake db:setup
+  #     - run:
+  #         name: Load config into solr
+  #         command: |
+  #           cd solr/conf
+  #           zip -1 -r solr_config.zip ./*
+  #           curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://solr:SolrRocks@127.0.0.1:8983/solr/admin/configs?action=UPLOAD&name=orangelight"
+  #           curl -H 'Content-type: application/json' http://solr:SolrRocks@127.0.0.1:8983/api/collections/  -d '{create: {name: orangelight-core-test, config: orangelight, numShards: 1}}'
+  #     - run:
+  #         name: Index Test Data
+  #         command: bundle exec rake pulsearch:solr:index
+  #     - browser-tools/install-chrome
+  #     - run: sudo npm install -g @lhci/cli@0.14.x
+  #     - run: lhci autorun
 
   rubocop:
     executor: basic-executor
@@ -217,9 +217,6 @@ workflows:
           - build
       - reek
       - js_tests:
-         requires:
-          - build
-      - lighthouse:
          requires:
           - build
       - test:

--- a/config/requests.yml
+++ b/config/requests.yml
@@ -25,7 +25,7 @@ development:
   bibdata_base: <%= ENV['BIBDATA_BASE'] || "https://bibdata.princeton.edu" %>
 test:
   <<: *defaults
-  bibdata_base: <%= ENV['BIBDATA_BASE'] || "https://bibdata-staging.princeton.edu" %>
+  bibdata_base: <%= ENV['BIBDATA_BASE'] || "https://bibdata-staging.lib.princeton.edu" %>
   illiad_api_key: 'TESTME'
   illiad_api_base: <%= ENV['ILLIAD_API_BASE_URL'] || "https://lib-illiad.princeton.edu" %>
 production:
@@ -34,7 +34,7 @@ staging:
   <<: *defaults
   aeon_base: https://princeton.aeon.atlas-sys.com/logon
   pulsearch_base: https://catalog-staging.princeton.edu
-  bibdata_base: <%= ENV['BIBDATA_BASE'] || "https://bibdata-staging.princeton.edu" %>
+  bibdata_base: <%= ENV['BIBDATA_BASE'] || "https://bibdata-staging.lib.princeton.edu" %>
 qa:
   <<: *defaults
   aeon_base: https://princeton.aeon.atlas-sys.com/logon

--- a/spec/cassettes/authorized_ol_authorized_bibdata_scsb_key.yml
+++ b/spec/cassettes/authorized_ol_authorized_bibdata_scsb_key.yml
@@ -69,7 +69,7 @@ http_interactions:
   recorded_at: Wed, 24 Aug 2022 17:39:53 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/scsbnypl.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/scsbnypl.json
     body:
       encoding: US-ASCII
       string: ''
@@ -116,7 +116,7 @@ http_interactions:
   recorded_at: Wed, 24 Aug 2022 17:39:53 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-7935196/holdings/8076325/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-7935196/holdings/8076325/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -158,7 +158,7 @@ http_interactions:
   recorded_at: Wed, 24 Aug 2022 17:39:53 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/delivery_locations.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/delivery_locations.json
     body:
       encoding: US-ASCII
       string: ''
@@ -199,51 +199,51 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"label":"Plasma Physics Library","address":"Forrestal Campus Princeton,
-        NJ 08544","phone_number":"609-243-3565","contact_email":"lewislib@princeton.edu","gfa_pickup":"PQ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/1.json","library":{"label":"Harold
+        NJ 08544","phone_number":"609-243-3565","contact_email":"lewislib@princeton.edu","gfa_pickup":"PQ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/1.json","library":{"label":"Harold
         P. Furth Plasma Physics Library","code":"plasma","order":0}},{"label":"Technical
-        Services 693","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/2.json","library":{"label":"Firestone
+        Services 693","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/2.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Architecture Library","address":"School
-        of Architecture Building, Second Floor Princeton, NJ 08544","phone_number":"609-258-3256","contact_email":"ues@princeton.edu","gfa_pickup":"PW","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/3.json","library":{"label":"Architecture
+        of Architecture Building, Second Floor Princeton, NJ 08544","phone_number":"609-258-3256","contact_email":"ues@princeton.edu","gfa_pickup":"PW","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/3.json","library":{"label":"Architecture
         Library","code":"arch","order":0}},{"label":"East Asian Library","address":"Frist
-        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"PL","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/4.json","library":{"label":"East
+        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"PL","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/4.json","library":{"label":"East
         Asian Library","code":"eastasian","order":0}},{"label":"Engineering Library","address":"Friend
-        Center for Engineering Education Princeton, NJ 08544","phone_number":"609-258-3200","contact_email":"englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/5.json","library":{"label":"Engineering
+        Center for Engineering Education Princeton, NJ 08544","phone_number":"609-258-3200","contact_email":"englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/5.json","library":{"label":"Engineering
         Library","code":"engineer","order":0}},{"label":"Firestone Library, Microforms","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PF","staff_only":false,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/6.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PF","staff_only":false,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/6.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Marquand Library of Art
-        and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/7.json","library":{"label":"Marquand
+        and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/7.json","library":{"label":"Marquand
         Library","code":"marquand","order":0}},{"label":"Mendel Music Library","address":"Woolworth
-        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"PK","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/8.json","library":{"label":"Mendel
+        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"PK","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/8.json","library":{"label":"Mendel
         Music Library","code":"mendel","order":0}},{"label":"Mudd Manuscript Library","address":"65
-        Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/9.json","library":{"label":"Mudd
+        Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/9.json","library":{"label":"Mudd
         Manuscript Library","code":"mudd","order":0}},{"label":"Stokes Library","address":"Wallace
-        Hall, Lower Level Princeton, NJ 08544","phone_number":"609-258-5455","contact_email":"piaprlib@princeton.edu","gfa_pickup":"PM","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/10.json","library":{"label":"Stokes
+        Hall, Lower Level Princeton, NJ 08544","phone_number":"609-258-5455","contact_email":"piaprlib@princeton.edu","gfa_pickup":"PM","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/10.json","library":{"label":"Stokes
         Library","code":"stokes","order":0}},{"label":"Firestone Library, Resource
-        Sharing","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QA","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/12.json","library":{"label":"Firestone
+        Sharing","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QA","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/12.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Special Collections","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/13.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/13.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Lewis Library","address":"Washington
-        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PN","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/14.json","library":{"label":"Lewis
+        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PN","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/14.json","library":{"label":"Lewis
         Library","code":"lewis","order":0}},{"label":"Firestone Library","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/15.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/15.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"ReCAP ILL","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"IL","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/16.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"IL","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/16.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Technical Services HMT","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/23.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/23.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"East Asian Library. Microforms","address":"Frist
-        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"QL","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/24.json","library":{"label":"East
+        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"QL","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/24.json","library":{"label":"East
         Asian Library","code":"eastasian","order":0}},{"label":"Lewis Library (Rare)","address":"Washington
-        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PS","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/25.json","library":{"label":"Lewis
+        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PS","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/25.json","library":{"label":"Lewis
         Library","code":"lewis","order":0}},{"label":"Marquand Library of Art and
-        Archaeology (Rare)","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PZ","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/26.json","library":{"label":"Marquand
+        Archaeology (Rare)","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PZ","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/26.json","library":{"label":"Marquand
         Library","code":"marquand","order":0}},{"label":"Mendel Music Library. Sound/Video","address":"Woolworth
-        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"QK","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/27.json","library":{"label":"Mendel
+        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"QK","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/27.json","library":{"label":"Mendel
         Music Library","code":"mendel","order":0}},{"label":"Firestone Library, Microforms
-        (Firestone Use Only)","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PB","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/28.json","library":{"label":"Firestone
+        (Firestone Use Only)","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PB","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/28.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Preservation","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/29.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/29.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Firestone Circulation Desk","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609 258-2345","contact_email":"fstcirc@princton.edu","gfa_pickup":"QX","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/30.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609 258-2345","contact_email":"fstcirc@princton.edu","gfa_pickup":"QX","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/30.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}}]'
   recorded_at: Wed, 24 Aug 2022 17:39:54 GMT
 - request:

--- a/spec/cassettes/form_controller.yml
+++ b/spec/cassettes/form_controller.yml
@@ -69,7 +69,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:02:26 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9963773693506421/holdings/22239658680006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9963773693506421/holdings/22239658680006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:02:32 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/delivery_locations.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/delivery_locations.json
     body:
       encoding: US-ASCII
       string: ''
@@ -166,54 +166,54 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"label":"Plasma Physics Library","address":"Forrestal Campus Princeton,
-        NJ 08544","phone_number":"609-243-3565","contact_email":"lewislib@princeton.edu","gfa_pickup":"PQ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/1.json","library":{"label":"Harold
+        NJ 08544","phone_number":"609-243-3565","contact_email":"lewislib@princeton.edu","gfa_pickup":"PQ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/1.json","library":{"label":"Harold
         P. Furth Plasma Physics Library","code":"plasma","order":0}},{"label":"Technical
-        Services 693","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/2.json","library":{"label":"Firestone
+        Services 693","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/2.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Architecture Library","address":"School
-        of Architecture Building, Second Floor Princeton, NJ 08544","phone_number":"609-258-3256","contact_email":"ues@princeton.edu","gfa_pickup":"PW","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/3.json","library":{"label":"Architecture
+        of Architecture Building, Second Floor Princeton, NJ 08544","phone_number":"609-258-3256","contact_email":"ues@princeton.edu","gfa_pickup":"PW","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/3.json","library":{"label":"Architecture
         Library","code":"arch","order":0}},{"label":"East Asian Library","address":"Frist
-        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"PL","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/4.json","library":{"label":"East
+        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"PL","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/4.json","library":{"label":"East
         Asian Library","code":"eastasian","order":0}},{"label":"Engineering Library","address":"Friend
-        Center for Engineering Education Princeton, NJ 08544","phone_number":"609-258-3200","contact_email":"englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/5.json","library":{"label":"Engineering
+        Center for Engineering Education Princeton, NJ 08544","phone_number":"609-258-3200","contact_email":"englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/5.json","library":{"label":"Engineering
         Library","code":"engineer","order":0}},{"label":"Firestone Library, Microforms","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PF","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/6.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PF","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/6.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Marquand Library of Art
-        and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/7.json","library":{"label":"Marquand
+        and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/7.json","library":{"label":"Marquand
         Library","code":"marquand","order":0}},{"label":"Mendel Music Library","address":"Woolworth
-        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"PK","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/8.json","library":{"label":"Mendel
+        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"PK","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/8.json","library":{"label":"Mendel
         Music Library","code":"mendel","order":0}},{"label":"Mudd Manuscript Library","address":"65
-        Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/9.json","library":{"label":"Mudd
+        Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/9.json","library":{"label":"Mudd
         Manuscript Library","code":"mudd","order":0}},{"label":"Stokes Library","address":"Wallace
-        Hall, Lower Level Princeton, NJ 08544","phone_number":"609-258-5455","contact_email":"piaprlib@princeton.edu","gfa_pickup":"PM","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/10.json","library":{"label":"Stokes
+        Hall, Lower Level Princeton, NJ 08544","phone_number":"609-258-5455","contact_email":"piaprlib@princeton.edu","gfa_pickup":"PM","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/10.json","library":{"label":"Stokes
         Library","code":"stokes","order":0}},{"label":"Firestone Library, Resource
-        Sharing","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QA","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/12.json","library":{"label":"Firestone
+        Sharing","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QA","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/12.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Special Collections","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/13.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/13.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Lewis Library","address":"Washington
-        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PN","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/14.json","library":{"label":"Lewis
+        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PN","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/14.json","library":{"label":"Lewis
         Library","code":"lewis","order":0}},{"label":"Firestone Library","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/15.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/15.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"ReCAP ILL","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"IL","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/16.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"IL","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/16.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Technical Services HMT","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/23.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/23.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"East Asian Library. Microforms","address":"Frist
-        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"QL","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/24.json","library":{"label":"East
+        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"QL","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/24.json","library":{"label":"East
         Asian Library","code":"eastasian","order":0}},{"label":"Lewis Library (Rare)","address":"Washington
-        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PS","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/25.json","library":{"label":"Lewis
+        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PS","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/25.json","library":{"label":"Lewis
         Library","code":"lewis","order":0}},{"label":"Marquand Library of Art and
-        Archaeology (Rare)","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PZ","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/26.json","library":{"label":"Marquand
+        Archaeology (Rare)","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PZ","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/26.json","library":{"label":"Marquand
         Library","code":"marquand","order":0}},{"label":"Mendel Music Library. Sound/Video","address":"Woolworth
-        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"QK","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/27.json","library":{"label":"Mendel
+        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"QK","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/27.json","library":{"label":"Mendel
         Music Library","code":"mendel","order":0}},{"label":"Firestone Library, Microforms
-        (Firestone Use Only)","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PB","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/28.json","library":{"label":"Firestone
+        (Firestone Use Only)","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PB","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/28.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Preservation","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/29.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/29.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Firestone Circulation Desk","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609 258-2345","contact_email":"fstcirc@princton.edu","gfa_pickup":"QX","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/30.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609 258-2345","contact_email":"fstcirc@princton.edu","gfa_pickup":"QX","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/30.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Engineering Library Off-Site
         Storage","address":"Friend Center for Engineering Education, Princeton, NJ
-        08544","phone_number":" 609-258-3200","contact_email":" englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/40.json","library":{"label":"Engineering
+        08544","phone_number":" 609-258-3200","contact_email":" englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/40.json","library":{"label":"Engineering
         Library","code":"engineer","order":0}}]'
   recorded_at: Fri, 06 Aug 2021 12:02:32 GMT
 - request:
@@ -285,7 +285,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:02:33 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9996764833506421/holdings/2275983490006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9996764833506421/holdings/2275983490006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -335,7 +335,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:02:38 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/mudd$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/mudd$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -455,7 +455,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:02:39 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/mudd$prnc.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/mudd$prnc.json
     body:
       encoding: US-ASCII
       string: ''
@@ -508,7 +508,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:02:39 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9995768803506421/holdings/22497016220006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9995768803506421/holdings/22497016220006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -560,7 +560,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:02:44 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9995768803506421/holdings/2298692650006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9995768803506421/holdings/2298692650006421/availability.json
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/form_features.yml
+++ b/spec/cassettes/form_features.yml
@@ -69,7 +69,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:02:52 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/recap$pa.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/recap$pa.json
     body:
       encoding: US-ASCII
       string: ''
@@ -145,7 +145,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:02:53 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9999443553506421/holdings/22743365320006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9999443553506421/holdings/22743365320006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -263,7 +263,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:03:00 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/4815239/holdings/5018096/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/4815239/holdings/5018096/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -378,7 +378,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:03:07 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/993365253506421/holdings/22220245570006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/993365253506421/holdings/22220245570006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -495,7 +495,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:03:16 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/eastasian$cjk.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/eastasian$cjk.json
     body:
       encoding: US-ASCII
       string: ''
@@ -546,7 +546,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:03:16 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99117665883506421/holdings/22707341710006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99117665883506421/holdings/22707341710006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -665,7 +665,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:03:24 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/firestone$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/firestone$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -718,7 +718,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:03:24 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99103251433506421/holdings/22480270140006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99103251433506421/holdings/22480270140006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -844,7 +844,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:03:31 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9994692/holdings/9800910/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9994692/holdings/9800910/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -959,7 +959,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:03:36 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9917887963506421/holdings/22503918400006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9917887963506421/holdings/22503918400006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1078,7 +1078,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:03:43 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9941150973506421/holdings/22492663380006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9941150973506421/holdings/22492663380006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1255,7 +1255,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:03:53 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9994933183506421/holdings/22558528920006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9994933183506421/holdings/22558528920006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1374,7 +1374,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:04:01 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99114026863506421/holdings/22753408610006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99114026863506421/holdings/22753408610006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1532,7 +1532,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:04:06 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99113283293506421/holdings/22750642660006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99113283293506421/holdings/22750642660006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1649,7 +1649,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:04:09 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/993083506421/holdings/22740191170006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/993083506421/holdings/22740191170006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1782,7 +1782,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:04:15 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9912636153506421/holdings/22557213410006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9912636153506421/holdings/22557213410006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1834,7 +1834,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:04:21 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/firestone$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/firestone$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1954,7 +1954,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:04:22 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/annex$fst.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/annex$fst.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2027,7 +2027,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:04:22 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/999455503506421/holdings/22642306790006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/999455503506421/holdings/22642306790006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2169,7 +2169,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:04:28 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/lewis$pn.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/lewis$pn.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2230,7 +2230,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:04:28 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9970533073506421/holdings/22667391160006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9970533073506421/holdings/22667391160006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2282,7 +2282,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:04:34 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/lewis$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/lewis$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2335,7 +2335,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:04:34 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9970533073506421/holdings/22667391180006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9970533073506421/holdings/22667391180006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2387,7 +2387,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:04:39 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/lewis$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/lewis$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2507,7 +2507,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:04:40 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/lewis$ref.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/lewis$ref.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2560,7 +2560,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:04:40 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9995948403506421/holdings/22500774400006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9995948403506421/holdings/22500774400006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2746,7 +2746,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:04:53 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99105746993506421/holdings/22547424510006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99105746993506421/holdings/22547424510006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2890,7 +2890,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:04:57 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/marquand$pj.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/marquand$pj.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2952,7 +2952,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:04:58 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99117809653506421/holdings/22613352460006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99117809653506421/holdings/22613352460006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3071,7 +3071,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:03 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/arch$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/arch$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3125,7 +3125,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:03 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99117876713506421/holdings/22561348800006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99117876713506421/holdings/22561348800006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3177,7 +3177,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:09 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/arch$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/arch$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3298,7 +3298,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:10 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/recap$qv.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/recap$qv.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3375,7 +3375,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:10 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99115783193506421/holdings/22534122440006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99115783193506421/holdings/22534122440006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3495,7 +3495,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:15 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9999946923506421/holdings/9800910/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9999946923506421/holdings/9800910/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3621,7 +3621,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:20 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9915057783506421/holdings/22686942210006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9915057783506421/holdings/22686942210006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3757,7 +3757,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:26 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/annex$locked.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/annex$locked.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3816,7 +3816,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:26 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9922868943506421/holdings/22692156940006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9922868943506421/holdings/22692156940006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3933,7 +3933,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:32 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/marquand$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/marquand$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3986,7 +3986,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:32 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9941274093506421/holdings/22690999210006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9941274093506421/holdings/22690999210006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4036,7 +4036,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:36 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/scsbcul.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/scsbcul.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4089,7 +4089,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:37 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-2879197/holdings/2856807/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-2879197/holdings/2856807/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4137,7 +4137,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:37 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-2879206/holdings/2856817/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-2879206/holdings/2856817/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4252,7 +4252,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:40 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9956364873506421/holdings/22587331490006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9956364873506421/holdings/22587331490006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4304,7 +4304,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:44 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/scsbnypl.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/scsbnypl.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4357,7 +4357,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:45 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-8953469/holdings/9159920/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-8953469/holdings/9159920/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4472,7 +4472,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:46 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99123340993506421/holdings/22569931350006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99123340993506421/holdings/22569931350006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4591,7 +4591,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:53 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99124449473506421/holdings/22664801380006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99124449473506421/holdings/22664801380006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4643,7 +4643,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:05:59 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/firestone$pf.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/firestone$pf.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4707,7 +4707,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:06:00 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/993083506421/holdings/22740191180006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/993083506421/holdings/22740191180006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4824,7 +4824,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:06:04 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9997708113506421/holdings/22729045760006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9997708113506421/holdings/22729045760006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4943,7 +4943,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:06:12 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/rare$ctsn.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/rare$ctsn.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4996,7 +4996,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:06:12 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9973529363506421/holdings/22667098990006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9973529363506421/holdings/22667098990006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5069,7 +5069,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:06:19 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9999946923506421/holdings/22558528920006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9999946923506421/holdings/22558528920006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5186,7 +5186,7 @@ http_interactions:
   recorded_at: Fri, 20 Aug 2021 16:33:07 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-9726156/holdings/10366966/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-9726156/holdings/10366966/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5301,7 +5301,7 @@ http_interactions:
   recorded_at: Fri, 20 Aug 2021 16:33:19 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-5595350/holdings/5589784/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-5595350/holdings/5589784/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5416,7 +5416,7 @@ http_interactions:
   recorded_at: Tue, 31 Aug 2021 18:57:34 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/scsbhl.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/scsbhl.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5469,7 +5469,7 @@ http_interactions:
   recorded_at: Tue, 31 Aug 2021 18:57:34 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-9919951/holdings/10658780/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-9919951/holdings/10658780/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5584,7 +5584,7 @@ http_interactions:
   recorded_at: Thu, 16 Sep 2021 14:04:56 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99125378834306421/holdings/22897184810006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99125378834306421/holdings/22897184810006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5703,7 +5703,7 @@ http_interactions:
   recorded_at: Fri, 01 Oct 2021 18:25:17 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9973397793506421/holdings/22541187250006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9973397793506421/holdings/22541187250006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5763,7 +5763,7 @@ http_interactions:
   recorded_at: Fri, 01 Oct 2021 18:25:23 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/eastasian$cjk.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/eastasian$cjk.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5881,7 +5881,7 @@ http_interactions:
   recorded_at: Tue, 16 Nov 2021 13:37:23 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/annex$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/annex$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5958,7 +5958,7 @@ http_interactions:
   recorded_at: Tue, 16 Nov 2021 13:37:23 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9941347943506421/holdings/22560381400006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9941347943506421/holdings/22560381400006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6079,7 +6079,7 @@ http_interactions:
   recorded_at: Wed, 06 Apr 2022 15:15:18 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/998574693506421/holdings/abc123/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/998574693506421/holdings/abc123/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6127,7 +6127,7 @@ http_interactions:
   recorded_at: Wed, 06 Apr 2022 15:15:28 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99105816503506421/holdings/22514405160006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99105816503506421/holdings/22514405160006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6181,7 +6181,7 @@ http_interactions:
   recorded_at: Tue, 12 Apr 2022 20:48:23 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/arch$la.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/arch$la.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6288,7 +6288,7 @@ http_interactions:
   recorded_at: Tue, 12 Apr 2022 20:48:32 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/arch$la.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/arch$la.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6409,7 +6409,7 @@ http_interactions:
   recorded_at: Wed, 06 Apr 2022 18:53:21 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-6710959/holdings/6792300/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-6710959/holdings/6792300/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6537,7 +6537,7 @@ http_interactions:
   recorded_at: Wed, 06 Apr 2022 18:53:32 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9941151723506421/holdings/22492702000006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9941151723506421/holdings/22492702000006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6656,7 +6656,7 @@ http_interactions:
   recorded_at: Wed, 06 Apr 2022 18:53:41 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/annex$doc.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/annex$doc.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6715,7 +6715,7 @@ http_interactions:
   recorded_at: Wed, 06 Apr 2022 18:53:41 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9947220743506421/holdings/22734584180006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9947220743506421/holdings/22734584180006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6846,7 +6846,7 @@ http_interactions:
   recorded_at: Wed, 06 Apr 2022 18:53:51 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/firestone$dixn.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/firestone$dixn.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6897,7 +6897,7 @@ http_interactions:
   recorded_at: Wed, 06 Apr 2022 18:53:51 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99125452799106421/holdings/22917143470006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99125452799106421/holdings/22917143470006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -7012,7 +7012,7 @@ http_interactions:
   recorded_at: Wed, 06 Apr 2022 19:05:12 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/firestone$clas.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/firestone$clas.json
     body:
       encoding: US-ASCII
       string: ''
@@ -7063,7 +7063,7 @@ http_interactions:
   recorded_at: Wed, 06 Apr 2022 19:05:12 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99125428126306421/holdings/22910398870006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99125428126306421/holdings/22910398870006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -7115,7 +7115,7 @@ http_interactions:
   recorded_at: Wed, 06 Apr 2022 19:05:16 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/engineer$serial.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/engineer$serial.json
     body:
       encoding: US-ASCII
       string: ''
@@ -7169,7 +7169,7 @@ http_interactions:
   recorded_at: Wed, 06 Apr 2022 19:05:23 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/998574693506421/holdings/22579850750006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/998574693506421/holdings/22579850750006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -8440,7 +8440,7 @@ http_interactions:
   recorded_at: Tue, 12 Apr 2022 14:37:56 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/recap$pa.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/recap$pa.json
     body:
       encoding: US-ASCII
       string: ''
@@ -8516,7 +8516,7 @@ http_interactions:
   recorded_at: Tue, 12 Apr 2022 19:36:12 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99125465081006421/holdings/22922148510006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99125465081006421/holdings/22922148510006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -8578,7 +8578,7 @@ http_interactions:
   recorded_at: Tue, 12 Apr 2022 19:36:16 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99124417723506421/holdings/22689758840006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99124417723506421/holdings/22689758840006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -8697,7 +8697,7 @@ http_interactions:
   recorded_at: Thu, 28 Apr 2022 19:32:58 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99125492003506421/holdings/22927395910006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99125492003506421/holdings/22927395910006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -8812,7 +8812,7 @@ http_interactions:
   recorded_at: Thu, 05 May 2022 19:10:43 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/arch$ref.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/arch$ref.json
     body:
       encoding: US-ASCII
       string: ''
@@ -8866,7 +8866,7 @@ http_interactions:
   recorded_at: Thu, 05 May 2022 19:10:44 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99123713303506421/holdings/22668310350006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99123713303506421/holdings/22668310350006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -8918,7 +8918,7 @@ http_interactions:
   recorded_at: Thu, 05 May 2022 19:10:49 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/firestone$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/firestone$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -8971,7 +8971,7 @@ http_interactions:
   recorded_at: Fri, 03 Jun 2022 13:09:07 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9991807103506421/holdings/22696270550006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9991807103506421/holdings/22696270550006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9025,7 +9025,7 @@ http_interactions:
   recorded_at: Fri, 03 Jun 2022 13:09:12 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/RES_SHARE$IN_RS_REQ.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/RES_SHARE$IN_RS_REQ.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9227,7 +9227,7 @@ http_interactions:
   recorded_at: Mon, 12 Dec 2022 19:24:12 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/lewis$serial.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/lewis$serial.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9274,7 +9274,7 @@ http_interactions:
   recorded_at: Mon, 12 Dec 2022 19:24:13 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/995597013506421/holdings/22641621120006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/995597013506421/holdings/22641621120006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9473,7 +9473,7 @@ http_interactions:
   recorded_at: Wed, 15 Feb 2023 18:59:54 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9931433603506421/holdings/22542676190006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9931433603506421/holdings/22542676190006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9590,7 +9590,7 @@ http_interactions:
   recorded_at: Thu, 30 Mar 2023 14:11:24 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99116000543506421/holdings/22635325770006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99116000543506421/holdings/22635325770006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9703,7 +9703,7 @@ http_interactions:
   recorded_at: Wed, 22 Nov 2023 15:06:54 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/mendel$pk.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/mendel$pk.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9765,7 +9765,7 @@ http_interactions:
   recorded_at: Wed, 22 Nov 2023 15:06:54 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99127133356906421/holdings/22971539920006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99127133356906421/holdings/22971539920006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9894,7 +9894,7 @@ http_interactions:
   recorded_at: Mon, 04 Dec 2023 19:24:42 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/recap$pa.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/recap$pa.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9970,7 +9970,7 @@ http_interactions:
   recorded_at: Mon, 04 Dec 2023 19:24:42 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99129134216906421/holdings/221002424820006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99129134216906421/holdings/221002424820006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -10150,7 +10150,7 @@ http_interactions:
   recorded_at: Wed, 03 Jan 2024 21:00:52 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99129147026006421/holdings/221003662090006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99129147026006421/holdings/221003662090006421/availability.json
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/form_models.yml
+++ b/spec/cassettes/form_models.yml
@@ -69,7 +69,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:51:37 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/firestone$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/firestone$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -122,7 +122,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:51:41 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9981794023506421/holdings/22591269990006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9981794023506421/holdings/22591269990006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -174,7 +174,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:51:53 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/delivery_locations.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/delivery_locations.json
     body:
       encoding: US-ASCII
       string: ''
@@ -221,54 +221,54 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"label":"Plasma Physics Library","address":"Forrestal Campus Princeton,
-        NJ 08544","phone_number":"609-243-3565","contact_email":"lewislib@princeton.edu","gfa_pickup":"PQ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/1.json","library":{"label":"Harold
+        NJ 08544","phone_number":"609-243-3565","contact_email":"lewislib@princeton.edu","gfa_pickup":"PQ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/1.json","library":{"label":"Harold
         P. Furth Plasma Physics Library","code":"plasma","order":0}},{"label":"Technical
-        Services 693","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/2.json","library":{"label":"Firestone
+        Services 693","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/2.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Architecture Library","address":"School
-        of Architecture Building, Second Floor Princeton, NJ 08544","phone_number":"609-258-3256","contact_email":"ues@princeton.edu","gfa_pickup":"PW","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/3.json","library":{"label":"Architecture
+        of Architecture Building, Second Floor Princeton, NJ 08544","phone_number":"609-258-3256","contact_email":"ues@princeton.edu","gfa_pickup":"PW","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/3.json","library":{"label":"Architecture
         Library","code":"arch","order":0}},{"label":"East Asian Library","address":"Frist
-        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"PL","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/4.json","library":{"label":"East
+        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"PL","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/4.json","library":{"label":"East
         Asian Library","code":"eastasian","order":0}},{"label":"Engineering Library","address":"Friend
-        Center for Engineering Education Princeton, NJ 08544","phone_number":"609-258-3200","contact_email":"englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/5.json","library":{"label":"Engineering
+        Center for Engineering Education Princeton, NJ 08544","phone_number":"609-258-3200","contact_email":"englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/5.json","library":{"label":"Engineering
         Library","code":"engineer","order":0}},{"label":"Firestone Library, Microforms","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PF","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/6.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PF","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/6.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Marquand Library of Art
-        and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/7.json","library":{"label":"Marquand
+        and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/7.json","library":{"label":"Marquand
         Library","code":"marquand","order":0}},{"label":"Mendel Music Library","address":"Woolworth
-        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"PK","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/8.json","library":{"label":"Mendel
+        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"PK","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/8.json","library":{"label":"Mendel
         Music Library","code":"mendel","order":0}},{"label":"Mudd Manuscript Library","address":"65
-        Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/9.json","library":{"label":"Mudd
+        Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/9.json","library":{"label":"Mudd
         Manuscript Library","code":"mudd","order":0}},{"label":"Stokes Library","address":"Wallace
-        Hall, Lower Level Princeton, NJ 08544","phone_number":"609-258-5455","contact_email":"piaprlib@princeton.edu","gfa_pickup":"PM","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/10.json","library":{"label":"Stokes
+        Hall, Lower Level Princeton, NJ 08544","phone_number":"609-258-5455","contact_email":"piaprlib@princeton.edu","gfa_pickup":"PM","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/10.json","library":{"label":"Stokes
         Library","code":"stokes","order":0}},{"label":"Firestone Library, Resource
-        Sharing","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QA","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/12.json","library":{"label":"Firestone
+        Sharing","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QA","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/12.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Special Collections","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/13.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/13.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Lewis Library","address":"Washington
-        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PN","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/14.json","library":{"label":"Lewis
+        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PN","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/14.json","library":{"label":"Lewis
         Library","code":"lewis","order":0}},{"label":"Firestone Library","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/15.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/15.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"ReCAP ILL","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"IL","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/16.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"IL","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/16.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Technical Services HMT","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/23.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/23.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"East Asian Library. Microforms","address":"Frist
-        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"QL","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/24.json","library":{"label":"East
+        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"QL","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/24.json","library":{"label":"East
         Asian Library","code":"eastasian","order":0}},{"label":"Lewis Library (Rare)","address":"Washington
-        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PS","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/25.json","library":{"label":"Lewis
+        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PS","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/25.json","library":{"label":"Lewis
         Library","code":"lewis","order":0}},{"label":"Marquand Library of Art and
-        Archaeology (Rare)","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PZ","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/26.json","library":{"label":"Marquand
+        Archaeology (Rare)","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PZ","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/26.json","library":{"label":"Marquand
         Library","code":"marquand","order":0}},{"label":"Mendel Music Library. Sound/Video","address":"Woolworth
-        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"QK","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/27.json","library":{"label":"Mendel
+        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"QK","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/27.json","library":{"label":"Mendel
         Music Library","code":"mendel","order":0}},{"label":"Firestone Library, Microforms
-        (Firestone Use Only)","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PB","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/28.json","library":{"label":"Firestone
+        (Firestone Use Only)","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PB","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/28.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Preservation","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/29.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/29.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Firestone Circulation Desk","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609 258-2345","contact_email":"fstcirc@princton.edu","gfa_pickup":"QX","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/30.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609 258-2345","contact_email":"fstcirc@princton.edu","gfa_pickup":"QX","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/30.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Engineering Library Off-Site
         Storage","address":"Friend Center for Engineering Education, Princeton, NJ
-        08544","phone_number":" 609-258-3200","contact_email":" englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/40.json","library":{"label":"Engineering
+        08544","phone_number":" 609-258-3200","contact_email":" englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/40.json","library":{"label":"Engineering
         Library","code":"engineer","order":0}}]'
   recorded_at: Fri, 06 Aug 2021 13:51:53 GMT
 - request:
@@ -340,7 +340,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:51:53 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9992220243506421/holdings/22558467250006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9992220243506421/holdings/22558467250006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -479,7 +479,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:52:01 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/lewis$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/lewis$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -532,7 +532,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:52:01 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9938488723506421/holdings/22522147400006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9938488723506421/holdings/22522147400006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -651,7 +651,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:52:06 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/994916543506421/holdings/22724990930006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/994916543506421/holdings/22724990930006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -770,7 +770,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:52:12 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/lewis$pn.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/lewis$pn.json
     body:
       encoding: US-ASCII
       string: ''
@@ -831,7 +831,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:52:13 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/994264203506421/holdings/22697858020006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/994264203506421/holdings/22697858020006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3414,7 +3414,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:53:01 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/rare$ctsn.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/rare$ctsn.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3467,7 +3467,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:53:01 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9973529363506421/holdings/22667098870006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9973529363506421/holdings/22667098870006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3654,7 +3654,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:54:37 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/foo/holdings//availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/foo/holdings//availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3827,7 +3827,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:54:37 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/arch$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/arch$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3881,7 +3881,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:54:38 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9988805493506421/holdings/22705318390006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9988805493506421/holdings/22705318390006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4067,7 +4067,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:54:46 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/rare$ex.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/rare$ex.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4120,7 +4120,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:54:46 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9917917633506421/holdings/22720740220006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9917917633506421/holdings/22720740220006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4237,7 +4237,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:54:51 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/recap$pa.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/recap$pa.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4313,7 +4313,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:54:51 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/994909303506421/holdings/22584686190006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/994909303506421/holdings/22584686190006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4667,7 +4667,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:54:58 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/rare$hsvc.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/rare$hsvc.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4718,7 +4718,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:54:58 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9947589763506421/holdings/22656885190006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9947589763506421/holdings/22656885190006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4881,7 +4881,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:03 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9924784993506421/holdings/22708132010006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9924784993506421/holdings/22708132010006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -4999,7 +4999,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:07 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9931973043506421/holdings/22185253590006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9931973043506421/holdings/22185253590006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5125,7 +5125,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:12 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/eastasian$gest.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/eastasian$gest.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5176,7 +5176,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:13 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9931805453506421/holdings/22705623210006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9931805453506421/holdings/22705623210006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5230,7 +5230,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:18 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/eastasian$reserve.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/eastasian$reserve.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5350,7 +5350,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:18 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9961959423506421/holdings/22525427880006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9961959423506421/holdings/22525427880006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5404,7 +5404,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:24 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/lewis$resterm.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/lewis$resterm.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5536,7 +5536,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:25 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9923858683506421/holdings//availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9923858683506421/holdings//availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5710,7 +5710,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:26 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/eastasian$pl.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/eastasian$pl.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5772,7 +5772,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:26 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9947595913506421/holdings/22489764810006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9947595913506421/holdings/22489764810006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5822,7 +5822,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:30 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/mudd$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/mudd$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5875,7 +5875,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:31 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/rare$num.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/rare$num.json
     body:
       encoding: US-ASCII
       string: ''
@@ -5993,7 +5993,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:33 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/firestone$nec.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/firestone$nec.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6046,7 +6046,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:33 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9929370033506421/holdings/22539090210006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9929370033506421/holdings/22539090210006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6165,7 +6165,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:40 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9943404133506421/holdings/22514049930006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9943404133506421/holdings/22514049930006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6284,7 +6284,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:46 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9995457263506421/holdings/22560953240006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9995457263506421/holdings/22560953240006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6403,7 +6403,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:53 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/99103251433506421/holdings/22480270140006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/99103251433506421/holdings/22480270140006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6530,7 +6530,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:55:57 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9996025453506421/holdings/22565008360006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9996025453506421/holdings/22565008360006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6649,7 +6649,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:56:01 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9920022063506421/holdings/22560993150006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9920022063506421/holdings/22560993150006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6776,7 +6776,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:56:05 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9996272613506421/holdings/22529639530006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9996272613506421/holdings/22529639530006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -6895,7 +6895,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:56:10 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/996160863506421/holdings/22563389780006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/996160863506421/holdings/22563389780006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -7026,7 +7026,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:56:15 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9996764833506421/holdings/22680107620006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9996764833506421/holdings/22680107620006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -7078,7 +7078,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:56:20 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/engineer$serial.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/engineer$serial.json
     body:
       encoding: US-ASCII
       string: ''
@@ -7132,7 +7132,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:56:20 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/994264203506421/holdings/22697842050006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/994264203506421/holdings/22697842050006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -7966,7 +7966,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:56:40 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9991001053506421/holdings/22691592660006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9991001053506421/holdings/22691592660006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -8085,7 +8085,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:56:45 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9999074333506421/holdings/22578723910006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9999074333506421/holdings/22578723910006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -8222,7 +8222,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:56:49 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/annex$fst.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/annex$fst.json
     body:
       encoding: US-ASCII
       string: ''
@@ -8295,7 +8295,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:56:50 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/994955013506421/holdings/22644665360006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/994955013506421/holdings/22644665360006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -8542,7 +8542,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:56:55 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9997467763506421/holdings/22597992220006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9997467763506421/holdings/22597992220006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -8684,7 +8684,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:57:01 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9948152393506421/holdings/22717671090006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9948152393506421/holdings/22717671090006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -8803,7 +8803,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:57:07 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/994952203506421/holdings/22644769680006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/994952203506421/holdings/22644769680006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -8918,7 +8918,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:57:30 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9974943583506421/holdings/22711798720006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9974943583506421/holdings/22711798720006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9067,7 +9067,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:57:36 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9925693243506421/holdings/22554332290006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9925693243506421/holdings/22554332290006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9223,7 +9223,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:57:41 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9926312653506421/holdings/22692741390006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9926312653506421/holdings/22692741390006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9340,7 +9340,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:57:45 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9917887963506421/holdings/22503918400006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9917887963506421/holdings/22503918400006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9459,7 +9459,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:57:50 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/arch$ref.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/arch$ref.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9513,7 +9513,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:57:50 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9919698813506421/holdings/22589919750006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9919698813506421/holdings/22589919750006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9632,7 +9632,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:57:56 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/firestone$pres.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/firestone$pres.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9685,7 +9685,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:57:56 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9997123553506421/holdings/22586693240006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9997123553506421/holdings/22586693240006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9804,7 +9804,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:58:02 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9946931463506421/holdings/22715350280006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9946931463506421/holdings/22715350280006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9856,7 +9856,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:58:08 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/scsbcul.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/scsbcul.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9909,7 +9909,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:58:09 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-5290772/holdings/5278611/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-5290772/holdings/5278611/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -9957,7 +9957,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:58:09 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-5640725/holdings/5630217/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-5640725/holdings/5630217/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -10005,7 +10005,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:58:11 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/scsbnypl.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/scsbnypl.json
     body:
       encoding: US-ASCII
       string: ''
@@ -10058,7 +10058,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:58:11 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-7935196/holdings/8076325/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-7935196/holdings/8076325/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -10106,7 +10106,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 13:58:12 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/marquand$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/marquand$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -10226,7 +10226,7 @@ http_interactions:
   recorded_at: Thu, 18 May 2023 16:49:13 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/eastasian$hy.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/eastasian$hy.json
     body:
       encoding: US-ASCII
       string: ''
@@ -10277,7 +10277,7 @@ http_interactions:
   recorded_at: Thu, 18 May 2023 16:49:14 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9942430233506421/holdings/22600149340006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9942430233506421/holdings/22600149340006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -10331,7 +10331,7 @@ http_interactions:
   recorded_at: Thu, 18 May 2023 16:49:20 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/delivery_locations.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/delivery_locations.json
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/mailer.yml
+++ b/spec/cassettes/mailer.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/firestone$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/firestone$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -55,7 +55,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:07:04 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/eastasian$cjk.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/eastasian$cjk.json
     body:
       encoding: US-ASCII
       string: ''
@@ -106,7 +106,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:07:04 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/plasma$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/plasma$stacks.json
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/requestable.yml
+++ b/spec/cassettes/requestable.yml
@@ -69,7 +69,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:10:51 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/firestone$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/firestone$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -122,7 +122,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:10:51 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9912140633506421/holdings/22722595360006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9912140633506421/holdings/22722595360006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -176,7 +176,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:10:55 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/delivery_locations.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/delivery_locations.json
     body:
       encoding: US-ASCII
       string: ''
@@ -223,59 +223,59 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"label":"Plasma Physics Library","address":"Forrestal Campus Princeton,
-        NJ 08544","phone_number":"609-243-3565","contact_email":"lewislib@princeton.edu","gfa_pickup":"PQ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/1.json","library":{"label":"Harold
+        NJ 08544","phone_number":"609-243-3565","contact_email":"lewislib@princeton.edu","gfa_pickup":"PQ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/1.json","library":{"label":"Harold
         P. Furth Plasma Physics Library","code":"plasma","order":0}},{"label":"Technical
-        Services 693","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/2.json","library":{"label":"Firestone
+        Services 693","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/2.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Architecture Library","address":"School
-        of Architecture Building, Second Floor Princeton, NJ 08544","phone_number":"609-258-3256","contact_email":"ues@princeton.edu","gfa_pickup":"PW","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/3.json","library":{"label":"Architecture
+        of Architecture Building, Second Floor Princeton, NJ 08544","phone_number":"609-258-3256","contact_email":"ues@princeton.edu","gfa_pickup":"PW","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/3.json","library":{"label":"Architecture
         Library","code":"arch","order":0}},{"label":"East Asian Library","address":"Frist
-        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"PL","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/4.json","library":{"label":"East
+        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"PL","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/4.json","library":{"label":"East
         Asian Library","code":"eastasian","order":0}},{"label":"Engineering Library","address":"Friend
-        Center for Engineering Education Princeton, NJ 08544","phone_number":"609-258-3200","contact_email":"englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/5.json","library":{"label":"Engineering
+        Center for Engineering Education Princeton, NJ 08544","phone_number":"609-258-3200","contact_email":"englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/5.json","library":{"label":"Engineering
         Library","code":"engineer","order":0}},{"label":"Firestone Library, Microforms","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PF","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/6.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PF","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/6.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Marquand Library of Art
-        and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/7.json","library":{"label":"Marquand
+        and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/7.json","library":{"label":"Marquand
         Library","code":"marquand","order":0}},{"label":"Mendel Music Library","address":"Woolworth
-        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"PK","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/8.json","library":{"label":"Mendel
+        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"PK","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/8.json","library":{"label":"Mendel
         Music Library","code":"mendel","order":0}},{"label":"Mudd Manuscript Library","address":"65
-        Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/9.json","library":{"label":"Mudd
+        Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/9.json","library":{"label":"Mudd
         Manuscript Library","code":"mudd","order":0}},{"label":"Stokes Library","address":"Wallace
-        Hall, Lower Level Princeton, NJ 08544","phone_number":"609-258-5455","contact_email":"piaprlib@princeton.edu","gfa_pickup":"PM","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/10.json","library":{"label":"Stokes
+        Hall, Lower Level Princeton, NJ 08544","phone_number":"609-258-5455","contact_email":"piaprlib@princeton.edu","gfa_pickup":"PM","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/10.json","library":{"label":"Stokes
         Library","code":"stokes","order":0}},{"label":"Firestone Library, Resource
-        Sharing","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QA","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/12.json","library":{"label":"Firestone
+        Sharing","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QA","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/12.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Special Collections","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/13.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/13.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Lewis Library","address":"Washington
-        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PN","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/14.json","library":{"label":"Lewis
+        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PN","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/14.json","library":{"label":"Lewis
         Library","code":"lewis","order":0}},{"label":"Firestone Library","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/15.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/15.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"ReCAP ILL","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"IL","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/16.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"IL","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/16.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Technical Services HMT","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/23.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/23.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"East Asian Library. Microforms","address":"Frist
-        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"QL","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/24.json","library":{"label":"East
+        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"QL","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/24.json","library":{"label":"East
         Asian Library","code":"eastasian","order":0}},{"label":"Lewis Library (Rare)","address":"Washington
-        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PS","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/25.json","library":{"label":"Lewis
+        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PS","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/25.json","library":{"label":"Lewis
         Library","code":"lewis","order":0}},{"label":"Marquand Library of Art and
-        Archaeology (Rare)","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PZ","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/26.json","library":{"label":"Marquand
+        Archaeology (Rare)","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PZ","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/26.json","library":{"label":"Marquand
         Library","code":"marquand","order":0}},{"label":"Mendel Music Library. Sound/Video","address":"Woolworth
-        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"QK","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/27.json","library":{"label":"Mendel
+        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"QK","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/27.json","library":{"label":"Mendel
         Music Library","code":"mendel","order":0}},{"label":"Firestone Library, Microforms
-        (Firestone Use Only)","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PB","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/28.json","library":{"label":"Firestone
+        (Firestone Use Only)","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PB","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/28.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Preservation","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/29.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/29.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Firestone Circulation Desk","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609 258-2345","contact_email":"fstcirc@princton.edu","gfa_pickup":"QX","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/30.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609 258-2345","contact_email":"fstcirc@princton.edu","gfa_pickup":"QX","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/30.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Engineering Library Off-Site
         Storage","address":"Friend Center for Engineering Education, Princeton, NJ
-        08544","phone_number":" 609-258-3200","contact_email":" englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/40.json","library":{"label":"Engineering
+        08544","phone_number":" 609-258-3200","contact_email":" englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/40.json","library":{"label":"Engineering
         Library","code":"engineer","order":0}}]'
   recorded_at: Fri, 06 Aug 2021 12:10:55 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/mudd$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/mudd$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -328,7 +328,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:10:55 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/rare$num.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/rare$num.json
     body:
       encoding: US-ASCII
       string: ''
@@ -463,7 +463,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:10:57 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/lewis$stacks.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/lewis$stacks.json
     body:
       encoding: US-ASCII
       string: ''
@@ -516,7 +516,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:10:57 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9915486663506421/holdings/22495908770006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9915486663506421/holdings/22495908770006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -676,7 +676,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:11:04 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9988406853506421/holdings/22743233800006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9988406853506421/holdings/22743233800006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -795,7 +795,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:11:11 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/992577173506421/holdings/22591178060006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/992577173506421/holdings/22591178060006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -988,7 +988,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:11:20 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/rare$crare.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/rare$crare.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1041,7 +1041,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:11:20 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9977213233506421/holdings/22707739710006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9977213233506421/holdings/22707739710006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1160,7 +1160,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:11:27 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/rare$xr.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/rare$xr.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1215,7 +1215,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:11:27 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9967949663506421/holdings/22677203260006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9967949663506421/holdings/22677203260006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1375,7 +1375,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:11:31 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/rare$ex.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/rare$ex.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1428,7 +1428,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:11:32 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/996160863506421/holdings/22563389780006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/996160863506421/holdings/22563389780006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1559,7 +1559,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:11:37 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9925358453506421/holdings/22615926030006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9925358453506421/holdings/22615926030006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1703,7 +1703,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:11:41 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9960234393506421/holdings/22524308350006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9960234393506421/holdings/22524308350006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1838,7 +1838,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:11:46 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/marquand$pz.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/marquand$pz.json
     body:
       encoding: US-ASCII
       string: ''
@@ -1892,7 +1892,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:11:46 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9979153343506421/holdings/22742463930006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9979153343506421/holdings/22742463930006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2011,7 +2011,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:11:52 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/rare$exov.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/rare$exov.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2062,7 +2062,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:11:52 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9929908463506421/holdings/22656754050006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9929908463506421/holdings/22656754050006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2181,7 +2181,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:12:00 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9995944353506421/holdings/22500750240006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9995944353506421/holdings/22500750240006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2314,7 +2314,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:12:08 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/annex$princeton.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/annex$princeton.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2365,7 +2365,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:12:08 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9944928463506421/holdings/22490610730006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9944928463506421/holdings/22490610730006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2482,7 +2482,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:12:13 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/firestone$clas.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/firestone$clas.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2533,7 +2533,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:12:13 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9939075533506421/holdings/22675089420006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9939075533506421/holdings/22675089420006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2682,7 +2682,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:12:22 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/recap$pa.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/recap$pa.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2758,7 +2758,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:12:22 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9999998003506421/holdings/22480198860006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9999998003506421/holdings/22480198860006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2897,7 +2897,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:12:27 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/9913891213506421/holdings/22739043950006421/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9913891213506421/holdings/22739043950006421/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -2949,7 +2949,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:12:33 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/scsbcul.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/scsbcul.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3002,7 +3002,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:12:35 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-5235419/holdings/5222238/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-5235419/holdings/5222238/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3050,7 +3050,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:12:36 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-5396104/holdings/5386007/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-5396104/holdings/5386007/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3098,7 +3098,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:12:36 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-2650865/holdings/2628739/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-2650865/holdings/2628739/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3146,7 +3146,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:12:37 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-2901229/holdings/2878971/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-2901229/holdings/2878971/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3194,7 +3194,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:12:38 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/scsbhl.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/scsbhl.json
     body:
       encoding: US-ASCII
       string: ''
@@ -3247,7 +3247,7 @@ http_interactions:
   recorded_at: Thu, 19 Aug 2021 15:13:36 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-10966202/holdings/11761058/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-10966202/holdings/11761058/availability.json
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/cassettes/requests_router.yml
+++ b/spec/cassettes/requests_router.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/scsbcul.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/scsbcul.json
     body:
       encoding: US-ASCII
       string: ''
@@ -55,7 +55,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:12:39 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-2635660/holdings/2613391/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-2635660/holdings/2613391/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -103,7 +103,7 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:12:40 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/delivery_locations.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/delivery_locations.json
     body:
       encoding: US-ASCII
       string: ''
@@ -150,54 +150,54 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"label":"Plasma Physics Library","address":"Forrestal Campus Princeton,
-        NJ 08544","phone_number":"609-243-3565","contact_email":"lewislib@princeton.edu","gfa_pickup":"PQ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/1.json","library":{"label":"Harold
+        NJ 08544","phone_number":"609-243-3565","contact_email":"lewislib@princeton.edu","gfa_pickup":"PQ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/1.json","library":{"label":"Harold
         P. Furth Plasma Physics Library","code":"plasma","order":0}},{"label":"Technical
-        Services 693","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/2.json","library":{"label":"Firestone
+        Services 693","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/2.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Architecture Library","address":"School
-        of Architecture Building, Second Floor Princeton, NJ 08544","phone_number":"609-258-3256","contact_email":"ues@princeton.edu","gfa_pickup":"PW","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/3.json","library":{"label":"Architecture
+        of Architecture Building, Second Floor Princeton, NJ 08544","phone_number":"609-258-3256","contact_email":"ues@princeton.edu","gfa_pickup":"PW","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/3.json","library":{"label":"Architecture
         Library","code":"arch","order":0}},{"label":"East Asian Library","address":"Frist
-        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"PL","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/4.json","library":{"label":"East
+        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"PL","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/4.json","library":{"label":"East
         Asian Library","code":"eastasian","order":0}},{"label":"Engineering Library","address":"Friend
-        Center for Engineering Education Princeton, NJ 08544","phone_number":"609-258-3200","contact_email":"englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/5.json","library":{"label":"Engineering
+        Center for Engineering Education Princeton, NJ 08544","phone_number":"609-258-3200","contact_email":"englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/5.json","library":{"label":"Engineering
         Library","code":"engineer","order":0}},{"label":"Firestone Library, Microforms","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PF","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/6.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PF","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/6.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Marquand Library of Art
-        and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/7.json","library":{"label":"Marquand
+        and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/7.json","library":{"label":"Marquand
         Library","code":"marquand","order":0}},{"label":"Mendel Music Library","address":"Woolworth
-        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"PK","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/8.json","library":{"label":"Mendel
+        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"PK","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/8.json","library":{"label":"Mendel
         Music Library","code":"mendel","order":0}},{"label":"Mudd Manuscript Library","address":"65
-        Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/9.json","library":{"label":"Mudd
+        Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/9.json","library":{"label":"Mudd
         Manuscript Library","code":"mudd","order":0}},{"label":"Stokes Library","address":"Wallace
-        Hall, Lower Level Princeton, NJ 08544","phone_number":"609-258-5455","contact_email":"piaprlib@princeton.edu","gfa_pickup":"PM","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/10.json","library":{"label":"Stokes
+        Hall, Lower Level Princeton, NJ 08544","phone_number":"609-258-5455","contact_email":"piaprlib@princeton.edu","gfa_pickup":"PM","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/10.json","library":{"label":"Stokes
         Library","code":"stokes","order":0}},{"label":"Firestone Library, Resource
-        Sharing","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QA","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/12.json","library":{"label":"Firestone
+        Sharing","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QA","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/12.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Special Collections","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/13.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/13.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Lewis Library","address":"Washington
-        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PN","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/14.json","library":{"label":"Lewis
+        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PN","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/14.json","library":{"label":"Lewis
         Library","code":"lewis","order":0}},{"label":"Firestone Library","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/15.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/15.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"ReCAP ILL","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"IL","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/16.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"IL","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/16.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Technical Services HMT","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/23.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/23.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"East Asian Library. Microforms","address":"Frist
-        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"QL","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/24.json","library":{"label":"East
+        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"QL","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/24.json","library":{"label":"East
         Asian Library","code":"eastasian","order":0}},{"label":"Lewis Library (Rare)","address":"Washington
-        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PS","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/25.json","library":{"label":"Lewis
+        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PS","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/25.json","library":{"label":"Lewis
         Library","code":"lewis","order":0}},{"label":"Marquand Library of Art and
-        Archaeology (Rare)","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PZ","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/26.json","library":{"label":"Marquand
+        Archaeology (Rare)","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PZ","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/26.json","library":{"label":"Marquand
         Library","code":"marquand","order":0}},{"label":"Mendel Music Library. Sound/Video","address":"Woolworth
-        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"QK","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/27.json","library":{"label":"Mendel
+        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"QK","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/27.json","library":{"label":"Mendel
         Music Library","code":"mendel","order":0}},{"label":"Firestone Library, Microforms
-        (Firestone Use Only)","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PB","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/28.json","library":{"label":"Firestone
+        (Firestone Use Only)","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PB","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/28.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Preservation","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/29.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/29.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Firestone Circulation Desk","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609 258-2345","contact_email":"fstcirc@princton.edu","gfa_pickup":"QX","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/30.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609 258-2345","contact_email":"fstcirc@princton.edu","gfa_pickup":"QX","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/30.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Engineering Library Off-Site
         Storage","address":"Friend Center for Engineering Education, Princeton, NJ
-        08544","phone_number":" 609-258-3200","contact_email":" englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/40.json","library":{"label":"Engineering
+        08544","phone_number":" 609-258-3200","contact_email":" englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/40.json","library":{"label":"Engineering
         Library","code":"engineer","order":0}}]'
   recorded_at: Fri, 06 Aug 2021 12:12:40 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/unauthorized_ol_authorized_bibdata_scsb_key.yml
+++ b/spec/cassettes/unauthorized_ol_authorized_bibdata_scsb_key.yml
@@ -69,7 +69,7 @@ http_interactions:
   recorded_at: Wed, 24 Aug 2022 17:45:00 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/holding_locations/scsbnypl.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/holding_locations/scsbnypl.json
     body:
       encoding: US-ASCII
       string: ''
@@ -116,7 +116,7 @@ http_interactions:
   recorded_at: Wed, 24 Aug 2022 17:45:01 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/bibliographic/SCSB-7935196/holdings/8076325/availability.json
+    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/SCSB-7935196/holdings/8076325/availability.json
     body:
       encoding: US-ASCII
       string: ''
@@ -158,7 +158,7 @@ http_interactions:
   recorded_at: Wed, 24 Aug 2022 17:45:01 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.princeton.edu/locations/delivery_locations.json
+    uri: https://bibdata-staging.lib.princeton.edu/locations/delivery_locations.json
     body:
       encoding: US-ASCII
       string: ''
@@ -199,51 +199,51 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '[{"label":"Plasma Physics Library","address":"Forrestal Campus Princeton,
-        NJ 08544","phone_number":"609-243-3565","contact_email":"lewislib@princeton.edu","gfa_pickup":"PQ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/1.json","library":{"label":"Harold
+        NJ 08544","phone_number":"609-243-3565","contact_email":"lewislib@princeton.edu","gfa_pickup":"PQ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/1.json","library":{"label":"Harold
         P. Furth Plasma Physics Library","code":"plasma","order":0}},{"label":"Technical
-        Services 693","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/2.json","library":{"label":"Firestone
+        Services 693","address":"693 Alexander Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QT","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/2.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Architecture Library","address":"School
-        of Architecture Building, Second Floor Princeton, NJ 08544","phone_number":"609-258-3256","contact_email":"ues@princeton.edu","gfa_pickup":"PW","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/3.json","library":{"label":"Architecture
+        of Architecture Building, Second Floor Princeton, NJ 08544","phone_number":"609-258-3256","contact_email":"ues@princeton.edu","gfa_pickup":"PW","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/3.json","library":{"label":"Architecture
         Library","code":"arch","order":0}},{"label":"East Asian Library","address":"Frist
-        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"PL","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/4.json","library":{"label":"East
+        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"PL","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/4.json","library":{"label":"East
         Asian Library","code":"eastasian","order":0}},{"label":"Engineering Library","address":"Friend
-        Center for Engineering Education Princeton, NJ 08544","phone_number":"609-258-3200","contact_email":"englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/5.json","library":{"label":"Engineering
+        Center for Engineering Education Princeton, NJ 08544","phone_number":"609-258-3200","contact_email":"englib@princeton.edu","gfa_pickup":"PT","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/5.json","library":{"label":"Engineering
         Library","code":"engineer","order":0}},{"label":"Firestone Library, Microforms","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PF","staff_only":false,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/6.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PF","staff_only":false,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/6.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Marquand Library of Art
-        and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/7.json","library":{"label":"Marquand
+        and Archaeology","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PJ","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/7.json","library":{"label":"Marquand
         Library","code":"marquand","order":0}},{"label":"Mendel Music Library","address":"Woolworth
-        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"PK","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/8.json","library":{"label":"Mendel
+        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"PK","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/8.json","library":{"label":"Mendel
         Music Library","code":"mendel","order":0}},{"label":"Mudd Manuscript Library","address":"65
-        Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/9.json","library":{"label":"Mudd
+        Olden Street Princeton, NJ 08544","phone_number":"609-258-6345","contact_email":"mudd@princeton.edu","gfa_pickup":"PH","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/9.json","library":{"label":"Mudd
         Manuscript Library","code":"mudd","order":0}},{"label":"Stokes Library","address":"Wallace
-        Hall, Lower Level Princeton, NJ 08544","phone_number":"609-258-5455","contact_email":"piaprlib@princeton.edu","gfa_pickup":"PM","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/10.json","library":{"label":"Stokes
+        Hall, Lower Level Princeton, NJ 08544","phone_number":"609-258-5455","contact_email":"piaprlib@princeton.edu","gfa_pickup":"PM","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/10.json","library":{"label":"Stokes
         Library","code":"stokes","order":0}},{"label":"Firestone Library, Resource
-        Sharing","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QA","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/12.json","library":{"label":"Firestone
+        Sharing","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QA","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/12.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Special Collections","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/13.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"rbsc@princeton.edu","gfa_pickup":"PG","staff_only":false,"pickup_location":false,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/13.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Lewis Library","address":"Washington
-        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PN","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/14.json","library":{"label":"Lewis
+        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PN","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/14.json","library":{"label":"Lewis
         Library","code":"lewis","order":0}},{"label":"Firestone Library","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/15.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"PA","staff_only":false,"pickup_location":true,"digital_location":true,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/15.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"ReCAP ILL","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"IL","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/16.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"IL","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/16.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Technical Services HMT","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/23.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"catalogn@princeton.edu","gfa_pickup":"QC","staff_only":true,"pickup_location":true,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/23.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"East Asian Library. Microforms","address":"Frist
-        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"QL","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/24.json","library":{"label":"East
+        Campus Center, Room 317 Princeton, NJ 08544","phone_number":"609-258-3182","contact_email":"gestcirc@princeton.edu","gfa_pickup":"QL","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/24.json","library":{"label":"East
         Asian Library","code":"eastasian","order":0}},{"label":"Lewis Library (Rare)","address":"Washington
-        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PS","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/25.json","library":{"label":"Lewis
+        Road and Ivy Lane Princeton, NJ 08544","phone_number":"609-258-6004","contact_email":"lewislib@princeton.edu","gfa_pickup":"PS","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/25.json","library":{"label":"Lewis
         Library","code":"lewis","order":0}},{"label":"Marquand Library of Art and
-        Archaeology (Rare)","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PZ","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/26.json","library":{"label":"Marquand
+        Archaeology (Rare)","address":"McCormick Hall Princeton, NJ 08544","phone_number":"609-258-5863","contact_email":"marquand@princeton.edu","gfa_pickup":"PZ","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/26.json","library":{"label":"Marquand
         Library","code":"marquand","order":0}},{"label":"Mendel Music Library. Sound/Video","address":"Woolworth
-        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"QK","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/27.json","library":{"label":"Mendel
+        Center Princeton, NJ 08544","phone_number":"609-258-3230","contact_email":"muslib@princeton.edu","gfa_pickup":"QK","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/27.json","library":{"label":"Mendel
         Music Library","code":"mendel","order":0}},{"label":"Firestone Library, Microforms
-        (Firestone Use Only)","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PB","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/28.json","library":{"label":"Firestone
+        (Firestone Use Only)","address":"One Washington Rd. Princeton, NJ 08544","phone_number":"609-258-3252","contact_email":"microfms@princeton.edu","gfa_pickup":"PB","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/28.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Preservation","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/29.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609-258-1470","contact_email":"fstcirc@princeton.edu","gfa_pickup":"QP","staff_only":true,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/29.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}},{"label":"Firestone Circulation Desk","address":"One
-        Washington Rd. Princeton, NJ 08544","phone_number":"609 258-2345","contact_email":"fstcirc@princton.edu","gfa_pickup":"QX","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.princeton.edu/locations/delivery_locations/30.json","library":{"label":"Firestone
+        Washington Rd. Princeton, NJ 08544","phone_number":"609 258-2345","contact_email":"fstcirc@princton.edu","gfa_pickup":"QX","staff_only":false,"pickup_location":false,"digital_location":false,"url":"https://bibdata-staging.lib.princeton.edu/locations/delivery_locations/30.json","library":{"label":"Firestone
         Library","code":"firestone","order":0}}]'
   recorded_at: Wed, 24 Aug 2022 17:45:01 GMT
 - request:

--- a/spec/requests/health_check_spec.rb
+++ b/spec/requests/health_check_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Health Check", type: :request do
       body: { responseHeader: { status: 0 } }.to_json, headers: { 'Content-Type' => 'text/json' }
     )
   end
-  let(:bibdata_url) { "https://bibdata-staging.princeton.edu/health.json" }
+  let(:bibdata_url) { "https://bibdata-staging.lib.princeton.edu/health.json" }
   let(:bibdata_stub) do
     stub_request(:get, bibdata_url).to_return(body: File.open('spec/fixtures/bibdata/health.json'))
   end

--- a/spec/views/catalog/librarian_view.html.erb_spec.rb
+++ b/spec/views/catalog/librarian_view.html.erb_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "catalog/librarian_view.html.erb" do
   context "when given an Alma marc source with AVA fields" do
     it "displays the AVA fields" do
       allow(view).to receive(:params).and_return(id: "9922486553506421")
-      stub_request(:get, "https://bibdata-staging.princeton.edu/bibliographic/9922486553506421")
+      stub_request(:get, "https://bibdata-staging.lib.princeton.edu/bibliographic/9922486553506421")
         .to_return(status: 200, body: File.open(Rails.root.join("spec", "fixtures", "alma", "9922486553506421_marc.xml")), headers: {})
 
       render


### PR DESCRIPTION
Rename bibdata-staging.princeton.edu to bibdata-staging.lib.princeton.edu

Bibdata staging is on adc-dev and using the `.lib`