### PR TITLE
Inherit record mailer

### DIFF
--- a/app/controllers/concerns/orangelight/catalog.rb
+++ b/app/controllers/concerns/orangelight/catalog.rb
@@ -41,7 +41,7 @@ module Orangelight
 
     # Email Action (this will render the appropriate view on GET requests and process the form and send the email on POST requests)
     def email_action(documents)
-      mail = RecordMailer.email_record(documents, { to: params[:to], reply_to: user_email, message: params[:message], subject: params[:subject] }, url_options)
+      mail = Orangelight::RecordMailer.email_record(documents, { to: params[:to], reply_to: user_email, message: params[:message], subject: params[:subject] }, url_options)
       if mail.respond_to? :deliver_now
         mail.deliver_now
       else

--- a/app/models/orangelight/record_mailer.rb
+++ b/app/models/orangelight/record_mailer.rb
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 
-# Only works for documents with a #to_marc right now.
-class RecordMailer < ActionMailer::Base
+class Orangelight::RecordMailer < RecordMailer
   def email_record(documents, details, url_gen_params)
+    begin
+      title_field = details[:config].email.title_field
+      if title_field
+        [documents.first[title_field]].flatten.first
+      else
+        documents.first.to_semantic_values[:title]
+      end
+    rescue StandardError
+      I18n.t('blacklight.email.text.default_title')
+    end
+
     subject = if details[:subject]&.first.present?
                 details[:subject].first
               else
@@ -11,14 +21,9 @@ class RecordMailer < ActionMailer::Base
 
     @documents      = documents
     @message        = details[:message]
+    @config         = details[:config]
     @url_gen_params = url_gen_params
 
     mail(to: details[:to], reply_to: details[:reply_to], subject:)
-  end
-
-  def sms_record(documents, details, url_gen_params)
-    @documents      = documents
-    @url_gen_params = url_gen_params
-    mail(to: details[:to], subject: '')
   end
 end

--- a/app/views/orangelight/record_mailer/email_record.text.erb
+++ b/app/views/orangelight/record_mailer/email_record.text.erb
@@ -1,5 +1,5 @@
 <%- if @message %>
-<%= t('blacklight.email.text.message', :message => @message)%>
+  <%= t('blacklight.email.text.message', :message => @message)%>
 <% end %>
 
 <% @documents.each do |document| %> 

--- a/app/views/record_mailer/email_record.text.erb
+++ b/app/views/record_mailer/email_record.text.erb
@@ -1,9 +1,13 @@
 <%- if @message %>
-  <%= t('blacklight.email.text.message', :message => @message)%>
+<%= t('blacklight.email.text.message', :message => @message)%>
 <% end %>
 
 <% @documents.each do |document| %> 
-  <%= document.to_email_text %>
+  <% if Orangelight.using_blacklight7? %>
+    <%= document.to_email_text %>
+  <% else %>
+    <%= render Blacklight::DocumentMetadataComponent.new(fields: document_presenter(document).field_presenters(blacklight_config.email_fields), tag: nil, field_layout: Blacklight::MetadataFieldPlainTextLayoutComponent, field_presenter_options: { format: 'text' }) %>
+  <% end %>
   <%= t('blacklight.email.text.url', :url =>polymorphic_url(document, @url_gen_params)) %>
   <%= '-'*80 %>
 <% end %>

--- a/spec/views/orangelight/email_record.text.erb_spec.rb
+++ b/spec/views/orangelight/email_record.text.erb_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'record_mailer/email_record' do
+RSpec.describe 'orangelight/record_mailer/email_record' do
   before do
     assign(:documents, [SolrDocument.new(properties)])
     assign(:url_gen_params, {})


### PR DESCRIPTION
By inheriting the RecordMailer from Blacklight, rather than overlaying it, we make our code more upgrade-proof.

Connected to #4486 