### PR TITLE
[#4655] Server side validation for report harmful language modal

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,8 +26,18 @@
 
 // Wait for the modal to open
 document.addEventListener('show.blacklight.blacklight-modal', function () {
+  // Add data-remote=true so that Rails UJS knows to submit the form as an AJAX request
+  document
+    .querySelector('#new_report_harmful_language_form')
+    ?.setAttribute('data-remote', true);
   // Wait for the form to be submitted successfully
   $('.modal_form').on('ajax:success', function () {
     Blacklight.Modal.hide();
+  });
+  // Wait for the form to be submitted with an error
+  $('.modal_form').on('ajax:error', function (event, xhr) {
+    if (xhr.status == 422) {
+      Blacklight.Modal.receiveAjax(xhr.responseText);
+    }
   });
 });

--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -23,13 +23,13 @@ class ContactController < ApplicationController
   end
 
   def report_harmful_language
-    @form = ReportHarmfulLanguageForm.new(report_harmful_language_params)
-    if @form.valid? && @form.submit
+    @harmful_language_form = ReportHarmfulLanguageForm.new(report_harmful_language_params)
+    if @harmful_language_form.valid? && @harmful_language_form.submit
       flash[:success] = 'Your report has been submitted'
 
       render "report_harmful_language_success"
     else
-      render partial: "catalog/report_harmful_language_form", locals: { form: @form }
+      render "feedback/report_harmful_language", layout: !request.xhr?, status: :unprocessable_entity
     end
   end
 

--- a/app/views/catalog/_report_harmful_language_form.html.erb
+++ b/app/views/catalog/_report_harmful_language_form.html.erb
@@ -1,8 +1,7 @@
 <%= render :partial=>'shared/flash_msg' %>
 <%= simple_form_for(
       form,
-      remote: true,
-      url: contact_report_harmful_language_path, 
+      url: contact_report_harmful_language_path,
       data:  { blacklight_modal: 'trigger' }, 
       html: { class: "modal_form" }
     ) do |f| 

--- a/spec/features/report_harmful_language_spec.rb
+++ b/spec/features/report_harmful_language_spec.rb
@@ -3,16 +3,30 @@
 require 'rails_helper'
 
 describe 'reporting harmful language', js: true do
-  before do
+  it 'gives an error when the email is invalid' do
     visit 'report_harmful_language?report_harmful_language_form[id]=1234&report_harmful_language_form[title]=Book'
     fill_in(id: 'report_harmful_language_form_message', with: 'Lorem ipsum dolor sit amet, consectetur...')
     fill_in(id: 'report_harmful_language_form_name', with: 'John Smith')
     fill_in(id: 'report_harmful_language_form_email', with: 'john@smith')
+
     click_on('Send')
+
+    expect(page).to have_content 'Email is not a valid email address'
   end
 
-  it 'gives an error when the email is invalid' do
-    pending 'see https://github.com/pulibrary/orangelight/issues/4655'
-    expect(page).to have_content 'Email is not a valid email address'
+  context 'when the form is in a modal' do
+    it 'gives an error within the modal the email is invalid' do
+      stub_holding_locations
+      visit 'catalog/99116000543506421'
+      click_link 'Report Harmful Language'
+      fill_in(id: 'report_harmful_language_form_message', with: 'Lorem ipsum dolor sit amet, consectetur...')
+      fill_in(id: 'report_harmful_language_form_name', with: 'John Smith')
+      fill_in(id: 'report_harmful_language_form_email', with: 'john@smith')
+
+      click_on('Send')
+
+      expect(page).to have_content 'Email is not a valid email address'
+      expect(current_path).to eq '/catalog/99116000543506421' # we should not go to another path, the validation should appear in the modal
+    end
   end
 end


### PR DESCRIPTION
* Make sure that the form has data-remote="true" when in a modal, but not when it is outside a modal.  This way, Rails UJS will handle form submission as an AJAX request while in a modal, but as a normal form submit while outside the modal.
* When form results are invalid, return HTTP status code 422, so that the front end knows to show the validation messages.


Closes #4655 