### PR TITLE
Remove <hr> from login partial

### DIFF
--- a/app/assets/stylesheets/requests/request.scss
+++ b/app/assets/stylesheets/requests/request.scss
@@ -55,6 +55,7 @@
   color: #737373;
   font-size: 1.1em;
   margin: -20px auto 8px;
+  padding-top: 1.8rem;
   text-align: center;
   width: 10ch;
 }

--- a/app/views/shared/_login.html.erb
+++ b/app/views/shared/_login.html.erb
@@ -1,7 +1,6 @@
  <div class='card border-0'>
     <div class='card-body text-center'>
       <%= link_to t('blacklight.login.netid_login_msg'), main_app.user_cas_omniauth_authorize_path, method: :post, class: 'btn btn-primary' %>
-      <hr>
       <p class="or-divider">
       or
       </p>


### PR DESCRIPTION
Remove `<hr>` from login partial
Add padding-top in .or-divider to preserve the space between the two login buttons 
Helps with https://github.com/pulibrary/orangelight/pull/4446