### PR TITLE
[#4529] Maintain the same selected facet heading color in Blacklight 7 and 8

### DIFF
--- a/app/assets/stylesheets/components/facets.scss
+++ b/app/assets/stylesheets/components/facets.scss
@@ -174,6 +174,14 @@ a.more_facets_link {
   }
 }
 
+.facet-limit-active {
+  .card-header {
+    .btn {
+      color: $dark;
+    }
+  }
+}
+
 .facet-field-heading {
   a {
     &::after {


### PR DESCRIPTION
Closes #4529