### PR TITLE
Improve performance of the solr query used to generate the advanced search form

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -841,8 +841,10 @@ class CatalogController < ApplicationController
     end
 
     def search_service_context
-      if %w[advanced_search numismatics].include? action_name
+      if action_name == 'advanced_search'
         { search_builder_class: AdvancedFormSearchBuilder }
+      elsif action_name == 'numismatics'
+        { search_builder_class: NumismaticsFormSearchBuilder }
       else
         return {} unless Flipflop.multi_algorithm?
         return {} unless configurable_search_builder_class # use default if none specified

--- a/app/models/advanced_form_search_builder.rb
+++ b/app/models/advanced_form_search_builder.rb
@@ -2,7 +2,7 @@
 # This class is responsible for building a solr query
 # that renders an advanced search form
 class AdvancedFormSearchBuilder < SearchBuilder
-  self.default_processor_chain += %i[do_not_limit_languages]
+  self.default_processor_chain += %i[do_not_limit_languages only_request_advanced_facets]
 
   def do_not_limit_languages(solr_params)
     solr_params.update(solr_params) do |key, value|
@@ -12,5 +12,11 @@ class AdvancedFormSearchBuilder < SearchBuilder
         value
       end
     end
+  end
+
+  # :reek:FeatureEnvy
+  def only_request_advanced_facets(solr_params)
+    solr_params['facet.field'] = blacklight_config.facet_fields.values.select(&:include_in_advanced_search).map(&:key)
+    %w[facet.pivot facet.query stats stats.field].each { |unneeded_field| solr_params.delete unneeded_field }
   end
 end

--- a/app/models/numismatics_form_search_builder.rb
+++ b/app/models/numismatics_form_search_builder.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+class NumismaticsFormSearchBuilder < SearchBuilder
+end

--- a/spec/requests/advanced_search_spec.rb
+++ b/spec/requests/advanced_search_spec.rb
@@ -2,6 +2,12 @@
 
 require 'rails_helper'
 
+RSpec::Matchers.define :request_without_facet_queries do
+  match do |actual|
+    actual[:params].keys.exclude? 'facet.query'
+  end
+end
+
 describe 'Orangelight advanced search', type: :request, advanced_search: true do
   before do
     stub_holding_locations
@@ -10,5 +16,16 @@ describe 'Orangelight advanced search', type: :request, advanced_search: true do
   it 'renders the advanced search form' do
     get '/advanced?f[subject_facet][]=United+Nations-Decision+making'
     expect(response.status).to eq(200)
+  end
+
+  it 'does not send complex facet queries to solr when rendering advanced search form' do
+    # rubocop:disable RSpec/AnyInstance
+    expect_any_instance_of(RSolr::Client).to receive(:send_and_receive)
+      .with('select', request_without_facet_queries)
+      .once
+      .and_call_original
+    # rubocop:enable RSpec/AnyInstance
+
+    get '/advanced'
   end
 end


### PR DESCRIPTION
Running this locally against the production solr sped the solr query up from a median 10,691 ms to a median 1,851 ms.

This removes several potentially expensive parameters from the solr query we send to generate the advanced search page:
* facet.query
* facet.pivot
* stats
* stats.field
* facet.field, except for the facet field values we need to retrieve to render the advanced search form

Since the logic is different on the numismatics form vs advanced form, this commit
splits them into two separate search builders.