### PR TITLE
Remove confluence link

### DIFF
--- a/app/views/shared/_ask_librarian.html.erb
+++ b/app/views/shared/_ask_librarian.html.erb
@@ -2,9 +2,6 @@
   <h4>Need help?</h4>
   <ul class="menu">
     <li class="help-link">
-      <%= link_to "Using Shared Collection Materials", "https://library.princeton.edu/help/shared-collection" %>
-    </li>
-    <li class="help-link">
       <%= link_to "Ask a librarian", "https://library.princeton.edu/help/ask-a-librarian", class: "icon-chat" %>
     </li>
 </div>


### PR DESCRIPTION
This page is not accessible to the public, and has information that is more useful for staff members, so we don't need this link on our public help page.