### PR TITLE
Display geographic facet

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -127,6 +127,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'subject_topic_facet', label: 'Subject: Topic', limit: true, include_in_advanced_search: false
     config.add_facet_field 'genre_facet', label: 'Subject: Genre', limit: true, include_in_advanced_search: false
     config.add_facet_field 'subject_era_facet', label: 'Subject: Era', limit: true, include_in_advanced_search: false
+    config.add_facet_field 'geographic_facet', label: 'Subject: Geographic', limit: true, include_in_advanced_search: false
     config.add_facet_field 'recently_added_facet', label: 'Recently added', home: true, query: {
       weeks_1: { label: 'Within 1 week', fq: 'cataloged_tdt:[NOW/DAY-7DAYS TO NOW/DAY+1DAY]' },
       weeks_2: { label: 'Within 2 weeks', fq: 'cataloged_tdt:[NOW/DAY-14DAYS TO NOW/DAY+1DAY]' },

--- a/spec/fixtures/alma/9933506421.json
+++ b/spec/fixtures/alma/9933506421.json
@@ -82,6 +82,9 @@
     "Booksellers and bookselling—Italy—Directories",
     "Directories"
   ],
+  "geographic_facet": [
+    "Italy"
+  ],
   "lcgft_s": [
     "Directories"
   ],


### PR DESCRIPTION
Connected to https://github.com/pulibrary/bibdata/issues/2034

<img width="690" alt="image" src="https://github.com/user-attachments/assets/f00a5e7d-2886-484e-ab66-10aec260a9fa">

This does not add it to the advanced search page, since the other "Subject: x" searches are not on the advanced search page. 