### PR TITLE
Remove font-display: fallback; unknown property

### DIFF
--- a/app/assets/stylesheets/components/record.scss
+++ b/app/assets/stylesheets/components/record.scss
@@ -14,7 +14,6 @@
   .main-content {
     font-family: $font-sans;
     font-size: 1rem;
-    font-display: fallback;
     line-height: 1.5;
 
     h2,


### PR DESCRIPTION
Remove font-display: fallback; unknown property from the dev tools in chrome and firefox