### PR TITLE
[#4554] ClausePresenter: don't attempt to call #display_label on a non-existant field configuration

### DIFF
--- a/app/presenters/orangelight/clause_presenter.rb
+++ b/app/presenters/orangelight/clause_presenter.rb
@@ -8,5 +8,12 @@ module Orangelight
         super
       end
     end
+
+    # We will no longer need to override #field_label when/if we
+    # use a release of Blacklight that includes
+    # https://github.com/projectblacklight/blacklight/pull/3442
+    def field_label
+      field_config&.display_label('search')
+    end
   end
 end

--- a/spec/presenters/orangelight/clause_presenter_spec.rb
+++ b/spec/presenters/orangelight/clause_presenter_spec.rb
@@ -16,4 +16,17 @@ RSpec.describe Orangelight::ClausePresenter do
       expect(subject.label).to eq 'NOT some search string'
     end
   end
+  describe '#field_label' do
+    context 'when the field config does not exist' do
+      let(:field_config) { nil }
+
+      it 'returns nil' do
+        expect(subject.field_label).to be_nil
+      end
+
+      it 'does not raise an error' do
+        expect { subject.field_label }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
This fixes an error that appeared when a user specified a search field that does not exist.  It is essentially the same as upstream fix https://github.com/projectblacklight/blacklight/pull/3442, so if that is accepted and we start using a Blacklight release that includes it, we can remove our customized version.

Closes #4554 