### PR TITLE
Update Clancy EDD class to reflect Alma patron group eligibility

### DIFF
--- a/app/models/requests/form.rb
+++ b/app/models/requests/form.rb
@@ -68,7 +68,7 @@ module Requests
       routed_requests = []
       return [] if requestable_items.blank?
       requestable_items.each do |requestable|
-        router = Requests::Router.new(requestable:, user: patron.user, any_loanable: any_loanable_copies?)
+        router = Requests::Router.new(requestable:, any_loanable: any_loanable_copies?, patron:)
         routed_requests << router.routed_request
       end
       routed_requests

--- a/app/models/requests/router.rb
+++ b/app/models/requests/router.rb
@@ -2,13 +2,14 @@
 module Requests
   # This class assigns "services" a given requestable object is available through
   class Router
-    attr_reader :user, :any_loanable, :requestable
+    attr_reader :user, :patron, :any_loanable, :requestable
 
     delegate :cas_provider?, :alma_provider?, to: :user
 
-    def initialize(requestable:, user:, any_loanable: false)
+    def initialize(requestable:, any_loanable: false, patron: nil)
       @requestable = requestable
-      @user = user
+      @user = patron.user
+      @patron = patron
       @any_loanable = any_loanable
     end
 
@@ -44,19 +45,20 @@ module Requests
 
     private
 
+      # rubocop:disable Metrics/AbcSize
       def eligibility_checks
         [
           ServiceEligibility::ILL.new(requestable:, user:, any_loanable:),
           ServiceEligibility::OnOrder.new(requestable:, user:),
-          ServiceEligibility::Annex.new(requestable:, user:),
-          ServiceEligibility::OnShelfDigitize.new(requestable:, user:),
-          ServiceEligibility::OnShelfPickup.new(requestable:, user:),
-          ServiceEligibility::ClancyUnavailable.new(user:, requestable:),
-          ServiceEligibility::ClancyInLibrary.new(user:, requestable:),
-          ServiceEligibility::ClancyEdd.new(user:, requestable:),
+          ServiceEligibility::Annex.new(requestable:, user:, patron:),
+          ServiceEligibility::OnShelfDigitize.new(requestable:, user:, patron:),
+          ServiceEligibility::OnShelfPickup.new(requestable:, user:, patron:),
+          ServiceEligibility::ClancyUnavailable.new(requestable:, user:),
+          ServiceEligibility::ClancyInLibrary.new(requestable:, user:),
+          ServiceEligibility::ClancyEdd.new(requestable:, user:),
           ServiceEligibility::InProcess.new(requestable:, user:),
-          ServiceEligibility::MarquandInLibrary.new(user:, requestable:),
-          ServiceEligibility::MarquandEdd.new(user:, requestable:),
+          ServiceEligibility::MarquandInLibrary.new(requestable:, user:),
+          ServiceEligibility::MarquandEdd.new(requestable:, user:),
           ServiceEligibility::Recap::NoItems.new(requestable:, user:),
           ServiceEligibility::Recap::InLibrary.new(requestable:, user:),
           ServiceEligibility::Recap::AskMe.new(requestable:, user:),
@@ -65,5 +67,6 @@ module Requests
           ServiceEligibility::Aeon.new(requestable:)
         ]
       end
+    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/app/models/requests/router.rb
+++ b/app/models/requests/router.rb
@@ -45,17 +45,16 @@ module Requests
 
     private
 
-      # rubocop:disable Metrics/AbcSize
       def eligibility_checks
         [
           ServiceEligibility::ILL.new(requestable:, user:, any_loanable:),
           ServiceEligibility::OnOrder.new(requestable:, user:),
-          ServiceEligibility::Annex.new(requestable:, user:, patron:),
-          ServiceEligibility::OnShelfDigitize.new(requestable:, user:, patron:),
-          ServiceEligibility::OnShelfPickup.new(requestable:, user:, patron:),
+          ServiceEligibility::Annex.new(requestable:, patron:),
+          ServiceEligibility::OnShelfDigitize.new(requestable:, patron:),
+          ServiceEligibility::OnShelfPickup.new(requestable:, patron:),
           ServiceEligibility::ClancyUnavailable.new(requestable:, user:),
           ServiceEligibility::ClancyInLibrary.new(requestable:, user:),
-          ServiceEligibility::ClancyEdd.new(requestable:, user:),
+          ServiceEligibility::ClancyEdd.new(requestable:, patron:),
           ServiceEligibility::InProcess.new(requestable:, user:),
           ServiceEligibility::MarquandInLibrary.new(requestable:, user:),
           ServiceEligibility::MarquandEdd.new(requestable:, user:),
@@ -67,6 +66,5 @@ module Requests
           ServiceEligibility::Aeon.new(requestable:)
         ]
       end
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/app/models/requests/service_eligibility/abstract_on_shelf.rb
+++ b/app/models/requests/service_eligibility/abstract_on_shelf.rb
@@ -22,6 +22,10 @@ module Requests
             raise "Please implement requestable_eligible? in the subclass"
           end
 
+          def user_eligible?
+            provider_eligible? && patron_group_eligible?
+          end
+
           def on_shelf_eligible?
             !requestable.aeon? && !requestable.charged? &&
               !requestable.in_process? &&
@@ -36,12 +40,11 @@ module Requests
           end
 
           def patron_group_eligible?
-            allowed_patron_groups = %w[P REG GRAD SENR UGRAD]
             allowed_patron_groups.include?(patron.patron_group)
           end
 
-          def user_eligible?
-            provider_eligible? && patron_group_eligible?
+          def allowed_patron_groups
+            @allowed_patron_groups ||= %w[P REG GRAD SENR UGRAD]
           end
 
           attr_reader :requestable, :user, :patron

--- a/app/models/requests/service_eligibility/abstract_on_shelf.rb
+++ b/app/models/requests/service_eligibility/abstract_on_shelf.rb
@@ -2,9 +2,9 @@
 module Requests
   module ServiceEligibility
     class AbstractOnShelf
-      def initialize(requestable:, user:, patron: nil)
+      def initialize(requestable:, patron:)
         @requestable = requestable
-        @user = user
+        @user = patron.user
         @patron = patron
       end
 

--- a/app/models/requests/service_eligibility/abstract_on_shelf.rb
+++ b/app/models/requests/service_eligibility/abstract_on_shelf.rb
@@ -2,9 +2,10 @@
 module Requests
   module ServiceEligibility
     class AbstractOnShelf
-      def initialize(requestable:, user:)
+      def initialize(requestable:, user:, patron: nil)
         @requestable = requestable
         @user = user
+        @patron = patron
       end
 
       def to_s
@@ -35,18 +36,15 @@ module Requests
           end
 
           def patron_group_eligible?
-            patron = ::Bibdata.get_patron(user, ldap: false)
-            return false if patron.nil?
-
             allowed_patron_groups = %w[P REG GRAD SENR UGRAD]
-            allowed_patron_groups.include?(patron["patron_group"])
+            allowed_patron_groups.include?(patron.patron_group)
           end
 
           def user_eligible?
             provider_eligible? && patron_group_eligible?
           end
 
-          attr_reader :requestable, :user
+          attr_reader :requestable, :user, :patron
     end
   end
 end

--- a/app/models/requests/service_eligibility/annex.rb
+++ b/app/models/requests/service_eligibility/annex.rb
@@ -13,6 +13,10 @@ module Requests
           def requestable_eligible?
             on_shelf_eligible? && requestable.annex?
           end
+
+          def allowed_patron_groups
+            @allowed_patron_groups ||= %w[P REG GRAD SENR UGRAD Affiliate-P Affiliate GST]
+          end
     end
   end
 end

--- a/app/models/requests/service_eligibility/clancy_edd.rb
+++ b/app/models/requests/service_eligibility/clancy_edd.rb
@@ -2,9 +2,10 @@
 module Requests
   module ServiceEligibility
     class ClancyEdd
-      def initialize(requestable:, user:)
+      def initialize(requestable:, patron:)
         @requestable = requestable
-        @user = user
+        @user = patron.user
+        @patron = patron
       end
 
       def to_s
@@ -12,13 +13,21 @@ module Requests
       end
 
       def eligible?
-        requestable_eligible? && user_eligible?
+        requestable_eligible? && user_eligible? && patron_eligible?
       end
 
     private
 
       def user_eligible?
         user.cas_provider? || user.alma_provider?
+      end
+
+      def patron_eligible?
+        allowed_patron_groups.include?(patron.patron_group)
+      end
+
+      def allowed_patron_groups
+        @allowed_patron_groups ||= %w[P REG GRAD SENR UGRAD]
       end
 
       def requestable_eligible?
@@ -32,7 +41,8 @@ module Requests
           (requestable.alma_managed? || requestable.partner_holding?) &&
           !requestable.aeon?
       end
-      attr_reader :requestable, :user
+
+      attr_reader :requestable, :user, :patron
     end
   end
 end

--- a/spec/helpers/requests/application_helper_spec.rb
+++ b/spec/helpers/requests/application_helper_spec.rb
@@ -13,9 +13,6 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
   let(:patron) do
     Requests::Patron.new(user:, patron_hash: valid_patron)
   end
-  before do
-    allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
-  end
 
   describe '#isbn_string' do
     let(:isbns) do

--- a/spec/models/requests/form_no_vcr_spec.rb
+++ b/spec/models/requests/form_no_vcr_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Requests::Form, type: :model, requests: true do
         .to_return(status: 200, body: fixture('/bibdata/eastasian_cjk_holding_locations.json'))
       stub_request(:get, "#{Requests.config[:bibdata_base]}/bibliographic/#{params[:system_id]}/holdings/#{params[:mfhd]}/availability.json").to_timeout
       stub_delivery_locations
-      allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
     end
 
     describe "#requestable" do

--- a/spec/models/requests/form_spec.rb
+++ b/spec/models/requests/form_spec.rb
@@ -63,9 +63,6 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       }
     end
     let(:request_with_holding_item) { described_class.new(**params) }
-    before do
-      allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
-    end
 
     describe "#doc" do
       it "returns a solr document" do
@@ -295,9 +292,6 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       }
     end
     let(:request_with_items_at_temp_locations) { described_class.new(**params) }
-    before do
-      allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
-    end
 
     describe "#requestable" do
       it "has a list of requestable objects" do
@@ -360,9 +354,6 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
     let(:architecture) do
       { label: "Architecture Library", gfa_pickup: "PW", pick_up_location_code: "arch", staff_only: false }
     end
-    before do
-      allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
-    end
 
     describe "#requestable" do
       it "has requestable items" do
@@ -415,7 +406,6 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
         .to_return(status: 200, body: "{\"success\":true,\"error\":\"\",\"barcode\":\"32101025649169\",\"status\":\"Item not Found\"}", headers: {})
       stub_request(:get, "#{Requests.config[:clancy_base]}/itemstatus/v1/32101026173334")
         .to_return(status: 200, body: "{\"success\":true,\"error\":\"\",\"barcode\":\"32101026173334\",\"status\":\"Item not Found\"}", headers: {})
-      allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
     end
     describe "#requestable" do
       it "has an requestable items" do
@@ -464,7 +454,6 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
     let(:request_preservation) { described_class.new(**params) }
     describe "#requestable" do
       it "shows items as eligible for illiad" do
-        allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
         expect(request_preservation.requestable[1].services.include?('ill')).to be_truthy
       end
     end
@@ -559,9 +548,6 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       }
     end
     let(:request) { described_class.new(**params) }
-    before do
-      allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
-    end
 
     describe "#requestable" do
       it "has an requestable items" do
@@ -589,9 +575,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       }
     end
     let(:request) { described_class.new(**params) }
-    before do
-      allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
-    end
+
     describe '#requestable' do
       it "has an requestable items" do
         expect(request.requestable.size).to be >= 1
@@ -618,7 +602,6 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
     let(:request) { described_class.new(**params) }
     describe '#requestable' do
       it "has an requestable items" do
-        allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
         expect(request.requestable.size).to be >= 1
       end
     end
@@ -635,7 +618,6 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
     let(:request) { described_class.new(**params) }
     describe '#any_loanable_copies?' do
       it "has available copy" do
-        allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
         expect(request.any_loanable_copies?).to be true
       end
     end
@@ -720,7 +702,6 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
     let(:request) { described_class.new(**params) }
     describe '#any_loanable_copies?' do
       it "has available copy" do
-        allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
         expect(request.any_loanable_copies?).to be true
       end
     end
@@ -737,7 +718,6 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
     let(:request) { described_class.new(**params) }
     describe '#requestable' do
       it "has an requestable items" do
-        allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
         expect(request.requestable.size).to be >= 1
       end
     end
@@ -755,7 +735,6 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
 
     describe "#request" do
       it "has accessible mfhd param" do
-        allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
         expect(request_with_optional_params.mfhd).to eq('22589919750006421')
       end
     end
@@ -772,7 +751,6 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
     let(:request_for_preservation) { described_class.new(**params) }
     describe "#requestable" do
       it "has a preservation location code" do
-        allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
         expect(request_for_preservation.requestable[0].location_code).to eq('firestone$pres')
       end
     end

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -11,9 +11,6 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
               email: "foo@princeton.edu", status: "staff", pustatus: "stf", universityid: "9999999", title: nil } }.with_indifferent_access
   end
   let(:patron) { Requests::Patron.new(user:, patron_hash: valid_patron) }
-  before do
-    allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
-  end
 
   context "Is a bibliographic record on the shelf" do
     let(:request) { FactoryBot.build(:request_on_shelf, patron:) }

--- a/spec/models/requests/router_spec.rb
+++ b/spec/models/requests/router_spec.rb
@@ -27,7 +27,7 @@ describe Requests::Router, vcr: { cassette_name: 'requests_router', record: :non
     let(:scsb_availability_response) { '[{"itemBarcode":"CU53020880","itemAvailabilityStatus":"Not Available","errorMessage":null}]' }
     let(:request_scsb) { Requests::Form.new(**params) }
     let(:requestable) { request_scsb.requestable.first }
-    let(:router) { described_class.new(requestable:, user:) }
+    let(:router) { described_class.new(requestable:, patron:) }
 
     describe "SCSB item that is charged" do
       before do

--- a/spec/models/requests/router_spec.rb
+++ b/spec/models/requests/router_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 describe Requests::Router, vcr: { cassette_name: 'requests_router', record: :none }, requests: true do
   context "A Princeton Community User has signed in" do
     let(:user) { FactoryBot.create(:user) }
-    let(:valid_patron) { { "netid" => "foo" }.with_indifferent_access }
+    let(:valid_patron) { { "netid" => "foo", "patron_group" => "P" }.with_indifferent_access }
     let(:patron) do
       Requests::Patron.new(user:, patron_hash: valid_patron)
     end

--- a/spec/models/requests/router_spec.rb
+++ b/spec/models/requests/router_spec.rb
@@ -54,9 +54,6 @@ describe Requests::Router, vcr: { cassette_name: 'requests_router', record: :non
           item_at_clancy?: false }
       end
       let(:requestable) { instance_double(Requests::Requestable, stubbed_questions) }
-      before do
-        allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
-      end
 
       context "in process" do
         before do

--- a/spec/models/requests/service_eligibility/annex_spec.rb
+++ b/spec/models/requests/service_eligibility/annex_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Requests::ServiceEligibility::Annex, requests: true do
   let(:user) { FactoryBot.create(:user) }
   let(:patron) { Requests::Patron.new(user:, patron_hash: { patron_group: 'P' }) }
-  let(:eligibility) { described_class.new(requestable:, user: FactoryBot.create(:user), patron:) }
+  let(:eligibility) { described_class.new(requestable:, patron:) }
   let(:requestable) { instance_double(Requests::Requestable) }
 
   describe '#eligible?' do

--- a/spec/models/requests/service_eligibility/annex_spec.rb
+++ b/spec/models/requests/service_eligibility/annex_spec.rb
@@ -2,10 +2,13 @@
 require 'rails_helper'
 
 RSpec.describe Requests::ServiceEligibility::Annex, requests: true do
+  let(:user) { FactoryBot.create(:user) }
+  let(:patron) { Requests::Patron.new(user:, patron_hash: { patron_group: 'P' }) }
+  let(:eligibility) { described_class.new(requestable:, user: FactoryBot.create(:user), patron:) }
+  let(:requestable) { instance_double(Requests::Requestable) }
+
   describe '#eligible?' do
     it 'returns true if the item is in the annex' do
-      allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
-      requestable = instance_double(Requests::Requestable)
       allow(requestable).to receive_messages(
           aeon?: false,
           charged?: false,
@@ -17,12 +20,10 @@ RSpec.describe Requests::ServiceEligibility::Annex, requests: true do
           recap_pf?: false,
           held_at_marquand_library?: false
         )
-      eligibility = described_class.new(requestable:, user: FactoryBot.create(:user))
 
       expect(eligibility.eligible?).to be(true)
     end
     it 'returns false if the item is not in the annex' do
-      requestable = instance_double(Requests::Requestable)
       allow(requestable).to receive_messages(
           aeon?: false,
           charged?: false,
@@ -34,7 +35,6 @@ RSpec.describe Requests::ServiceEligibility::Annex, requests: true do
           recap_pf?: false,
           held_at_marquand_library?: false
         )
-      eligibility = described_class.new(requestable:, user: FactoryBot.create(:user))
 
       expect(eligibility.eligible?).to be(false)
     end

--- a/spec/models/requests/service_eligibility/clancy_edd_spec.rb
+++ b/spec/models/requests/service_eligibility/clancy_edd_spec.rb
@@ -2,9 +2,13 @@
 require 'rails_helper'
 
 RSpec.describe Requests::ServiceEligibility::ClancyEdd, requests: true do
+  let(:user) { FactoryBot.create(:user) }
+  let(:patron) { Requests::Patron.new(user:, patron_hash: { patron_group: 'P' }) }
+  let(:eligibility) { described_class.new(requestable:, patron:) }
+  let(:requestable) { instance_double(Requests::Requestable) }
+
   describe '#eligible?' do
     it 'returns true if all criteria are met' do
-      requestable = instance_double(Requests::Requestable)
       allow(requestable).to receive_messages(
           alma_managed?: true,
           held_at_marquand_library?: true,
@@ -18,12 +22,10 @@ RSpec.describe Requests::ServiceEligibility::ClancyEdd, requests: true do
           recap?: false,
           recap_pf?: false
         )
-      eligibility = described_class.new(requestable:, user: FactoryBot.create(:user))
 
       expect(eligibility.eligible?).to be(true)
     end
     it 'returns false if the clancy item is not available' do
-      requestable = instance_double(Requests::Requestable)
       allow(requestable).to receive_messages(
           clancy_available?: false,
           alma_managed?: true,
@@ -37,9 +39,29 @@ RSpec.describe Requests::ServiceEligibility::ClancyEdd, requests: true do
           recap?: false,
           recap_pf?: false
         )
-      eligibility = described_class.new(requestable:, user: FactoryBot.create(:user))
 
       expect(eligibility.eligible?).to be(false)
+    end
+    context 'with an ineligible patron' do
+      let(:patron) { Requests::Patron.new(user:, patron_hash: { patron_group: 'Affiliate-P' }) }
+
+      it 'returns false if the patron is not in an eligible patron group' do
+        allow(requestable).to receive_messages(
+            alma_managed?: true,
+            held_at_marquand_library?: true,
+            item_at_clancy?: true,
+            clancy_available?: true,
+            aeon?: false,
+            charged?: false,
+            in_process?: false,
+            on_order?: false,
+            annex?: false,
+            recap?: false,
+            recap_pf?: false
+          )
+
+        expect(eligibility.eligible?).to be(false)
+      end
     end
   end
 end

--- a/spec/models/requests/service_eligibility/on_shelf_digitize_spec.rb
+++ b/spec/models/requests/service_eligibility/on_shelf_digitize_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Requests::ServiceEligibility::OnShelfDigitize, requests: true do
   let(:user) { FactoryBot.create(:user) }
   let(:patron) { Requests::Patron.new(user:, patron_hash: { patron_group: 'P' }) }
-  let(:eligibility) { described_class.new(requestable:, user: FactoryBot.create(:user), patron:) }
+  let(:eligibility) { described_class.new(requestable:, patron:) }
   let(:requestable) { instance_double(Requests::Requestable) }
 
   describe '#eligible?' do

--- a/spec/models/requests/service_eligibility/on_shelf_digitize_spec.rb
+++ b/spec/models/requests/service_eligibility/on_shelf_digitize_spec.rb
@@ -2,9 +2,13 @@
 require 'rails_helper'
 
 RSpec.describe Requests::ServiceEligibility::OnShelfDigitize, requests: true do
+  let(:user) { FactoryBot.create(:user) }
+  let(:patron) { Requests::Patron.new(user:, patron_hash: { patron_group: 'P' }) }
+  let(:eligibility) { described_class.new(requestable:, user: FactoryBot.create(:user), patron:) }
+  let(:requestable) { instance_double(Requests::Requestable) }
+
   describe '#eligible?' do
     it 'returns true if all criteria are met' do
-      requestable = instance_double(Requests::Requestable)
       allow(requestable).to receive_messages(
           aeon?: false,
           charged?: false,
@@ -17,14 +21,9 @@ RSpec.describe Requests::ServiceEligibility::OnShelfDigitize, requests: true do
           held_at_marquand_library?: false
         )
 
-      user = FactoryBot.create(:valid_princeton_patron)
-      allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
-      eligibility = described_class.new(requestable:, user:)
-
       expect(eligibility.eligible?).to be(true)
     end
     it 'returns true even if the item is in the annex' do
-      requestable = instance_double(Requests::Requestable)
       allow(requestable).to receive_messages(
           aeon?: false,
           charged?: false,
@@ -36,49 +35,46 @@ RSpec.describe Requests::ServiceEligibility::OnShelfDigitize, requests: true do
           recap_pf?: false,
           held_at_marquand_library?: false
         )
-      user = FactoryBot.create(:valid_princeton_patron)
-      allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
-      eligibility = described_class.new(requestable:, user:)
 
       expect(eligibility.eligible?).to be(true)
     end
-    it 'returns true for a user with patron group REG' do
-      requestable = instance_double(Requests::Requestable)
-      allow(requestable).to receive_messages(
-          aeon?: false,
-          charged?: false,
-          in_process?: false,
-          on_order?: false,
-          alma_managed?: true,
-          annex?: false,
-          recap?: false,
-          recap_pf?: false,
-          held_at_marquand_library?: false
-        )
-      user = FactoryBot.create(:valid_princeton_patron)
-      allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "REG" })
-      eligibility = described_class.new(requestable:, user:)
+    context 'with a staff user' do
+      let(:patron) { Requests::Patron.new(user:, patron_hash: { patron_group: 'REG' }) }
 
-      expect(eligibility.eligible?).to be(true)
+      it 'returns true for a user with patron group REG' do
+        allow(requestable).to receive_messages(
+            aeon?: false,
+            charged?: false,
+            in_process?: false,
+            on_order?: false,
+            alma_managed?: true,
+            annex?: false,
+            recap?: false,
+            recap_pf?: false,
+            held_at_marquand_library?: false
+          )
+
+        expect(eligibility.eligible?).to be(true)
+      end
     end
-    it 'returns false for a user with patron group Affiliate' do
-      requestable = instance_double(Requests::Requestable)
-      allow(requestable).to receive_messages(
-          aeon?: false,
-          charged?: false,
-          in_process?: false,
-          on_order?: false,
-          alma_managed?: true,
-          annex?: false,
-          recap?: false,
-          recap_pf?: false,
-          held_at_marquand_library?: false
-        )
-      user = FactoryBot.create(:valid_princeton_patron)
-      allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "Affiliate" })
-      eligibility = described_class.new(requestable:, user:)
 
-      expect(eligibility.eligible?).to be(false)
+    context 'with an Affiliate user' do
+      let(:patron) { Requests::Patron.new(user:, patron_hash: { patron_group: 'Affiliate' }) }
+      it 'returns false for a user with patron group Affiliate' do
+        allow(requestable).to receive_messages(
+            aeon?: false,
+            charged?: false,
+            in_process?: false,
+            on_order?: false,
+            alma_managed?: true,
+            annex?: false,
+            recap?: false,
+            recap_pf?: false,
+            held_at_marquand_library?: false
+          )
+
+        expect(eligibility.eligible?).to be(false)
+      end
     end
   end
 end

--- a/spec/models/requests/service_eligibility/on_shelf_pickup_spec.rb
+++ b/spec/models/requests/service_eligibility/on_shelf_pickup_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Requests::ServiceEligibility::OnShelfPickup, requests: true do
   let(:user) { FactoryBot.create(:user) }
   let(:patron) { Requests::Patron.new(user:, patron_hash: { patron_group: 'P' }) }
-  let(:eligibility) { described_class.new(requestable:, user: FactoryBot.create(:user), patron:) }
+  let(:eligibility) { described_class.new(requestable:, patron:) }
   let(:requestable) { instance_double(Requests::Requestable) }
 
   describe '#eligible?' do

--- a/spec/models/requests/service_eligibility/on_shelf_pickup_spec.rb
+++ b/spec/models/requests/service_eligibility/on_shelf_pickup_spec.rb
@@ -2,10 +2,13 @@
 require 'rails_helper'
 
 RSpec.describe Requests::ServiceEligibility::OnShelfPickup, requests: true do
+  let(:user) { FactoryBot.create(:user) }
+  let(:patron) { Requests::Patron.new(user:, patron_hash: { patron_group: 'P' }) }
+  let(:eligibility) { described_class.new(requestable:, user: FactoryBot.create(:user), patron:) }
+  let(:requestable) { instance_double(Requests::Requestable) }
+
   describe '#eligible?' do
     it 'returns true if all criteria are met' do
-      allow(Bibdata).to receive(:get_patron).and_return({ "patron_group" => "P" })
-      requestable = instance_double(Requests::Requestable)
       allow(requestable).to receive_messages(
           aeon?: false,
           alma_managed?: true,
@@ -18,12 +21,10 @@ RSpec.describe Requests::ServiceEligibility::OnShelfPickup, requests: true do
           recap_pf?: false,
           held_at_marquand_library?: false
         )
-      eligibility = described_class.new(requestable:, user: FactoryBot.create(:user))
 
       expect(eligibility.eligible?).to be(true)
     end
     it 'returns false if the item is in the annex' do
-      requestable = instance_double(Requests::Requestable)
       allow(requestable).to receive_messages(
           aeon?: false,
           charged?: false,
@@ -36,7 +37,6 @@ RSpec.describe Requests::ServiceEligibility::OnShelfPickup, requests: true do
           recap_pf?: false,
           held_at_marquand_library?: false
         )
-      eligibility = described_class.new(requestable:, user: FactoryBot.create(:user))
 
       expect(eligibility.eligible?).to be(false)
     end


### PR DESCRIPTION
- Pass patron to Router, instead of user, since patron includes user, and sometimes we need the patron available
- Make ServiceEligibility signatures more consistent (requestable and then either user or patron)
- Create allowed_patron_groups method in abstract class so that it is more easily overridden
- According to the [spreadsheet](https://docs.google.com/spreadsheets/d/1c4lmMiOzSqMbPYEM5Ni2pofI8lvKpv0FlaRx-xui39E/edit?gid=0#gid=0), Affiliate,  Affiliate-P, and GST patrons should be able to request physical annex items

Closes #4407 
