### PR TITLE
Upgrade zeitwerk to 2.6.18

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -734,7 +734,7 @@ GEM
     yajl-ruby (1.4.3)
     yard (0.9.36)
     yell (2.2.2)
-    zeitwerk (2.6.17)
+    zeitwerk (2.6.18)
 
 PLATFORMS
   aarch64-linux


### PR DESCRIPTION
This allows us to use Blacklight 8.6.1.  On our current verions of zeitwerk, Blacklight 8.6.1 gives us an `uninitialized constant Blacklight::Rendering (NameError)` error when we try to start the application.

Many thanks to @cgalarza for your detective work on this issue!

Helps with #4539, since this will allow us to use 8.6.1, which includes a fix for this bug.

See also https://github.com/projectblacklight/blacklight/issues/3431