### PR TITLE
pull-right pull-left are from the fontawesome library.

### DIFF
--- a/app/components/numismatics_search_form_component.html.erb
+++ b/app/components/numismatics_search_form_component.html.erb
@@ -38,7 +38,7 @@
   </div>
 
   <div class="search-submit-buttons clearfix col-sm-7">
-    <div class="submit-buttons pull-right form-group">
+    <div class="submit-buttons float-right form-group">
       <%= submit_tag t('blacklight.advanced_search.form.search_btn_html'), class: 'btn btn-primary advanced-search-submit', id: "advanced-search-submit" %>
     </div>
 

--- a/app/components/orangelight/advanced_search_form_component.html.erb
+++ b/app/components/orangelight/advanced_search_form_component.html.erb
@@ -49,7 +49,7 @@
   </div>
 
   <div class="search-submit-buttons clearfix col-sm-7">
-    <div class="submit-buttons pull-right form-group">
+    <div class="submit-buttons float-right form-group">
       <%= submit_tag t('blacklight.advanced_search.form.search_btn_html'), class: 'btn btn-primary advanced-search-submit', id: "advanced-search-submit" %>
     </div>
 

--- a/app/views/advanced/numismatics.html.erb
+++ b/app/views/advanced/numismatics.html.erb
@@ -3,7 +3,7 @@
 <div class="advanced-search-form col-12">
   <h1 class="advanced page-header">
     <%= t('blacklight.advanced_search.form.numismatics_title') %>
-    <%= link_to t('blacklight.advanced_search.form.start_over'), '/numismatics', :class =>"btn pull-right clear-form" %>
+    <%= link_to t('blacklight.advanced_search.form.start_over'), '/numismatics', :class =>"btn float-right clear-form" %>
   </h1>
   <p>
   With about 125,000 coins, medals, tokens, decorations, and banknotes, the Princeton University Numismatic Collection

--- a/app/views/bookmarks/_clear_bookmarks_widget.html.erb
+++ b/app/views/bookmarks/_clear_bookmarks_widget.html.erb
@@ -1,1 +1,1 @@
-  <%= link_to t('blacklight.bookmarks.clear.action_title'), clear_bookmarks_path, :method => :delete, :data => { :confirm => t('blacklight.bookmarks.clear.action_confirm') }, :class => 'clear-bookmarks btn btn-danger pull-right' %>
+  <%= link_to t('blacklight.bookmarks.clear.action_title'), clear_bookmarks_path, :method => :delete, :data => { :confirm => t('blacklight.bookmarks.clear.action_confirm') }, :class => 'clear-bookmarks btn btn-danger float-right' %>

--- a/app/views/catalog/_show_tools.html.erb
+++ b/app/views/catalog/_show_tools.html.erb
@@ -1,5 +1,5 @@
 <div class="search-widgets col pr-4">
-  <ul class="navbar navbar-nav pull-right">
+  <ul class="navbar navbar-nav float-right">
     <% if @document.alma_record? || @document.scsb_record? %>
       <li>
         <%= render_cite_link(citation_solr_document_path(id: @document)) %>

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,5 +1,5 @@
 <div id="sortAndPerPage" class="clearfix">
-  <div class="pagination-rss pull-left">
+  <div class="pagination-rss float-left">
     <div class="page-links">
     <%= render :partial => "paginate_compact", :object => @response if show_pagination? %>
     <%= link_to(" ", search_catalog_path(params.permit!.merge(format: 'atom',
@@ -7,7 +7,7 @@
                 :class => "icon-rssfeed", :title => "Subscribe to results feed", "aria-label"=>"Subscribe to results feed" ) %>
     </div>
   </div>
-  <div class="search-widgets pull-right">
+  <div class="search-widgets float-right">
     <% if bookmarks? %>
       <%= render partial: 'tools', locals: { document_list: @document_list } %>
     <% end %>

--- a/app/views/catalog/advanced_search.html.erb
+++ b/app/views/catalog/advanced_search.html.erb
@@ -6,7 +6,7 @@
   <h1 class="advanced page-header">
       <%= t('blacklight.advanced_search.form.title') %>
 
-      <%= link_to t('blacklight.advanced_search.form.start_over'), '/advanced', :class =>"btn pull-right clear-form" %>
+      <%= link_to t('blacklight.advanced_search.form.start_over'), '/advanced', :class =>"btn float-right clear-form" %>
   </h1>
 </div>
 <%= render 'advanced_search_form' %>

--- a/app/views/catalog/librarian_view.html.erb
+++ b/app/views/catalog/librarian_view.html.erb
@@ -5,7 +5,7 @@
     <%= link_to "Back to item", solr_document_path(@document), :class => "btn btn-primary" %>
     </div>
     <div class="search-widgets col pr-4">
-      <ul class="navbar navbar-nav pull-right">
+      <ul class="navbar navbar-nav float-right">
         <li class="print">
           <a href="javascript:if(window.print)window.print()" class="dropdown-item"><span class="icon-print" aria-hidden="true"></span>Send to printer</a>
         </li>

--- a/app/views/feedback/_form.html.erb
+++ b/app/views/feedback/_form.html.erb
@@ -46,7 +46,7 @@
   <%= f.hidden_field :current_url %>
   <div class="form-group row">
     <div class="col-sm-12">
-      <%= f.submit t('blacklight.sms.form.submit'), class: 'btn btn-primary pull-right' %>
+      <%= f.submit t('blacklight.sms.form.submit'), class: 'btn btn-primary float-right' %>
     </div>
   </div>
 <% end %>

--- a/app/views/pages/request.html.erb
+++ b/app/views/pages/request.html.erb
@@ -103,7 +103,7 @@
         <table class="table table-striped">
           <thead>
             <th>Call number</th>
-            <th class="pull-right">Status</th>
+            <th class="float-right">Status</th>
           </thead>
           <tbody>
             <tr>
@@ -113,7 +113,7 @@
                 Q1 .N3 v.210-211 Indices Apr.-Sept. 1966</label>
               </td>
               <td>
-                <span class="list-status pull-right">Available</span>
+                <span class="list-status float-right">Available</span>
               </td>
             </tr>
             <tr>
@@ -123,7 +123,7 @@
                 Q1 .N3   v.212 no.5057-5061 Oct. 1966</label>
               </td>
               <td>
-                <span class="list-status pull-right">Available</span>
+                <span class="list-status float-right">Available</span>
               </td>
             </tr>
             <tr>
@@ -133,7 +133,7 @@
                 Q1 .N3   v.212 no.5062-5065 Nov. 1966</label>
               </td>
               <td>
-                <span class="list-status pull-right">Available</span>
+                <span class="list-status float-right">Available</span>
               </td>
             </tr>
             <tr class="text-muted">
@@ -143,7 +143,7 @@
                 Q1 .N3   v. 212 Dec. 1966</label>
               </td>
               <td>
-                <span class="list-status pull-right">Unavailable</span>
+                <span class="list-status float-right">Unavailable</span>
               </td>
             </tr>
             <tr>
@@ -153,7 +153,7 @@
                 Q1 .N3   v.213,no. 5071-5074 Jan.7-Jan.28, 1967</label>
               </td>
               <td>
-                <span class="list-status pull-right">Available</span>
+                <span class="list-status float-right">Available</span>
               </td>
             </tr>
           </tbody>
@@ -203,7 +203,7 @@
         <table class="table table-striped">
           <thead>
             <th>Call number</th>
-            <th class="pull-right">Status</th>
+            <th class="float-right">Status</th>
           </thead>
           <tbody>
             <tr>
@@ -213,7 +213,7 @@
                 Q1 .N3 v.210-211 Indices Apr.-Sept. 1966</label>
               </td>
               <td>
-                <span class="list-status pull-right">Available</span>
+                <span class="list-status float-right">Available</span>
               </td>
             </tr>
             <tr>
@@ -223,7 +223,7 @@
                 Q1 .N3   v.212 no.5057-5061 Oct. 1966</label>
               </td>
               <td>
-                <span class="list-status pull-right">Available</span>
+                <span class="list-status float-right">Available</span>
               </td>
             </tr>
             <tr>
@@ -233,7 +233,7 @@
                 Q1 .N3   v.212 no.5062-5065 Nov. 1966</label>
               </td>
               <td>
-                <span class="list-status pull-right">Available</span>
+                <span class="list-status float-right">Available</span>
               </td>
             </tr>
             <tr class="text-muted">
@@ -243,7 +243,7 @@
                 Q1 .N3   v. 212 Dec. 1966</label>
               </td>
               <td>
-                <span class="list-status pull-right">Unavailable</span>
+                <span class="list-status float-right">Unavailable</span>
               </td>
             </tr>
             <tr>
@@ -253,7 +253,7 @@
                 Q1 .N3   v.213,no. 5071-5074 Jan.7-Jan.28, 1967</label>
               </td>
               <td>
-                <span class="list-status pull-right">Available</span>
+                <span class="list-status float-right">Available</span>
               </td>
             </tr>
           </tbody>

--- a/app/views/search_history/index.html.erb
+++ b/app/views/search_history/index.html.erb
@@ -5,7 +5,7 @@
   <%= render 'account/login_links', feature_page: "search history" %>
   <h2 class='section-heading'><%=t('blacklight.search_history.no_history')%></h2>
 <%- else -%>
-  <%= link_to t('blacklight.search_history.clear.action_title'), blacklight.clear_search_history_path, :method => :delete, :data => { :confirm => t('blacklight.search_history.clear.action_confirm') }, :class => 'clear-search-history btn btn-danger pull-right' %>
+  <%= link_to t('blacklight.search_history.clear.action_title'), blacklight.clear_search_history_path, :method => :delete, :data => { :confirm => t('blacklight.search_history.clear.action_confirm') }, :class => 'clear-search-history btn btn-danger float-right' %>
   <%= render 'account/login_links', feature_page: "search history" %>
   <h2 class='section-heading'><%=t('blacklight.search_history.recent')%></h2>
   <table class="table table-striped search_history">


### PR DESCRIPTION
currently pull-right pull-left are from the fontawesome library.
Replace then with float-left float-right from Bootstrap 4.x. Helps with the migration to Bootstrap v5
Keeps a consistency with the libraries we use to float items