### PR TITLE
Add microform icon

### DIFF
--- a/app/assets/stylesheets/icons/icons.scss
+++ b/app/assets/stylesheets/icons/icons.scss
@@ -127,6 +127,13 @@
     }
 }
 
+.icon-microform,
+.blacklight-microform .document-thumbnail .default {
+    &:before {
+        content: $icon-film;
+    }
+}
+
 .icon-audio,
 .blacklight-audio .document-thumbnail .default {
     &:before {


### PR DESCRIPTION
Closes https://github.com/pulibrary/bibdata/issues/2498

Here's how the facets look with this icon:
![an icon showing a strip of film with perforations on the side, next to the term Microform and a count of 18873 matching resources](https://github.com/user-attachments/assets/682c3805-98d8-4ef4-8d2e-d16a18245d04)
