### PR TITLE
[#4597] Add back all languages to facets on the advanced search form

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -395,6 +395,7 @@ detectors:
     - BookmarksController
     - CatalogController
     - Orangelight::Catalog
+    - Orangelight::ExcessivePaging
     - Orangelight::Stackmap
     - ContactController
     - ErrorsController
@@ -908,6 +909,7 @@ detectors:
     - Requests::RequestHelper#pul_patron_name
     - Requests::RequestHelper#request_title
     - Requests::RequestMailer#annex_items
+    - AdvancedFormSearchBuilder#do_not_limit_facets
     - Bookmark#alma_id?
     - Bookmark#special_system_id?
     - Blacklight::Document::Email#add_online_text

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -841,12 +841,16 @@ class CatalogController < ApplicationController
     end
 
     def search_service_context
-      return {} unless Flipflop.multi_algorithm?
-      return {} unless alternate_search_builder_class # use default if none specified
-      { search_builder_class: alternate_search_builder_class }
+      if %w[advanced_search numismatics].include? action_name
+        { search_builder_class: AdvancedFormSearchBuilder }
+      else
+        return {} unless Flipflop.multi_algorithm?
+        return {} unless configurable_search_builder_class # use default if none specified
+        { search_builder_class: configurable_search_builder_class }
+      end
     end
 
-    def alternate_search_builder_class
+    def configurable_search_builder_class
       return unless search_algorithm_param && allowed_search_algorithms.include?(search_algorithm_param)
 
       "#{search_algorithm_param}_search_builder".camelize.constantize

--- a/app/models/advanced_form_search_builder.rb
+++ b/app/models/advanced_form_search_builder.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+# This class is responsible for building a solr query
+# that renders an advanced search form
+class AdvancedFormSearchBuilder < SearchBuilder
+  self.default_processor_chain += %i[do_not_limit_facets]
+
+  def do_not_limit_facets(solr_params)
+    solr_params.update(solr_params) do |key, value|
+      if key.to_s.end_with? 'facet.limit'
+        "-1"
+      else
+        value
+      end
+    end
+  end
+end

--- a/spec/models/advanced_form_search_builder_spec.rb
+++ b/spec/models/advanced_form_search_builder_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe AdvancedFormSearchBuilder do
+  subject(:builder) { described_class.new([], scope) }
+
+  let(:blacklight_config) { Blacklight::Configuration.new }
+  let(:scope) { Blacklight::SearchService.new config: blacklight_config, search_state: state }
+  let(:state) { Blacklight::SearchState.new({}, blacklight_config) }
+
+  describe '#do_not_limit_facets' do
+    it 'modifies existing facet limits to -1' do
+      solr_params = { "f.instrumentation_facet.facet.limit" => "11" }
+      builder.do_not_limit_facets(solr_params)
+      expect(solr_params).to eq({ "f.instrumentation_facet.facet.limit" => "-1" })
+    end
+
+    it 'does not affect solr parameters unrelated to facet limits' do
+      solr_params = { "rows" => "20" }
+      expect do
+        builder.do_not_limit_facets(solr_params)
+      end.not_to(change { solr_params })
+    end
+  end
+end

--- a/spec/views/catalog/advanced_search.html.erb_spec.rb
+++ b/spec/views/catalog/advanced_search.html.erb_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe 'catalog/index' do
         visit '/advanced'
       end
       it 'has the full list of languages' do
-        pending('Resolving https://github.com/pulibrary/orangelight/issues/4597')
         within '#language_facet-list' do
           language_list_elements = page.find_all('li')
           expect(language_list_elements.size).to be > 10
@@ -29,7 +28,6 @@ RSpec.describe 'catalog/index' do
         visit '/advanced?q=a&search_field=all_fields'
       end
       it 'has the full list of languages' do
-        pending('Resolving https://github.com/pulibrary/orangelight/issues/4597')
         within '#language_facet-list' do
           language_list_elements = page.find_all('li')
           expect(language_list_elements.size).to be > 10


### PR DESCRIPTION
Thanks @maxkadel for finding the underlying issue and writing failing tests! This sends numismatics and advanced search forms through a different search builder than other searches.  As a future step, it would be nice to move some logic specific to those forms out of the general search builder and into this one.

Closes #4597 