### PR TITLE
[#4472] Provide an abstraction of SearchService#fetch

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -55,7 +55,7 @@ class BookmarksController < CatalogController
     end
 
     def fetch_bookmarked_documents
-      _, @documents = search_service.fetch(bookmark_ids, rows: bookmark_ids.length, fl: '*')
+      @documents = RetrieveRecordService.new.retrieve(search_service, bookmark_ids, rows: bookmark_ids.length, fl: '*')
     end
 
     def convert_to_alma_id(id)

--- a/app/controllers/concerns/orangelight/catalog.rb
+++ b/app/controllers/concerns/orangelight/catalog.rb
@@ -74,7 +74,7 @@ module Orangelight
       return head(:bad_request) unless params[:id] && params[:field]
 
       begin
-        _response, document = search_service.fetch(params[:id])
+        document = RetrieveRecordService.new.retrieve(search_service, params[:id])
       rescue Blacklight::Exceptions::RecordNotFound
         return head(:bad_request)
       end

--- a/app/services/retrieve_record_service.rb
+++ b/app/services/retrieve_record_service.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 # We can remove this service (and just call search_service.fetch directly)
 # after we migrate to Blacklight 8
+# :reek:UncommunicativeVariableName
 class RetrieveRecordService
   # :reek:DuplicateMethodCall
   # :reek:FeatureEnvy
@@ -15,8 +16,7 @@ class RetrieveRecordService
 
   private
 
-    # :reek:UtilityFunction
     def using_blacklight7?
-      Gem.loaded_specs['blacklight'].version.to_s.start_with? '7'
+      @using_blacklight7 ||= Gem.loaded_specs['blacklight'].version.to_s.start_with? '7'
     end
 end

--- a/app/services/retrieve_record_service.rb
+++ b/app/services/retrieve_record_service.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+# We can remove this service (and just call search_service.fetch directly)
+# after we migrate to Blacklight 8
+class RetrieveRecordService
+  # :reek:DuplicateMethodCall
+  # :reek:FeatureEnvy
+  def retrieve(search_service, ...)
+    if using_blacklight7?
+      _response, document = search_service.fetch(...)
+      document
+    else
+      search_service.fetch(...)
+    end
+  end
+
+  private
+
+    # :reek:UtilityFunction
+    def using_blacklight7?
+      Gem.loaded_specs['blacklight'].version.to_s.start_with? '7'
+    end
+end


### PR DESCRIPTION
This method from the search service has a different API in Blacklight 7 vs. Blacklight 8.  This commit provides a small abstraction that checks whether we are using Blacklight 7 or 8, and then uses the appropriate API.

Closes #4472