### PR TITLE
Remove bookmarks customizations that are no longer needed

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -27,7 +27,7 @@ class BookmarksController < CatalogController
   private
 
     def fetch_bookmarked_documents
-      bookmark_ids = token_or_current_or_guest_user.bookmarks.collect { |b| b.document_id.to_s }
+      bookmark_ids = token_or_current_or_guest_user.bookmarks.collect { |bookmark| bookmark.document_id.to_s }
       @documents = search_service_compatibility_wrapper.fetch(bookmark_ids, rows: bookmark_ids.length, fl: '*')
     end
 

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -27,6 +27,7 @@ class BookmarksController < CatalogController
   private
 
     def fetch_bookmarked_documents
+      bookmark_ids = token_or_current_or_guest_user.bookmarks.collect { |b| b.document_id.to_s }
       @documents = search_service_compatibility_wrapper.fetch(bookmark_ids, rows: bookmark_ids.length, fl: '*')
     end
 

--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -13,29 +13,6 @@ class BookmarksController < CatalogController
       }
   end
 
-  # Copied from
-  # https://github.com/projectblacklight/blacklight/blob/040933c7a383cd0c5be5895d51ab1004ef3ad5e1/app/controllers/concerns/blacklight/bookmarks.rb#L40-L57
-  def index
-    @bookmarks = token_or_current_or_guest_user.bookmarks
-    @response, deprecated_document_list = search_service.fetch(bookmark_ids)
-    # <Princeton Modifications>
-    # Commented out to use the instance method instead, which adds alma IDs.
-    # bookmark_ids = @bookmarks.collect { |b| b.document_id.to_s }
-    # </Princeton Modifications>
-    @document_list = ActiveSupport::Deprecation::DeprecatedObjectProxy.new(deprecated_document_list, "The @document_list instance variable is now deprecated and will be removed in Blacklight 8.0")
-    respond_to do |format|
-      format.html {}
-      format.rss  { render layout: false }
-      format.atom { render layout: false }
-      format.json do
-        render json: render_search_results_as_json
-      end
-
-      additional_response_formats(format)
-      document_export_formats(format)
-    end
-  end
-
   def print
     fetch_bookmarked_documents
     @url_gen_params = {}
@@ -49,21 +26,8 @@ class BookmarksController < CatalogController
 
   private
 
-    def bookmark_ids
-      bookmarks = token_or_current_or_guest_user.bookmarks
-      bookmarks.collect { |b| convert_to_alma_id(b.document_id.to_s) }
-    end
-
     def fetch_bookmarked_documents
       @documents = search_service_compatibility_wrapper.fetch(bookmark_ids, rows: bookmark_ids.length, fl: '*')
-    end
-
-    def convert_to_alma_id(id)
-      if (id.length < 13) && (id =~ /^\d+$/)
-        "99#{id}3506421"
-      else
-        id
-      end
     end
 
     # byte-order-mark declaring our output as UTF-8 (required for non-ASCII to be handled by Excel)

--- a/spec/features/bookmarks_spec.rb
+++ b/spec/features/bookmarks_spec.rb
@@ -48,12 +48,13 @@ RSpec.describe 'bookmarks' do
       end
     end
 
-    it "displays bookmarks for old voyager IDs" do
-      Bookmark.create(user:, document_id: "10647164", document_type: "SolrDocument")
+    it "only displays bookmarked titles" do
+      stub_holding_locations
+      Bookmark.create(user:, document_id: "99122304923506421", document_type: "SolrDocument")
       login_as user
       visit "/bookmarks"
 
-      expect(page).to have_content "History."
+      expect(page).to have_content "1 entry found"
     end
   end
 end

--- a/spec/system/sorting_spec.rb
+++ b/spec/system/sorting_spec.rb
@@ -24,7 +24,7 @@ describe 'sorting', type: :system, js: false do
 
   context 'the bookmarks page' do
     before do
-      Bookmark.create(user:, document_id: "10647164", document_type: "SolrDocument")
+      Bookmark.create(user:, document_id: "99106471643506421", document_type: "SolrDocument")
       login_as user
       visit "/bookmarks"
     end


### PR DESCRIPTION
This allows us to use Blacklight's built-in #index method, rather than needing to keep our own custom method compatible with both Blacklight 7 and 8.