### PR TITLE
Add Requests::Submission#to_h method that is sidekiq-compatible

### DIFF
--- a/spec/support/sidekiq_data_check.rb
+++ b/spec/support/sidekiq_data_check.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+# This class is responsible for checking whether a provided data structure
+# is compatible with sidekiq.
+#
+# See https://github.com/sidekiq/sidekiq/wiki/Best-Practices#1-make-your-job-parameters-small-and-simple
+class SidekiqDataCheck
+  include Sidekiq::JobUtil
+  def initialize(data_to_check)
+    @data_to_check = { "args" => data_to_check }
+  end
+
+  def valid?
+    check
+    true
+  rescue ArgumentError
+    false
+  end
+
+  def error_message
+    check
+  rescue ArgumentError => e
+    e.message
+  end
+
+  private
+
+    attr_reader :data_to_check
+
+    # Returns nil if valid, raises ArgumentError if not
+    def check
+      Sidekiq::Config::DEFAULTS[:on_complex_arguments] = :raise
+      verify_json data_to_check
+    end
+end
+
+RSpec::Matchers.define :be_compatible_with_sidekiq do
+  match { |actual| SidekiqDataCheck.new(actual).valid? }
+  failure_message { |actual| SidekiqDataCheck.new(actual).error_message }
+end


### PR DESCRIPTION
Sidekiq is [very restrictive about which data structures we can pass in with jobs, including to email jobs](https://github.com/sidekiq/sidekiq/wiki/Best-Practices#1-make-your-job-parameters-small-and-simple).

Our `Requests::Submission` object was not built with sidekiq's restrictions in mind, so this commit adds a method that can convert the object into one that is compatible with Sidekiq.

Note that we do not yet use this method anywhere, this is just a preparatory step.  The next steps will be to start incrementally teaching our mailer views to use the `to_h` output rather than `Requests::Submission` directly.

Helps with #4609