### PR TITLE
[#4539] Add test to confirm that bookmark count adjusts when you remove a bookmark.

### DIFF
--- a/spec/features/bookmarks_spec.rb
+++ b/spec/features/bookmarks_spec.rb
@@ -56,5 +56,17 @@ RSpec.describe 'bookmarks' do
 
       expect(page).to have_content "1 entry found"
     end
+
+    it "updates the count of bookmarks when a user removes a bookmark", js: true do
+      stub_holding_locations
+      Bookmark.create(user:, document_id: "99122304923506421", document_type: "SolrDocument")
+      login_as user
+      visit "/bookmarks"
+      expect(page).to have_content 'Bookmarks (1)'
+
+      uncheck 'In Bookmarks'
+
+      expect(page).to have_content 'Bookmarks (0)'
+    end
   end
 end


### PR DESCRIPTION
Currently, this test passes on Blacklight 7, fails on Blacklight 8.3, and passes on Blacklight 8.6.1 thanks to @kirkkwang's work in https://github.com/projectblacklight/blacklight/pull/3351

Helps with #4539