### PR TITLE
[#4566] Move Next and Previous text in the actual <a> tag so that the

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -1,8 +1,8 @@
 en:
   views:
     pagination:
-      previous: '&laquo; <span class="d-none d-lg-inline"> Previous</span>'
-      next: '<span class="d-none d-lg-inline">Next</span> &raquo;'
+      previous: '&laquo; Previous'
+      next: 'Next &raquo;'
   blacklight:
     advanced_search:
       form:


### PR DESCRIPTION
closes #4566 


Tested and works both on main and the Blacklight8-upgrade-v2 branch .

Move Next and Previous text in the actual <a> tag so that the event target in

https://github.com/projectblacklight/blacklight/blob/main/app/javascript/blacklight-frontend/search_context.js#L2 always succeeds on the check regardless of where in the button the user clicks.