### PR TITLE
Remove a CSS customization that is no longer needed

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -61,7 +61,6 @@
 @import 'components/search-banner.scss';
 @import 'components/search-options';
 @import 'components/search-results';
-@import 'components/skip-links';
 @import 'components/stackmap-modal';
 @import 'components/tables';
 @import 'components/tables--labels';

--- a/app/assets/stylesheets/components/skip-links.scss
+++ b/app/assets/stylesheets/components/skip-links.scss
@@ -1,3 +1,0 @@
-#skip-link {
-  z-index: 25;
-}


### PR DESCRIPTION
We used to need a z-index to make sure that the library logo didn't cover the skip links.  However, now that we use the Lux Header, we no longer need this!

We expecially won't need it in recent versions of Blacklight 8.  In those versions, the skip link navigation pushes the rest of the content down, rather than appearing on top of existing content.  Therefore, the skip links aren't even fighting for the same part of the screen as the logo, so we definitely don't need a z-index.

In fact, this z-index customization looks very goofy on Blacklight 8.6.1.