### PR TITLE
[#4531] Remove pivot facet icon customization

### DIFF
--- a/app/assets/stylesheets/components/facets.scss
+++ b/app/assets/stylesheets/components/facets.scss
@@ -211,3 +211,18 @@ h3.facet-field-heading {
   margin-top: 0px;
   padding: .3rem .9rem !important;
 }
+
+/* Blacklight 7 facet customization, we can remove when Blacklight 8 is merged
+   (this rule specifically matches the Blacklight 7 DOM, it does not match anything
+   in Blacklight 8) */
+li:not(.treeitem) button.facet-toggle-handle {
+  font-size: 1.75rem;
+}
+
+/* Blacklight 7 facet customization, we can remove when Blacklight 8 is merged
+   (this rule specifically matches the Blacklight 7 DOM, it does not match anything
+   in Blacklight 8) */
+li:not(.treeitem) .facet-leaf-node {
+  margin-left: 1.5rem;
+  margin-top: -2.2rem;
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -141,10 +141,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'publication_place_facet', label: 'Place of publication', limit: true, include_in_advanced_search: false
 
     config.add_facet_field 'lc_facet', label: 'Classification', component: Blacklight::Hierarchy::FacetFieldListComponent, sort: 'index', limit: 1000, include_in_advanced_search: false, if: ->(_controller, _config, _field) { Flipflop.blacklight_hierarchy_facet? }
-    config.add_facet_field 'classification_pivot_field', label: 'Classification', pivot: %w[lc_1letter_facet lc_rest_facet], collapsing: true, icons: {
-      hide: '<i class="icon toggle"></i>'.html_safe,
-      show: '<i class="icon toggle collapsed"></i>'.html_safe
-    }, include_in_advanced_search: false, unless: ->(_controller, _config, _field) { Flipflop.blacklight_hierarchy_facet? }
+    config.add_facet_field 'classification_pivot_field', label: 'Classification', pivot: %w[lc_1letter_facet lc_rest_facet], collapsing: true, include_in_advanced_search: false, unless: ->(_controller, _config, _field) { Flipflop.blacklight_hierarchy_facet? }
 
     config.add_facet_field 'lc_1letter_facet', label: 'Classification', limit: 25, include_in_request: false, sort: 'index'
     config.add_facet_field 'lc_rest_facet', label: 'Full call number code', limit: 25, include_in_request: false, sort: 'index'


### PR DESCRIPTION
Since we're moving away from the pivot facet anyway (see #4505), I thought we might not mind moving away from our customized pivot facet icon.

The default Blacklight 7 icon doesn't look the greatest (it's a little small), but the default Blacklight 8 icon looks pretty similar to our customized one.

In both Blacklight 7 and 8, the icon is lined up vertically with the facet text, which is a nice improvement over main.

Blacklight 8 default icon:
![large plus and minus icons](https://github.com/user-attachments/assets/12d045fc-df4f-4b19-a1b0-ee8490c97098)

Blacklight 7 default icon:
![Small plus and minus icons](https://github.com/user-attachments/assets/db31c49d-b15a-4c28-97af-c0bfe6a9c33c)

Our customized icon:
![large plus and minus icons, but the icon is much higher vertically than the text](https://github.com/user-attachments/assets/3ea6fc3f-87a3-461c-ad76-ca21af5d8fba)


Closes #4531