### PR TITLE
[#4436] Don't add publisher to corporate author field in default OpenURL

### DIFF
--- a/app/models/concerns/blacklight/marc/book_ctx_builder.rb
+++ b/app/models/concerns/blacklight/marc/book_ctx_builder.rb
@@ -17,7 +17,6 @@ module Blacklight
           {
             genre: 'book',
             au: author,
-            aucorp: publisher,
             pub: publisher,
             edition:,
             isbn:,

--- a/app/models/concerns/blacklight/marc/ctx_builder.rb
+++ b/app/models/concerns/blacklight/marc/ctx_builder.rb
@@ -42,7 +42,6 @@ module Blacklight
             genre:,
             title:,
             creator: author,
-            aucorp: publisher,
             pub: publisher,
             format: @format,
             issn:,

--- a/app/models/requests/aeon_url.rb
+++ b/app/models/requests/aeon_url.rb
@@ -19,6 +19,8 @@ module Requests
 
     private
 
+      attr_reader :document
+
       def query_string
         "#{ctx_with_item_info.kev}&#{aeon_basic_params.to_query}"
       end
@@ -46,7 +48,8 @@ module Requests
           Location: shelf_location_code,
           SubLocation: sub_location,
           ItemInfo1: I18n.t("requests.aeon.access_statement"),
-          ItemNumber: item&.barcode
+          ItemNumber: item&.barcode,
+          'rft.aucorp': document['pub_citation_display']&.first
         }.compact
       end
 

--- a/spec/components/index_document_component_spec.rb
+++ b/spec/components/index_document_component_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe IndexDocumentComponent, type: :component do
     expect(subject.css('span[vocab="http://id.loc.gov/vocabulary/identifiers/"]').length).to eq 1
   end
 
-  it 'includes metadata in the COinS format, which Zotero can read' do
+  it 'includes metadata in the COinS format, which Zotero can read', zotero: true do
     expect(subject.css('span.Z3988').first[:title]).to eq 'ctx_ver=Z39.88-2004&amp;rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&amp;rft.issn=1045-4438'
   end
 end

--- a/spec/features/zotero_support_spec.rb
+++ b/spec/features/zotero_support_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-describe 'Zotero Support via Context Objects' do
+describe 'Zotero Support via Context Objects', zotero: true do
   before do
     stub_holding_locations
   end

--- a/spec/models/concerns/blacklight/marc/book_ctx_builder_spec.rb
+++ b/spec/models/concerns/blacklight/marc/book_ctx_builder_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Blacklight::Marc::BookCtxBuilder do
+RSpec.describe Blacklight::Marc::BookCtxBuilder, zotero: true do
   let(:document) { SolrDocument.new(edition_display: ['Fifth edition']) }
   let(:format) { 'Journal/Magazine' }
   let(:builder) { described_class.new(document:, format:) }

--- a/spec/models/concerns/blacklight/marc/ctx_builder_spec.rb
+++ b/spec/models/concerns/blacklight/marc/ctx_builder_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Blacklight::Marc::CtxBuilder do
+RSpec.describe Blacklight::Marc::CtxBuilder, zotero: true do
   let(:document) { SolrDocument.new }
   let(:format) { 'conference' }
   let(:builder) { described_class.new(document:, format:) }
@@ -36,8 +36,7 @@ RSpec.describe Blacklight::Marc::CtxBuilder do
     end
     context 'when publisher exists in solr' do
       let(:document) { SolrDocument.new('pub_citation_display': ['Penguin', 'Random House']) }
-      it 'publisher is used for the aucorp and pub fields' do
-        expect(builder.build.referent.get_metadata('aucorp')).to eq('Penguin')
+      it 'publisher is used for the pub field' do
         expect(builder.build.referent.get_metadata('pub')).to eq('Penguin')
       end
     end

--- a/spec/models/concerns/blacklight/marc/journal_ctx_builder_spec.rb
+++ b/spec/models/concerns/blacklight/marc/journal_ctx_builder_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe Blacklight::Marc::JournalCtxBuilder do
+RSpec.describe Blacklight::Marc::JournalCtxBuilder, zotero: true do
   let(:document) { SolrDocument.new(author_citation_display: ['Nature Editors']) }
   let(:format) { 'Journal/Magazine' }
   let(:builder) { described_class.new(document:, format:) }

--- a/spec/models/requests/aeon_url_spec.rb
+++ b/spec/models/requests/aeon_url_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Requests::AeonUrl, requests: true do
   let(:document) do
     SolrDocument.new({
                        id: '9999999',
+                       pub_citation_display: ['Random House'],
                        holdings_1display: holdings.to_json.to_s
                      })
   end
@@ -42,6 +43,13 @@ RSpec.describe Requests::AeonUrl, requests: true do
   end
   it 'begins with the aeon prefix' do
     expect(subject).to match(/^#{Requests.config[:aeon_base]}/)
+  end
+  it 'includes publisher as a corporate author' do
+    # This may or may not be desired, emailed special collections on 29 October 2024 to inquire
+    expect(subject).to include('rft.aucorp=Random+House')
+  end
+  it 'includes publisher as a publisher' do
+    expect(subject).to include('rft.pub=Random+House')
   end
   context 'when the location is at a Mudd location' do
     let(:holdings) do


### PR DESCRIPTION
For aeon backwards compatibility, we still include the publisher in the corporate author field when the OpenURL is intended for Aeon.

Also, add a zotero tag to the relevant rspec tests


Closes #4436 