### PR TITLE
[#4459] Allow to display html in the message

### DIFF
--- a/app/views/shared/_announcement.html.erb
+++ b/app/views/shared/_announcement.html.erb
@@ -1,7 +1,7 @@
 <%# To remove messages altogether, go to /features and turn off Message display %>
 <%# To set a new message, run the rake task `bundle exec rake announcement:set\["This is my new text."\]` %>
 <%# To see the current message, run `bundle exec rake announcement:show` %>
-<% message = Announcement&.first&.text %>
+<% message = Announcement&.first&.text&.html_safe %>
 <% if Orangelight.read_only_mode %>
   <div class="col-12 alert alert-warning announcement">
     <div class="container">


### PR DESCRIPTION
closes #4459 


See https://github.com/pulibrary/orangelight/issues/4459#issuecomment-2427699155