### PR TITLE
Don't request documents from solr for the advanced search form

### DIFF
--- a/app/models/advanced_form_search_builder.rb
+++ b/app/models/advanced_form_search_builder.rb
@@ -2,7 +2,7 @@
 # This class is responsible for building a solr query
 # that renders an advanced search form
 class AdvancedFormSearchBuilder < SearchBuilder
-  self.default_processor_chain += %i[do_not_limit_languages only_request_advanced_facets]
+  self.default_processor_chain += %i[do_not_limit_languages only_request_advanced_facets no_documents]
 
   def do_not_limit_languages(solr_params)
     solr_params.update(solr_params) do |key, value|
@@ -18,5 +18,10 @@ class AdvancedFormSearchBuilder < SearchBuilder
   def only_request_advanced_facets(solr_params)
     solr_params['facet.field'] = blacklight_config.facet_fields.values.select(&:include_in_advanced_search).map(&:key)
     %w[facet.pivot facet.query stats stats.field].each { |unneeded_field| solr_params.delete unneeded_field }
+  end
+
+  # :reek:UtilityFunction
+  def no_documents(solr_params)
+    solr_params['rows'] = 0
   end
 end

--- a/spec/models/advanced_form_search_builder_spec.rb
+++ b/spec/models/advanced_form_search_builder_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe AdvancedFormSearchBuilder do
+RSpec.describe AdvancedFormSearchBuilder, advanced_search: true do
   subject(:builder) { described_class.new([], scope) }
 
   let(:blacklight_config) { Blacklight::Configuration.new }
@@ -69,6 +69,14 @@ RSpec.describe AdvancedFormSearchBuilder do
       expect(solr_params.keys).not_to include 'stats'
       expect(solr_params.keys).not_to include 'stats.field'
       expect(solr_params.keys).to include 'facet.field'
+    end
+  end
+
+  describe '#no_documents' do
+    it 'adds rows=0' do
+      solr_params = {}
+      builder.no_documents(solr_params)
+      expect(solr_params).to eq({ "rows" => 0 })
     end
   end
 end


### PR DESCRIPTION
Running the solr query with `debug=timing` doesn't indicate any time spent on selecting the documents or retrieving their metadata.  I did however see a slight performance improvement when running `curl` with `rows=0` over the previous `rows=20`. After running it 20 times, it was consistently about 100ms faster with `rows=0`. At the very least, it's a smaller response to send over the network or to write/read to the on-disk cache.