### PR TITLE
[#4513] Allow users to edit facet-only searches

### DIFF
--- a/app/components/orangelight/advanced_search_form_component.html.erb
+++ b/app/components/orangelight/advanced_search_form_component.html.erb
@@ -7,7 +7,7 @@
   </div>
 <% end %>
 <%= form_tag search_catalog_path, method: @method, class: @classes.join(' '), role: 'search', 'aria-label' => t('blacklight.search.form.submit') do %>
-  <%= render Blacklight::HiddenSearchStateComponent.new(params: {'advanced_type' => 'advanced'}) %>
+  <%= render Blacklight::HiddenSearchStateComponent.new(params: hidden_search_state_params) %>
 
   <div class="advanced row">
       <%# Column 1 %>

--- a/app/components/orangelight/advanced_search_form_component.rb
+++ b/app/components/orangelight/advanced_search_form_component.rb
@@ -38,4 +38,8 @@ class Orangelight::AdvancedSearchFormComponent < Blacklight::AdvancedSearchFormC
       end
     end
   end
+
+  def hidden_search_state_params
+    @params.except(:clause, :f_inclusive, :op, :sort).merge({ 'advanced_type' => 'advanced' })
+  end
 end

--- a/spec/components/orangelight/advanced_search_form_component_spec.rb
+++ b/spec/components/orangelight/advanced_search_form_component_spec.rb
@@ -39,4 +39,13 @@ RSpec.describe Orangelight::AdvancedSearchFormComponent, type: :component, advan
     expect(rendered).to have_field 'clause_1_field', with: 'author'
     expect(rendered).to have_field 'clause_2_field', with: 'title'
   end
+
+  context 'when there is a facet in the params' do
+    let(:params) do
+      { "f" => { "subject_topic_facet" => ["Manuscripts, Arabic"] } }.with_indifferent_access
+    end
+    it 'includes the facet as a hidden field' do
+      expect(rendered).to have_field 'f[subject_topic_facet][]', type: :hidden, with: 'Manuscripts, Arabic'
+    end
+  end
 end

--- a/spec/features/advanced_searching_spec.rb
+++ b/spec/features/advanced_searching_spec.rb
@@ -163,4 +163,17 @@ describe 'advanced searching', advanced_search: true do
       expect(page).to have_field('Format', with: /Audio/)
     end
   end
+
+  it 'can edit a facet-only search' do
+    visit '/?f[subject_topic_facet][]=Manuscripts%2C+Arabic&search_field=all_fields'
+    expect(page).to have_content '1 - 6 of 6'
+
+    click_link 'Edit search'
+    fill_in 'clause_0_query', with: 'literature'
+    click_button 'Search'
+
+    expect(page).to have_content '1 - 2 of 2'
+    expect(page).to have_content 'المقامات'
+    expect(page).to have_content 'مطول'
+  end
 end


### PR DESCRIPTION
We need to include current facet values as hidden fields on the advanced search form, so that they are included in the subsequent search request.

Closes #4513 