### PR TITLE
Add a new content-security-policy-report-only header

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -5,22 +5,20 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.frame_ancestors :self, 'https://princeton.libwizard.com'
+    policy.connect_src :self, '*.princeton.edu', 'http://localhost:*'
+    policy.font_src    :self, 'https://maxcdn.bootstrapcdn.com', 'https://use.typekit.net'
+    policy.img_src     :self, :https, :data
+    policy.media_src   :self, :data
+    policy.script_src  :self, :https, :unsafe_eval, :unsafe_inline
+    policy.style_src   :self, :https, :unsafe_inline
+    policy.frame_src   :self, 'https://figgy.princeton.edu'
+    policy.report_uri -> { "https://api.honeybadger.io/v1/browser/csp?api_key=#{ENV.fetch('HONEYBADGER_API_KEY', nil)}&report_only=true&env=#{Rails.env}&context[user_id]=#{respond_to?(:current_user) ? current_user&.id : nil}" }
+  end
+
+  # Report violations without enforcing the policy.
+  config.content_security_policy_report_only = true
+end

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'rails_helper'
+RSpec.describe 'Content Security Policy' do
+  let(:directives) do
+    get '/'
+    response.headers['content-security-policy-report-only'].split(';').map(&:strip)
+  end
+  it 'allows libwizard to embed the catalog in an iframe' do
+    frame_ancestors_directive = directives.find { |directive| directive.start_with? 'frame-ancestors' }
+    expect(frame_ancestors_directive).to include('https://princeton.libwizard.com')
+  end
+  it 'allows the catalog to embed figgy in an iframe' do
+    frame_src_directive = directives.find { |directive| directive.start_with? 'frame-src' }
+    expect(frame_src_directive).to include('https://figgy.princeton.edu')
+  end
+end


### PR DESCRIPTION
Report any violations to the console and also to honeybadger, but don't actually block any violations.

The eventual goal will be to replace our current content-security-policy header (currently configured in princeton_ansible) with the contents of the content-security-policy-report-only introduced in this commit.  We can do that when we don't see many violations in Honeybadger.