### PR TITLE
[#4344] Remove mm solr parameter when the user's query contains boolean OR

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -12,7 +12,8 @@ class SearchBuilder < Blacklight::SearchBuilder
                                      cjk_mm wildcard_char_strip excessive_paging_error
                                      only_home_facets prepare_left_anchor_search
                                      series_title_results pul_holdings html_facets
-                                     numismatics_facets numismatics_advanced]
+                                     numismatics_facets numismatics_advanced
+                                     adjust_mm]
 
   # mutate the solr_parameters to remove words that are
   # boolean operators, but not intended as such.
@@ -126,6 +127,16 @@ class SearchBuilder < Blacklight::SearchBuilder
         blacklight_config.search_fields[field].delete('clause_params')
       end
     end
+  end
+
+  def adjust_mm(solr_parameters)
+    # If the user is attempting a boolean OR query,
+    # for example: activism OR "social justice"
+    # don't want to cancel out the boolean OR with
+    # an mm configuration that requires all the clauses
+    # to be in the document
+    return unless blacklight_params[:q].to_s.split.include? 'OR'
+    solr_parameters['mm'] = 0
   end
 
   private

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -205,4 +205,30 @@ RSpec.describe SearchBuilder do
       end
     end
   end
+
+  describe '#adjust_mm' do
+    context 'when the query contains a boolean OR' do
+      let(:blacklight_params) do
+        { q: 'Douglas OR fir' }
+      end
+      it 'sets the mm to 0, meaning that we do not require all search terms to appear in the document' do
+        allow(search_builder).to receive(:blacklight_params).and_return(blacklight_params)
+        solr_parameters = {}
+
+        expect { search_builder.adjust_mm(solr_parameters) }.to change { solr_parameters }
+        expect(solr_parameters['mm']).to eq(0)
+      end
+    end
+    context 'when the query does not contain a boolean OR' do
+      let(:blacklight_params) do
+        { q: 'Douglas AND fir for or maybe NOT' }
+      end
+      it 'does not adjust solr_parameters' do
+        allow(search_builder).to receive(:blacklight_params).and_return(blacklight_params)
+        solr_parameters = {}
+
+        expect { search_builder.adjust_mm(solr_parameters) }.not_to change { solr_parameters }
+      end
+    end
+  end
 end

--- a/spec/system/searching_spec.rb
+++ b/spec/system/searching_spec.rb
@@ -164,6 +164,13 @@ describe 'Searching', type: :system, js: false do
     expect(search_results_count).to be < original_results_count
   end
 
+  context 'when the json query dsl is on' do
+    it 'can handle a boolean OR search' do
+      visit '/catalog?search_field=all_fields&q=plasticity+OR+afganistan'
+      expect(page).to have_content('1 - 2 of 2')
+    end
+  end
+
   context 'with the built-in advanced search form', advanced_search: true do
     before do
       allow(Flipflop).to receive(:view_components_advanced_search?).and_return(true)


### PR DESCRIPTION
`mm` has a particular meaning when using the Boolean query parser, which is used when we send JSON queries like this to solr:

```
{"query":{"bool":{"must":[{"edismax":{"query":"activism OR \"social justice\""}}]}}}
```

In these cases, according to Solr's documentation, mm specifies the number of should clauses required for a document to be included in the results.  In our configuration, the default mm is 6<90%, meaning that if there are 6 or fewer clauses, all are required (and if there are 7 or more, 90% of the clauses are required).  This conflicts with and overrides the OR that the user intended.

Therefore, if we notice that the user's query includes OR in all caps, set the mm to 0 (meaning no minimum number of the clauses needs to be included).

Many thanks to @maxkadel for troubleshooting this with me!

closes #4344