### PR TITLE
[#4520] Consistent placement of bookmark checkbox and thumbnail image

### DIFF
--- a/app/assets/stylesheets/components/search-results.scss
+++ b/app/assets/stylesheets/components/search-results.scss
@@ -71,6 +71,12 @@ dd.blacklight-electronic_access_display {
   padding-left: 1em;
 }
 
+.search-result-wrapper {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+}
+
 .thumbnail-wrapper {
   width: 120px;
   float: right;

--- a/app/components/index_document_component.html.erb
+++ b/app/components/index_document_component.html.erb
@@ -7,7 +7,7 @@
   itemscope: true,
   itemtype: @document.itemtype,
   class: classes.flatten.join(' ') do %>
-    <div class="row">
+    <div class="row search-result-wrapper">
       <div class="record-wrapper">
         <%= title %>
         <%= render partial: 'catalog/show_identifiers_default', locals: { document: @document } %>


### PR DESCRIPTION
This keeps the same appearance on Blacklight 7, but fixes the Blacklight 8 appearance.

closes #4520 