### PR TITLE
Include the solr parameters in Publisher and Notes fields for the advanced search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -564,9 +564,9 @@ class CatalogController < ApplicationController
     config.add_search_field('publisher') do |field|
       field.include_in_simple_select = false
       field.label = 'Publisher'
-      field.solr_adv_parameters = {
-        qf: '$publisher_qf',
-        pf: '$publisher_pf'
+      field.solr_parameters = {
+        qf: '${publisher_qf}',
+        pf: '${publisher_pf}'
       }
     end
 
@@ -587,9 +587,9 @@ class CatalogController < ApplicationController
     config.add_search_field('notes') do |field|
       field.include_in_simple_select = false
       field.label = 'Notes'
-      field.solr_adv_parameters = {
-        qf: '$notes_qf',
-        pf: '$notes_pf'
+      field.solr_parameters = {
+        qf: '${notes_qf}',
+        pf: '${notes_pf}'
       }
     end
 

--- a/spec/features/advanced_searching_spec.rb
+++ b/spec/features/advanced_searching_spec.rb
@@ -207,4 +207,31 @@ describe 'advanced searching', advanced_search: true do
     click_button 'Search'
     expect(page).to have_content '1 entry found'
   end
+  it 'gives different results for the publisher search vs. keyword search' do
+    visit '/advanced'
+    select('Keyword', from: 'clause_0_field')
+    fill_in(id: 'clause_0_query', with: 'Center')
+    click_button 'Search'
+    expect(page).to have_content 'Zhong gong zhong yao li shi wen'
+
+    visit '/advanced'
+    select('Publisher', from: 'clause_0_field')
+    fill_in(id: 'clause_0_query', with: 'Center')
+    click_button 'Search'
+    expect(page).to have_content 'Boulder, Col. : The Center, 1978-'
+    expect(page).not_to have_content 'Service Center for Chinese Publications'
+  end
+  it 'gives different results for the notes search vs. keyword search' do
+    visit '/advanced'
+    select('Keyword', from: 'clause_0_field')
+    fill_in(id: 'clause_0_query', with: 'Turkish')
+    click_button 'Search'
+    expect(page).to have_content 'Ahmet Kutsi Tecer sempozyum bildirileri : Sıvas 24 - 27 Nisan 2018'
+
+    visit '/advanced'
+    select('Notes', from: 'clause_0_field')
+    fill_in(id: 'clause_0_query', with: 'Turkish')
+    click_button 'Search'
+    expect(page).not_to have_content 'Ahmet Kutsi Tecer sempozyum bildirileri : Sıvas 24 - 27 Nisan 2018'
+  end
 end


### PR DESCRIPTION
Include the solr parameters in Publisher and Notes fields for the advanced search

Without these they behave like the keyword search
This is fixing a regression related to removing the advanced search gem and replacing it with the built-in advanced search

Thanks to @caroldh who found this bug! 🐛