### PR TITLE
[#4530] Selected facet value contrast on Blacklight 8

### DIFF
--- a/app/assets/stylesheets/components/facets.scss
+++ b/app/assets/stylesheets/components/facets.scss
@@ -15,7 +15,7 @@
   border-color: #ddd;
 }
 
-.facet-values {
+ul.facet-values {
   li {
     .selected {
       @extend .text-dark;


### PR DESCRIPTION
Both Blacklight 8 and our custom styles specify an !important color for selector `.facet-values li .selected`.

This commit makes our selector a little more specific, so that our rule wins the CSS specificity algorithm.

closes #4530