### PR TITLE
[#4374] Remove unneeded cc_email call

### DIFF
--- a/app/mailers/requests/request_mailer.rb
+++ b/app/mailers/requests/request_mailer.rb
@@ -121,7 +121,6 @@ module Requests
       destination_email = @submission.email
       subject = I18n.t('requests.recap.email_subject')
       mail(to: destination_email,
-           cc: cc_email,
            from: I18n.t('requests.default.email_from'),
            subject:)
     end


### PR DESCRIPTION
This used to be needed for access patrons, since Firestone circulation needed to be CCed on those emails.

Since we no longer have the access patron feature, we can remove it.

Resolves #4374