### PR TITLE
Ensure Cotsen accession numbers file correctly for call number browse

### DIFF
--- a/lib/orangelight/string_functions.rb
+++ b/lib/orangelight/string_functions.rb
@@ -44,7 +44,7 @@ module StringFunctions
         norm = norm.gsub(/(CD|DVD|LP|LS)-/, '\1') # should file together regardless of dash
 
         # normalize number to 7-digits, ignore oversize q
-        norm.gsub(/(\d{1,7})(Q|Q OVERSIZE)?$/) do
+        norm.gsub(/(\d{1,7})(Q$|Q OVERSIZE$)?/) do
           format('%07d', Regexp.last_match[1].to_i)
         end
       end

--- a/spec/features/browsables_spec.rb
+++ b/spec/features/browsables_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Browsables' do
+describe 'Browsables', browse: true do
   describe 'Browse by Call Number' do
     context 'with an LC call number' do
       before do

--- a/spec/helpers/orangelight/browsables_helper_spec.rb
+++ b/spec/helpers/orangelight/browsables_helper_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe Orangelight::BrowsablesHelper do
+describe Orangelight::BrowsablesHelper, browse: true do
   let(:integer_bib) { '234267' }
   let(:non_integer_bib) { '?f[call_number_browse_s][]=PRIN 685 2015' }
   let(:scsb_bib) { 'SCSB-8096576' }

--- a/spec/lib/orangelight/browse_lists/call_number_csv_spec.rb
+++ b/spec/lib/orangelight/browse_lists/call_number_csv_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 require 'orangelight/browse_lists'
 require 'orangelight/browse_lists/call_number_csv'
 
-RSpec.describe BrowseLists::CallNumberCSV do
+RSpec.describe BrowseLists::CallNumberCSV, browse: true do
   let(:solr_url) do
     # Remove Solr auth username and password used in CI.
     # Faraday adds as Base64 encoded credentials in the
@@ -55,9 +55,9 @@ RSpec.describe BrowseLists::CallNumberCSV do
       expect(File.read(csv_file).scan(/\n/).count).to eq 496_050
       # Ensure call numbers with spaces in them are stripped for the CSV.
       space_call_line = File.open(csv_file).readlines.find do |line|
-        line.start_with?("53.8")
+        line.start_with?("0000053.0000008")
       end
-      expect(space_call_line).to start_with("53.8,53.8")
+      expect(space_call_line).to start_with("0000053.0000008,53.8")
     end
 
     context "when solr returns a hash with no response key" do

--- a/spec/lib/orangelight/string_functions_spec.rb
+++ b/spec/lib/orangelight/string_functions_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe StringFunctions do
+RSpec.describe StringFunctions, browse: true do
   describe '#cn_normalize' do
     describe 'LC call numbers' do
       it 'LC call numbers with a lowercase x normalize the same as cns without it' do
@@ -42,6 +42,15 @@ RSpec.describe StringFunctions do
       end
       it 'leading zeros normalize the same as without' do
         expect(described_class.cn_normalize('CASSETTE 423')).to eq described_class.cn_normalize('CASSETTE 0423')
+      end
+
+      context 'Cotsen accession numbers' do
+        it 'interleaves integers with strings' do
+          cotsen_one = described_class.cn_normalize('8754 Pams / Eng 19 / Box 071')
+          cotsen_two = described_class.cn_normalize('87550')
+          cotsen_three = described_class.cn_normalize('87550 Pams / Asian 20 / India / Box 2')
+          expect(cotsen_one..cotsen_three).to cover(cotsen_two)
+        end
       end
     end
   end

--- a/spec/lib/tasks/browse_spec.rb
+++ b/spec/lib/tasks/browse_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 require 'rake'
 
-RSpec.describe 'browse rake tasks' do
+RSpec.describe 'browse rake tasks', browse: true do
   self.use_transactional_tests = false
   before do
     Orangelight::Application.load_tasks

--- a/spec/orangelight/browse_list_spec.rb
+++ b/spec/orangelight/browse_list_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe BrowseLists do
+RSpec.describe BrowseLists, browse: true do
   describe ".table_prefix" do
     it "is alma_orangelight" do
       expect(described_class.table_prefix).to eq "alma_orangelight"

--- a/spec/processors/orangelight/browse_link_processor_spec.rb
+++ b/spec/processors/orangelight/browse_link_processor_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Orangelight::BrowseLinkProcessor do
+RSpec.describe Orangelight::BrowseLinkProcessor, browse: true do
   let(:values) { ['1'] }
   let(:config) { Blacklight::Configuration::Field.new(key: 'field', browse_link: :name) }
   let(:document) { SolrDocument.new }

--- a/spec/requests/orangelight/browse_spec.rb
+++ b/spec/requests/orangelight/browse_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Orangelight Browsables', type: :request do
+RSpec.describe 'Orangelight Browsables', type: :request, browse: true do
   describe 'Redirect Tests for Browse' do
     it 'browse_name redirects to browse search' do
       get '/catalog?search_field=browse_name&q=velez'

--- a/spec/requests/request_spec.rb
+++ b/spec/requests/request_spec.rb
@@ -339,7 +339,7 @@ describe 'blacklight tests' do
     end
   end
 
-  describe 'escaping search/browse link urls' do
+  describe 'escaping search/browse link urls', browse: true do
     before do
       stub_holding_locations
       allow(Flipflop).to receive(:highlighting?).and_return(false)

--- a/spec/requests/robots_spec.rb
+++ b/spec/requests/robots_spec.rb
@@ -20,7 +20,7 @@ describe 'robot user-agents' do
       expect(response.body).not_to include('data-availability-record="true"')
     end
   end
-  context 'when visiting call number browse' do
+  context 'when visiting call number browse', browse: true do
     it 'does not include availability information' do
       stub_holding_locations
       get '/browse/call_numbers?search_field=browse_cn&q=HQ',

--- a/spec/routing/orangelight/browsables_routing_spec.rb
+++ b/spec/routing/orangelight/browsables_routing_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe Orangelight::BrowsablesController, type: :routing do
+RSpec.describe Orangelight::BrowsablesController, type: :routing, browse: true do
   describe 'routing' do
     it 'browse/names routes to #index' do
       expect(get: '/browse/names').to route_to('orangelight/browsables#index', model: Orangelight::Name)


### PR DESCRIPTION
- Normalize accession numbers to seven digits whether or not they end with a number
- Add tag for browse tests

Generating call number browse lists on QA.

Closes #4449