### PR TITLE
Remove unnecessary partial

### DIFF
--- a/app/components/index_document_component.html.erb
+++ b/app/components/index_document_component.html.erb
@@ -11,7 +11,6 @@
       <div class="record-wrapper">
         <%= title %>
         <%= render partial: 'catalog/show_identifiers_default', locals: { document: @document } %>
-        <%= render partial: 'catalog/thumbnail_default', locals: { document: @document } %>
         <%= render partial: 'catalog/index_default', locals: { document: @document, doc_presenter: presenter, using_blacklight7:, action: } %>
     </div>
 <% end %>

--- a/app/views/catalog/_thumbnail_default.html.erb
+++ b/app/views/catalog/_thumbnail_default.html.erb
@@ -1,5 +1,0 @@
-<%- if document_presenter(document).thumbnail.exists? && tn = document_presenter(document).thumbnail.thumbnail_tag({}, :counter => document_counter_with_offset(document_counter)) %>
-<%= content_tag(:div, class: "document-thumbnail", data: document.identifier_data) do %>
-  <%= tn %>
-<% end %>
-<%- end %>


### PR DESCRIPTION
This partial is wrapped in an if statement with a condition that always returns `false`. It would return `true` if we had configured a custom `thumbnail_presenter`, but we don't have one of those, so it never displays anything.