### PR TITLE
[#4372] Retrieving a temp location for the second time in Requests::Form should not return nil

### DIFF
--- a/app/models/requests/form.rb
+++ b/app/models/requests/form.rb
@@ -258,8 +258,8 @@ module Requests
 
       def get_current_location(item_location_code:)
         if item_location_code != location_code
-          @temp_locations ||= {}
-          @temp_locations[item_location_code] = get_location_data(item_location_code) if @temp_locations[item_location_code].blank?
+          @temp_locations ||= TempLocationCache.new
+          @temp_locations.retrieve(item_location_code)
         else
           location
         end

--- a/app/models/requests/temp_location_cache.rb
+++ b/app/models/requests/temp_location_cache.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Requests
+  # This class is responsible for caching a list of temporary
+  # locations in memory
+  class TempLocationCache
+    include Requests::Bibdata
+
+    def initialize
+      @temp_locations = {}
+    end
+
+    def retrieve(item_location_code)
+      @temp_locations[item_location_code] ||= get_location_data(item_location_code)
+    end
+  end
+end

--- a/spec/requests/temp_location_cache_spec.rb
+++ b/spec/requests/temp_location_cache_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Requests::TempLocationCache do
+  describe 'retrieve' do
+    it 'gets the data from a bibdata request' do
+      bibdata_stub = stub_temp_location_request
+      cache = described_class.new
+
+      cache.retrieve 'RES_SHARE$OUT_RS_REQ'
+
+      expect(bibdata_stub).to have_been_requested
+    end
+    it 'returns a hash of data' do
+      stub_temp_location_request
+      cache = described_class.new
+
+      expect(cache.retrieve('RES_SHARE$OUT_RS_REQ')[:label]).to eq('Borrowing Resource Sharing Requests')
+    end
+    context 'when the specific temp location is requested multiple times' do
+      it 'sends only one request to bibdata' do
+        bibdata_stub = stub_temp_location_request
+        cache = described_class.new
+
+        3.times { cache.retrieve 'RES_SHARE$OUT_RS_REQ' }
+
+        expect(bibdata_stub).to have_been_requested.times(1)
+      end
+      it 'returns a hash of data' do
+        stub_temp_location_request
+        cache = described_class.new
+
+        3.times do
+          expect(cache.retrieve('RES_SHARE$OUT_RS_REQ')[:label]).to eq('Borrowing Resource Sharing Requests')
+        end
+      end
+    end
+  end
+end
+
+def stub_temp_location_request
+  stub_request(:get, 'https://bibdata-staging.lib.princeton.edu/locations/holding_locations/RES_SHARE$OUT_RS_REQ.json')
+    .to_return(body: '{"label":"Borrowing Resource Sharing Requests","code":"RES_SHARE$OUT_RS_REQ","aeon_location":false,"recap_electronic_delivery_location":false,"open":true,"requestable":true,"always_requestable":false,"circulates":true,"remote_storage":"","fulfillment_unit":"RES_FU","library":{"label":"Resource Sharing Library","code":"RES_SHARE","order":0},"holding_library":null,"delivery_locations":[]}')
+end


### PR DESCRIPTION
Prior to this commit, `Requests::Form#get_current_location` would return the location data the first time it was called for a particular temporary location, and then cache the hash in memory.  However, the second time `#get_current_location` was called for a particular temp location, rather than returning the cached value, it would return `nil`, which causes errors later in the process.

This scenario happened when multiple items on a record are in the same temp location.

This commit extracts the caching logic into its own tiny class, and ensures that it returns the location hash whether or not it had been cached previously.

Closes #4372