### PR TITLE
[CSP] Set object-src to none to remove vulnerability warning: "object-src" value is not safe

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,6 +13,7 @@ Rails.application.configure do
     policy.font_src    :self, :https, :data
     policy.img_src     :self, :https, :data
     policy.media_src   :self, :data
+    policy.object_src  :none
     policy.script_src  :self, :https, :unsafe_eval, :unsafe_inline
     policy.style_src   :self, :https, :unsafe_inline
     policy.frame_src   :self, 'https://figgy.princeton.edu', 'https://*.doubleclick.net'


### PR DESCRIPTION
related to #4352 

See MDN documentation: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src