### PR TITLE
Relax the report-only CSP connect-src directive

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -9,7 +9,7 @@ Rails.application.configure do
   config.content_security_policy do |policy|
     policy.default_src :self
     policy.frame_ancestors :self, 'https://princeton.libwizard.com'
-    policy.connect_src :self, '*.princeton.edu', 'http://localhost:*', 'https://*.google.com', 'https://*.g.doubleclick.net', 'https://maxcdn.bootstrapcdn.com', 'https://*.typekit.net', 'https://*.stackmapintegration.com', 'https://books.google.com'
+    policy.connect_src :self, '*.princeton.edu', 'http://localhost:*', :https
     policy.font_src    :self, :data, 'https://maxcdn.bootstrapcdn.com', 'https://use.typekit.net', 'https://fonts.gstatic.com'
     policy.img_src     :self, :https, :data
     policy.media_src   :self, :data


### PR DESCRIPTION
Google analytics may wish to connect with any of 187 different top-level domains, and it would be annoying to maintain this list in our CSP configuration.  See https://developers.google.com/tag-platform/security/guides/csp#google_analytics_4_google_analytics

Rather than explicitly allow each one of those 187 different domains, this commit just allows connecting to any domain as long as it uses https.