### PR TITLE
Only load datadog in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem 'bootstrap', '~> 4.6'
 # In the Capistrano documentation, it has these limited to the development group, and `require: false``
 gem 'capistrano', '~> 3.4'
 gem 'capistrano-passenger'
-gem 'ddtrace'
 # Authentication and authorization
 gem 'devise'
 gem 'devise-guests'
@@ -119,4 +118,7 @@ group :development, :test do
   gem "erblint-github"
   gem 'pry-byebug'
   gem 'solargraph'
+end
+group :production do
+  gem 'datadog', require: 'datadog/auto_instrument'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,15 +194,12 @@ GEM
       rexml
     crass (1.0.6)
     csv (3.3.0)
-    datadog-ci (0.8.3)
-      msgpack
-    date (3.3.4)
-    ddtrace (1.23.3)
-      datadog-ci (~> 0.8.1)
+    datadog (2.3.0)
       debase-ruby_core_source (= 3.3.1)
-      libdatadog (~> 7.0.0.1.0)
+      libdatadog (~> 11.0.0.1.0)
       libddwaf (~> 1.14.0.0.0)
       msgpack
+    date (3.3.4)
     debase-ruby_core_source (3.3.1)
     deprecation (1.1.0)
       activesupport
@@ -348,9 +345,9 @@ GEM
       kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
     lcsort (0.9.1)
-    libdatadog (7.0.0.1.0)
-    libdatadog (7.0.0.1.0-aarch64-linux)
-    libdatadog (7.0.0.1.0-x86_64-linux)
+    libdatadog (11.0.0.1.0)
+    libdatadog (11.0.0.1.0-aarch64-linux)
+    libdatadog (11.0.0.1.0-x86_64-linux)
     libddwaf (1.14.0.0.0)
       ffi (~> 1.0)
     libddwaf (1.14.0.0.0-aarch64-linux)
@@ -389,7 +386,7 @@ GEM
     mini_mime (1.1.5)
     mini_portile2 (2.8.7)
     minitest (5.25.1)
-    msgpack (1.7.2)
+    msgpack (1.7.3)
     multi_xml (0.6.0)
     mutex_m (0.2.0)
     net-http (0.4.1)
@@ -747,7 +744,7 @@ DEPENDENCIES
   capistrano-rails
   capybara
   coveralls_reborn
-  ddtrace
+  datadog
   devise
   devise-guests
   ed25519

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
-Datadog.configure do |c|
-  c.tracing.enabled = false unless Rails.env.production?
-  c.env = 'production'
-  # Rails
-  c.tracing.instrument :rails
+if Rails.env.production?
+  Datadog.configure do |c|
+    c.tracing.enabled = false
+    c.env = 'production'
+    # Rails
+    c.tracing.instrument :rails
 
-  # Net::HTTP
-  c.tracing.instrument :http
+    # Net::HTTP
+    c.tracing.instrument :http
 
-  # Faraday
-  c.tracing.instrument :faraday
+    # Faraday
+    c.tracing.instrument :faraday
+  end
 end


### PR DESCRIPTION
This speeds up tests significantly, a random sample of 100 tests takes 19 seconds less without loading datadog.

Identified using [test-prof](https://github.com/test-prof/test-prof) and [speedscope](https://www.speedscope.app/)