### PR TITLE
Change harmful-content-bar not to be sticky

### DIFF
--- a/app/assets/stylesheets/components/nav--harmful-content.scss
+++ b/app/assets/stylesheets/components/nav--harmful-content.scss
@@ -3,7 +3,6 @@
   background-color: #e4e4e4;
   color: #23578B;
   justify-content: space-around;
-  position: sticky;
   bottom: 0;
   @media (max-width: $bp-small) {
     align-items: flex-start;


### PR DESCRIPTION
This came up in one of the Fable user testing sessions where the user, testing with a screen magnifier accessibility tool, could not read the content of the page since the sticky bar was covering a large percentage of the page.

### Current record page in production:

![Current record page in production with sticky bar](https://github.com/user-attachments/assets/d6cd772a-bb14-4a0e-83bc-c3c110b3ccd1)

### Record page with no sticky bar:

![Record page with no sticky bar](https://github.com/user-attachments/assets/68c34c82-4c5d-4790-b11c-6ec5d3883a14)


