### PR TITLE
Don't filter out non-home facets on facet suggest searches

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -114,7 +114,7 @@ class SearchBuilder < Blacklight::SearchBuilder
     end
 
     def facet_query_present?
-      blacklight_params[:f].present?
+      blacklight_params[:f].present? || blacklight_params[:action] == 'facet'
     end
 
     def json_query_dsl_clauses

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -133,6 +133,15 @@ RSpec.describe SearchBuilder do
         expect { search_builder.only_home_facets(solr_parameters) }.not_to change { solr_parameters }
       end
     end
+    context 'when there is a facet suggest query' do
+      let(:blacklight_params) do
+        { "controller" => "catalog", "action" => "facet", "id" => "language_facet", "query_fragment" => "a", "only_values" => true }.with_indifferent_access
+      end
+      it 'does not make any changes to the facets' do
+        solr_parameters = { 'facet.field' => ['access_facet', 'language_facet'] }
+        expect { search_builder.only_home_facets(solr_parameters) }.not_to change { solr_parameters }
+      end
+    end
   end
 
   describe '#adjust_mm' do


### PR DESCRIPTION
This allows us to do facet.contains searches, which are needed for #4025, for facet fields like language, which don't show up on the home page.

Helps with #4025