### PR TITLE
Use search_service wrapper for bookmarks

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -17,7 +17,8 @@ class BookmarksController < CatalogController
   # https://github.com/projectblacklight/blacklight/blob/040933c7a383cd0c5be5895d51ab1004ef3ad5e1/app/controllers/concerns/blacklight/bookmarks.rb#L40-L57
   def index
     @bookmarks = token_or_current_or_guest_user.bookmarks
-    @response, deprecated_document_list = search_service.fetch(bookmark_ids)
+    @response = search_service_compatibility_wrapper.search_results
+    deprecated_document_list = search_service_compatibility_wrapper.fetch(bookmark_ids)
     # <Princeton Modifications>
     # Commented out to use the instance method instead, which adds alma IDs.
     # bookmark_ids = @bookmarks.collect { |b| b.document_id.to_s }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -14,7 +14,7 @@ class CatalogController < ApplicationController
 
   rescue_from Blacklight::Exceptions::RecordNotFound do
     alma_id = "99#{params[:id]}3506421"
-    search_service.fetch(alma_id)
+    search_service_compatibility_wrapper.fetch(alma_id)
     redirect_to solr_document_path(id: alma_id)
   rescue Blacklight::Exceptions::RecordNotFound
     redirect_to '/404'

--- a/spec/features/bookmarks_spec.rb
+++ b/spec/features/bookmarks_spec.rb
@@ -3,6 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'bookmarks' do
+  before do
+    stub_holding_locations
+  end
   describe 'action buttons' do
     it 'has a clear bookmarks button' do
       visit '/bookmarks'
@@ -46,14 +49,6 @@ RSpec.describe 'bookmarks' do
       within('#content') do
         expect(page).not_to have_link("log in")
       end
-    end
-
-    it "displays bookmarks for old voyager IDs" do
-      Bookmark.create(user:, document_id: "10647164", document_type: "SolrDocument")
-      login_as user
-      visit "/bookmarks"
-
-      expect(page).to have_content "History."
     end
   end
 end


### PR DESCRIPTION
We have a rake task to update any existing Voyager ID bookmarks in the database, so we no longer need to migrate the ID number on the fly.