### PR TITLE
Advanced form: only process facets that have include_in_advanced_search: true

### DIFF
--- a/app/components/orangelight/advanced_search_form_component.rb
+++ b/app/components/orangelight/advanced_search_form_component.rb
@@ -2,7 +2,7 @@
 
 class Orangelight::AdvancedSearchFormComponent < Blacklight::AdvancedSearchFormComponent
   def initialize_search_filter_controls
-    fields = blacklight_config.facet_fields.select { |_k, v| v.include_in_advanced_search || v.include_in_advanced_search.nil? }
+    fields = blacklight_config.facet_fields.select { |_k, v| v.include_in_advanced_search }
 
     fields.each do |_k, config|
       config.advanced_search_component = Orangelight::FacetFieldCheckboxesComponent


### PR DESCRIPTION
Before this commit, the AdvancedSearchFormComponent processed any field in the CatalogController that did not have include_in_advanced_search: false.

In theory, this should not be particularly expensive, but a subtle bug in Blacklight causes some performance issues in cases where we try to process fields that aren't included in the Solr response and when the solr response contains many facet values -- basically the exact situation of our advanced search form!  See
https://github.com/projectblacklight/blacklight/issues/3484 and https://github.com/projectblacklight/blacklight/pull/3485 for further details.