### PR TITLE
[#4595] Fix More in Series link on show page

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -230,7 +230,6 @@ detectors:
     - Orangelight::ReferenceNoteUrlProcessor#render
     - Orangelight::SeriesLinkProcessor#render
     - Orangelight::SubjectsOrNotesProcessor#render
-    - SubmissionSerializer#serialize
     - Bibdata#get_patron
     - Bibdata#holding_locations
     - Bibdata#sorted_locations
@@ -256,12 +255,12 @@ detectors:
     - AdvancedHelper#advanced_key_value
     - AdvancedHelper#advanced_search_fields
     - AdvancedHelper#param_for_field
-    - ApplicationHelper#action_notes_display
     - ApplicationHelper#series_results
     - ApplicationHelper#title_hierarchy
     - BlacklightHelper#isbn_resolve
     - BlacklightHelper#issn_resolve
     - BlacklightHelper#lccn_resolve
+    - BlacklightHelper#left_anchor_search?
     - BlacklightHelper#oclc_resolve
     - CatalogHelper#render_search_to_page_title
     - Requests::ApplicationHelper#display_status
@@ -882,10 +881,10 @@ detectors:
     - ApplicationHelper#same_series_result
     - ApplicationHelper#scsb_supervised_items?
     - BlacklightHelper#add_wildcard
+    - BlacklightHelper#boolean_query_searches_left_anchored_field?
     - BlacklightHelper#cjk_unigrams_size
     - BlacklightHelper#escape_left_anchor_query
     - BlacklightHelper#json_field?
-    - BlacklightHelper#left_anchor_search?
     - BlacklightHelper#linked_record_field?
     - BlacklightHelper#render_icon
     - BlacklightHelper#wildcard_char_strip

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -573,6 +573,10 @@ class CatalogController < ApplicationController
       field.include_in_advanced_search = false
       field.include_in_simple_select = false
       field.label = 'Series starts with'
+      field.solr_parameters = {
+        qf: '${in_series_qf}',
+        pf: '${in_series_qf}'
+      }
       field.solr_adv_parameters = {
         qf: '$in_series_qf',
         pf: '$in_series_pf'

--- a/app/processors/orangelight/series_link_processor.rb
+++ b/app/processors/orangelight/series_link_processor.rb
@@ -30,7 +30,7 @@ module Orangelight
         no_parens = authorized_form_of_title(title).gsub(/[()]/, '')
         path = '/catalog'
         query = {
-          "clause[0][field]": 'series_title',
+          "clause[0][field]": 'in_series',
           "clause[0][query]": no_parens,
           "commit": "Search"
         }.to_query

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -82,6 +82,18 @@ describe BlacklightHelper do
         expect(left_anchor_search?(query)).to be true
       end
     end
+    it 'mutates queries that search the in_series field' do
+      query = { "qt" => nil, "json" => { "query" => { "bool" => { "must" => [
+        { edismax:
+          {
+            qf: "${in_series_qf}",
+            pf: "${in_series_pf}",
+            query: "my favorite series"
+          } }
+      ] } } } }
+      prepare_left_anchor_search(query)
+      expect(query["json"]["query"]["bool"]["must"][0][:edismax][:query]).to eq 'my\ favorite\ series*'
+    end
   end
 
   describe '#html_facets' do

--- a/spec/processors/orangelight/series_link_processor_spec.rb
+++ b/spec/processors/orangelight/series_link_processor_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Orangelight::SeriesLinkProcessor do
       expect(rendered.first).to eq('Offenbach, Jacques, 1819-1880. Operas. Selections (Bourg) '\
                                    '<a class="more-in-series" '\
                                    'data-original-title="More in series: Offenbach, Jacques, 1819-1880. Operas. Selections (Bourg)" '\
-                                   'dir="ltr" href="/catalog?clause%5B0%5D%5Bfield%5D=series_title&amp;clause%5B0%5D%5Bquery%5D=Offenbach%2C+Jacques%2C+1819-1880.+Operas.+Selections+Bourg&amp;commit=Search">'\
+                                   'dir="ltr" href="/catalog?clause%5B0%5D%5Bfield%5D=in_series&amp;clause%5B0%5D%5Bquery%5D=Offenbach%2C+Jacques%2C+1819-1880.+Operas.+Selections+Bourg&amp;commit=Search">'\
                                    '[More in this series]</a>')
     end
 
@@ -39,7 +39,7 @@ RSpec.describe Orangelight::SeriesLinkProcessor do
         expect(rendered.first).to eq('Offenbach, Jacques, 1819-1880. Operas. Selections (Bourg) '\
         '<a class="more-in-series" '\
         'data-original-title="More in series: Offenbach, Jacques, 1819-1880. Operas. Selections (Bourg)" '\
-        'dir="ltr" href="/catalog?clause%5B0%5D%5Bfield%5D=series_title&amp;clause%5B0%5D%5Bquery%5D=Offenbach%2C+Jacques%2C+1819-1880.+Operas&amp;commit=Search">'\
+        'dir="ltr" href="/catalog?clause%5B0%5D%5Bfield%5D=in_series&amp;clause%5B0%5D%5Bquery%5D=Offenbach%2C+Jacques%2C+1819-1880.+Operas&amp;commit=Search">'\
         '[More in this series]</a>')
       end
     end

--- a/spec/requests/left_anchor_spec.rb
+++ b/spec/requests/left_anchor_spec.rb
@@ -103,4 +103,23 @@ RSpec.describe "left anchor search", left_anchor: true do
       expect(r['data'].any? { |d| d['id'] == '9928379683506421' }).to eq true
     end
   end
+  context 'in_series field' do
+    it 'matches left-anchored queries' do
+      title_in_series = '9948322283506421' # In the series "Cong shu ji cheng chu bian"
+      query = 'Cong+shu+ji+cheng'
+
+      get "/catalog.json?clause[0][field]=in_series&clause[0][query]=#{query}"
+      matching_ids = JSON.parse(response.body)['data'].pluck('id')
+      expect(matching_ids).to include title_in_series
+    end
+
+    it 'does not match queries with the same keywords that start differently' do
+      title_in_series = '9948322283506421' # In the series "Cong shu ji cheng chu bian"
+      query = 'ji+cheng+chu+bian'
+
+      get "/catalog.json?clause[0][field]=in_series&clause[0][query]=#{query}"
+      matching_ids = JSON.parse(response.body)['data'].pluck('id')
+      expect(matching_ids).not_to include title_in_series
+    end
+  end
 end


### PR DESCRIPTION
Before we started using the JSON Query DSL, this link pointed to a left-anchored search in a solr field called in_series.  The JSON Query DSL was using a different field called series_title (thanks @maxkadel for pointing that out), and it wasn't left-anchored. This meant that users who clicked on that link would get a lot of irrelevant records mixed in with titles from the series.

This commit brings back the old field and the old behavior into the JSON Query DSL implementation.

Thanks to @minjiec for finding and reporting this issue!

Closes #4595 