### PR TITLE
[#4534] Make Bookmark All button compatible with Blacklight 8

### DIFF
--- a/app/javascript/orangelight/bookmark_all.es6
+++ b/app/javascript/orangelight/bookmark_all.es6
@@ -1,19 +1,21 @@
 export default class BookmarkAllManager {
-
   constructor() {
-    this.element = $("#bookmark_all_input");
+    this.element = $('#bookmark_all_input');
     this.prepopulate_value();
     this.bind_element();
   }
 
   prepopulate_value() {
-    if ($("input.toggle-bookmark:checked").length == $("input.toggle-bookmark").length) {
+    if (
+      $('input.toggle-bookmark:checked').length ==
+      $('input.toggle-bookmark').length
+    ) {
       this.element.prop('checked', true);
     }
   }
 
   bind_element() {
-    $("input.toggle-bookmark").on('click', (e) => {
+    $('input.toggle-bookmark').on('click', (e) => {
       if (!e.target.checked) {
         this.element.prop('checked', false);
       } else {
@@ -30,10 +32,14 @@ export default class BookmarkAllManager {
   }
 
   bookmark_all() {
-    $("input.toggle-bookmark:not(:checked)").trigger('click');
+    document
+      .querySelectorAll('input.toggle-bookmark:not(:checked)')
+      .forEach((checkbox) => checkbox.click());
   }
 
   unbookmark_all() {
-    $("input.toggle-bookmark:checked").trigger('click');
+    document
+      .querySelectorAll('input.toggle-bookmark:checked')
+      .forEach((checkbox) => checkbox.click());
   }
 }


### PR DESCRIPTION
Our jquery code attempts to trigger an event, but it appears that Blacklight 8 is not listening to the events we send.  There are many changes in the JS between Blacklight 7 and Blacklight 8 (7 is in jquery while 8 is in vanilla js, 7 puts the event listener on the specific checkbox/button while 8 puts the event listener on the entire document).

I'm not sure why the jquery event triggering doesn't work with the Blacklight 8 js, but migrating from jquery to vanilla js seems to do the trick in both Blacklight 7 and 8.

Closes #4534