### PR TITLE
[#4640] Show skip-links on focus.

### DIFF
--- a/app/assets/stylesheets/components/skip-links.scss
+++ b/app/assets/stylesheets/components/skip-links.scss
@@ -4,5 +4,6 @@
 #skip-link a {
     @include visually-hidden;
     @include visually-hidden-focusable;
+    position: sticky !important;
     margin: .2rem 0;
 }


### PR DESCRIPTION
closes #4640 
This change will not affect the main branch. It fixes #4640 and additionally creates a grey area when the skip-links are on focus. Similar to the Blacklight 8 project.

Skip-links on focus keep the grey area similar to the Blacklight project. 
This is visible only on blacklight 8