### PR TITLE
Only run coveralls in CI, to speed up local test runs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -114,7 +114,7 @@ group :development, :test do
   gem 'rubocop-rails', require: false
   gem 'rubocop-performance', require: false
   gem 'capybara'
-  gem 'coveralls_reborn'
+  gem 'coveralls_reborn', require: false
   gem "erb_lint", require: false
   gem "erblint-github"
   gem 'pry-byebug'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
-require 'coveralls'
+def in_ci?
+  !ENV['CI'].nil? && ENV['CI'] == 'true'
+end
+
+require 'coveralls' if in_ci?
 require 'factory_bot'
 require 'webmock/rspec'
 
@@ -7,11 +11,13 @@ require 'webmock/rspec'
 WebMock.disable_net_connect!(allow_localhost: true,
                              allow: 'chromedriver.storage.googleapis.com')
 
-Coveralls.wear!('rails') do
-  add_filter '/lib/orangelight/browse_lists.rb'
-  add_filter '/app/models/orangelight.rb'
-  add_filter '/lib/tasks'
-  add_filter 'app/controllers/search_history_controller.rb'
+if in_ci?
+  Coveralls.wear!('rails') do
+    add_filter '/lib/orangelight/browse_lists.rb'
+    add_filter '/app/models/orangelight.rb'
+    add_filter '/lib/tasks'
+    add_filter 'app/controllers/search_history_controller.rb'
+  end
 end
 
 FactoryBot.find_definitions
@@ -19,10 +25,6 @@ FactoryBot.find_definitions
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.example_status_persistence_file_path = "tmp/rspec_examples.txt"
-end
-
-def in_ci?
-  !ENV['CI'].nil? && ENV['CI'] == 'true'
 end
 
 ENV['GRAPHQL_API_URL'] = 'https://figgy.princeton.edu/graphql' unless ENV['GRAPHQL_API_URL']


### PR DESCRIPTION
On a sample of tests run locally, this reduced the median time running the tests by 3%.