### PR TITLE
[#4524] Use lux to provide flash messages

### DIFF
--- a/app/components/orangelight/system/flash_message_component.html.erb
+++ b/app/components/orangelight/system/flash_message_component.html.erb
@@ -1,0 +1,3 @@
+<div class="lux">
+    <lux-alert status="<%= lux_status %>" autoclear autoclear-seconds="5" dismissible><%= message %></lux-alert>
+</div>

--- a/app/components/orangelight/system/flash_message_component.rb
+++ b/app/components/orangelight/system/flash_message_component.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+module Orangelight
+  module System
+    class FlashMessageComponent < Blacklight::System::FlashMessageComponent
+      def initialize(type:, message: nil)
+        super
+        @type = type
+      end
+
+        private
+
+          def lux_status
+            @lux_status ||= { 'success' => 'success',
+                              'notice' => 'info',
+                              'alert' => 'warning',
+                              'error' => 'error' }[@type.to_s] || 'info'
+          end
+    end
+  end
+end

--- a/app/javascript/orangelight/lux_import.js
+++ b/app/javascript/orangelight/lux_import.js
@@ -1,6 +1,6 @@
 import { createApp } from 'vue';
 import 'lux-design-system/dist/style.css';
-import { LuxLibraryFooter } from 'lux-design-system';
+import { LuxAlert, LuxLibraryFooter } from 'lux-design-system';
 import OrangelightHeader from '../orangelight/vue_components/orangelight_header.vue';
 import OnlineOptions from './vue_components/online_options.vue';
 
@@ -12,6 +12,7 @@ export function luxImport() {
     const elements = document.getElementsByClassName('lux');
     for (let i = 0; i < elements.length; i++) {
       createMyApp()
+        .component('lux-alert', LuxAlert)
         .component('lux-library-footer', LuxLibraryFooter)
         .component('online-options', OnlineOptions)
         .component('orangelight-header', OrangelightHeader)

--- a/app/views/shared/_flash_msg.html.erb
+++ b/app/views/shared/_flash_msg.html.erb
@@ -2,7 +2,7 @@
 <div class="flash_messages">
   <div class="container">
     <% [:success, :notice, :error, :alert].each do |type| %>
-      <%= render(Blacklight::System::FlashMessageComponent.with_collection(Array.wrap(flash[type]), type: type)) if flash[type] %>
+      <%= render(Orangelight::System::FlashMessageComponent.with_collection(Array.wrap(flash[type]), type: type)) if flash[type] %>
     <% end %>
   </div>
 </div>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "@vitejs/plugin-vue": "^5.1.2",
     "graphql": "^16.8.1",
     "jest-environment-jsdom": "^29.4.0",
-    "lux-design-system": "^5.9.0",
+    "lux-design-system": "^5.11.0",
     "serialize-javascript": "^5.0.1",
     "unfetch": "^3.1.1",
     "vue": "^3.4.21"

--- a/spec/components/orangelight/system/flash_message_component_spec.rb
+++ b/spec/components/orangelight/system/flash_message_component_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Orangelight::System::FlashMessageComponent, type: :component do
+  it 'can display a notice' do
+    collection = ['Hello!  Welcome!']
+    rendered = render_inline(described_class.with_collection(collection, type: 'notice'))
+
+    lux_alert = rendered.css("lux-alert")
+
+    expect(lux_alert.attribute("status").value).to eq 'info'
+    expect(lux_alert.text).to eq 'Hello!  Welcome!'
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -4227,10 +4227,10 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lux-design-system@^5.9.0:
-  version "5.9.0"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.9.0.tgz#572d489d119b292df84751acb5118b22ad998428"
-  integrity sha512-5jT0T1Cn0Pfee5d5i0ePsBuK0RwxrQRZGCZuhYpk5JwOHKDLNYE+/9gpDbCuMyNkHZOMmFES9wmBQdgOvV6KmQ==
+lux-design-system@^5.11.0:
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-5.11.0.tgz#ee219382ac5c9325b617d02e52e145744b73e23f"
+  integrity sha512-5xk5PPGZxEkuKwgivQA2AXN0VuYyP4Tbk/VEGLcXQGVOcYD40tgy7UWe4kVWoW6Ko900LYrRj+AKS3dmJqYzDQ==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"


### PR DESCRIPTION
This allows us to avoid a bootstrap 4 incompatibility in the Blacklight 8's `Blacklight::System::FlashMessageComponent`.

closes #4524 