### PR TITLE
[#4095]FaST subject headings provide a link for subject_facet search

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -111,6 +111,7 @@ detectors:
     - BlacklightAdvancedSearch::QueryParser#prepare_q2
     - BlacklightAdvancedSearch::QueryParser#prepare_q3
     - ApplicationHelper#action_notes_display
+    - ApplicationHelper#fast_subjects_value?
     - ApplicationHelper#html_safe
     - ApplicationHelper#language_iana
     - ApplicationHelper#location_full_display
@@ -266,7 +267,6 @@ detectors:
     - Orangelight::SearchBarComponent#search_fields
     - ApplicationController#after_sign_out_path_for
     - Requests::FormController#sanitize_submission
-    - Requests::ServiceEligibility::AbstractOnShelf#patron_group_eligible?
     - AdvancedHelper#advanced_key_value
     - AdvancedHelper#advanced_search_fields
     - AdvancedHelper#param_for_field
@@ -399,6 +399,7 @@ detectors:
     - Orangelight::AdvancedSearchFormComponent
     - Orangelight::ConstraintComponent
     - Orangelight::ConstraintsComponent
+    - Orangelight::Document::CitationComponent
     - Orangelight::DropdownHelpTextComponent
     - Orangelight::FacetFieldCheckboxesComponent
     - Orangelight::SearchBarComponent
@@ -525,7 +526,6 @@ detectors:
     - Orangelight::ConstraintsComponent#initialize
     - ApplicationHelper#locate_link_with_glyph
     - ApplicationHelper#locate_url
-    - HoldingsHelper#first_two_holdings_block
     - HoldingsHelper#holding_status_li
     - Requests::ApplicationHelper#single_pickup
     - Requests::RequestMailer#confirmation_email
@@ -602,6 +602,7 @@ detectors:
     - BlacklightAdvancedSearch::ParsingNestingParser#process_query
     - ApplicationHelper#aeon_location?
     - ApplicationHelper#alma_location_display
+    - ApplicationHelper#fast_subjects_value?
     - ApplicationHelper#holding_location_label
     - ApplicationHelper#locate_link_with_glyph
     - ApplicationHelper#render_location_code
@@ -617,7 +618,6 @@ detectors:
     - Requests::ApplicationHelper#hidden_fields_item
     - Requests::ApplicationHelper#hidden_fields_mfhd
     - Requests::RequestHelper#login_url
-    - Requests::ServiceEligibility::AbstractOnShelf#patron_group_eligible?
     - Blacklight::Document::Ris#ris_authors
     - Blacklight::Document::Ris#ris_format
     - Blacklight::Marc::CtxBuilder#add_identifiers
@@ -841,6 +841,7 @@ detectors:
     exclude:
     - BlacklightAdvancedSearch::QueryParser#prepare_q2
     - BlacklightAdvancedSearch::QueryParser#prepare_q3
+    - ApplicationHelper#fast_subjects_value?
     - Requests::IlliadMetadata::Metadata#initialize
     - Orangelight::LinkToFacetProcessor#link
   UncommunicativeVariableName:
@@ -918,6 +919,7 @@ detectors:
     - ApplicationHelper#alma_location_display
     - ApplicationHelper#bibdata_location_code_to_sym
     - ApplicationHelper#current_year
+    - ApplicationHelper#fast_subjects_value?
     - ApplicationHelper#format_render
     - ApplicationHelper#holding_location
     - ApplicationHelper#holding_request_block

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -286,6 +286,7 @@ Naming/MethodParameterName:
     - 'app/services/faceted_query_service.rb'
     - 'app/services/stackmap_service.rb'
     - 'lib/orangelight/browse_lists/call_number_csv.rb'
+    - 'app/helpers/application_helper.rb'
 
 # Offense count: 7
 # This cop supports safe autocorrection (--autocorrect).

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -294,7 +294,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'homoit_genre_s', label: 'Homosaurus genre(s)', helper_method: :subjectify
     config.add_show_field 'rbgenr_s', label: 'Rare books genre', helper_method: :subjectify
     config.add_show_field 'aat_s', label: 'Getty AAT genre', helper_method: :subjectify
-    config.add_show_field 'fast_subject_display', label: 'FaST Subject(s)'
+    config.add_show_field 'fast_subject_display', label: 'FaST Subject(s)', helper_method: :subjectify
     config.add_show_field 'related_works_1display', label: 'Related work(s)', helper_method: :name_title_hierarchy
     config.add_show_field 'series_display', label: 'Series', series_link: true
     config.add_show_field 'contains_1display', label: 'Contains', helper_method: :name_title_hierarchy

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -148,12 +148,12 @@ module ApplicationHelper
       full_sub = ''
       all_subjects[i].each_with_index do |subsubject, j|
         lnk = lnk_accum + link_to(subsubject,
-                                  "/?f[subject_facet][]=#{CGI.escape sub_array[i][j]}", class: 'search-subject', 'data-original-title' => "Search: #{sub_array[i][j]}")
+                                  "/?f[subject_facet][]=#{CGI.escape StringFunctions.trim_punctuation(sub_array[i][j])}", class: 'search-subject', 'data-original-title' => "Search: #{sub_array[i][j]}")
         lnk_accum = lnk + content_tag(:span, SEPARATOR, class: 'subject-level')
         full_sub = sub_array[i][j]
       end
       lnk += '  '
-      lnk += link_to('[Browse]', "/browse/subjects?q=#{CGI.escape full_sub}", class: 'browse-subject', 'data-original-title' => "Browse: #{full_sub}", 'aria-label' => "Browse: #{full_sub}", dir: full_sub.dir.to_s)
+      lnk += link_to('[Browse]', "/browse/subjects?q=#{CGI.escape full_sub}", class: 'browse-subject', 'data-original-title' => "Browse: #{full_sub}", 'aria-label' => "Browse: #{full_sub}", dir: full_sub.dir.to_s) unless fast_subjects_value?(args, i)
       args[:document][args[:field]][i] = lnk.html_safe
     end
     content_tag :ul do
@@ -351,4 +351,12 @@ module ApplicationHelper
   def should_show_viewer?
     request.human? && controller.action_name != "librarian_view"
   end
+
+  private
+
+    def fast_subjects_value?(args, i)
+      fast_subject_display_field = args[:document]["fast_subject_display"]
+      return false if fast_subject_display_field.nil?
+      fast_subject_display_field.present? && fast_subject_display_field.include?(args[:document][args[:field]][i])
+    end
 end

--- a/spec/requests/request_spec.rb
+++ b/spec/requests/request_spec.rb
@@ -109,7 +109,7 @@ describe 'blacklight tests' do
 
   SEPARATOR = '—'
   describe 'subjectify check' do
-    it 'provides links to facet search based on hierarchy' do
+    it 'provides links on LC subject headings to facet search based on hierarchy' do
       stub_holding_locations
       get '/catalog/9961398363506421/raw'
       r = JSON.parse(response.body)
@@ -128,6 +128,25 @@ describe 'blacklight tests' do
                                         "href=\"/?f[subject_facet][]="\
                                         "#{CGI.escape subject[/.*#{c}/]}\">"\
                                         "#{component}</a>")
+        end
+      end
+    end
+    it 'provides links on FaST subject headings to facet search based on hierarchy' do
+      stub_holding_locations
+      get '/catalog/99125527882306421/raw'
+      r = JSON.parse(response.body)
+      sub_component = []
+      fullsubject = r['fast_subject_display']
+      fullsubject.each do |subject|
+        sub_component << subject.split(SEPARATOR)
+      end
+      get '/catalog/99125527882306421'
+      fullsubject.each_with_index do |_subject, i|
+        sub_component[i].each do |component|
+          Regexp.escape(component)
+          expect(response.body).to include("class=\"search-subject\" data-original-title=\"Search: Criticism, interpretation, etc.\" href=\"/?f[subject_facet][]=Criticism%2C+interpretation%2C+etc\">Criticism, interpretation, etc.</a>  </li><li dir=\"ltr\">")
+
+          expect(response.body).not_to include('href=\"/browse/subjects?q=Criticism%2C+interpretation%2C+etc.\"')
         end
       end
     end


### PR DESCRIPTION
closes #4095 

It does not provide a link for browse subject search

deployed on https://catalog-staging.princeton.edu/catalog/SCSB-13606521