### PR TITLE
[#4518] Center magnifying glass icon in search button on Blacklight 8

### DIFF
--- a/app/assets/stylesheets/components/search.scss
+++ b/app/assets/stylesheets/components/search.scss
@@ -27,6 +27,9 @@ header .search-navbar .input-group .custom-select {
 
 header .search-navbar .input-group .input-group-append .search-btn {
   width: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 #search-navbar {


### PR DESCRIPTION
This does not change the appearance of the blacklight 7 search button, but fixes the blacklight 8 button appearance.

![The magnifying glass icon is centered, although it does look a little top heavy](https://github.com/user-attachments/assets/0c173b43-d189-43e2-ad04-1fd114920ed0)
