### PR TITLE
[#4430] Printing search results prints title (besides Chinese and Japanese)

### DIFF
--- a/app/assets/stylesheets/print.scss
+++ b/app/assets/stylesheets/print.scss
@@ -60,7 +60,7 @@ td {
   padding: 0;
 }
 
-header,
+header.lux,
 footer,
 #facets,
 .documents-list .col-md-2,
@@ -285,7 +285,7 @@ abbr {
   margin: 0;
 }
 
-.blacklight-catalog-index .blacklight-holdings {
+.blacklight-catalog-index .document-metadata .blacklight-holdings {
   border-left: 2px solid lightgray;
   padding-left: 1em;
   margin-top: 1em;
@@ -294,6 +294,13 @@ abbr {
     margin-bottom: 1em;
   }
 }
+
+header.documentHeader a {
+  font-size: 12pt;
+  font-weight: normal;
+  text-decoration-line: none;
+}
+
 
 /* Hides blocks from print view */
 .hide-print {


### PR DESCRIPTION
closes #4430

Update with correct class path name for search results holding block
Update with correct class foe the app header
Include class for search results header to print the record title with custom styling

- Titles with Japanese or Chinese characters will not get printed in the search results page. 
- Currently the Japanese characters are only printed in the record page because we include the 'lang="ja" attribute. 
- Title with Chinese characters, even though we provide the lang attribute in the record page they are not printed.
- Will create a separate ticket to add the lang attribute in the title search results page to fix the Japanese characters and further investigate the issue with Chinese.