### PR TITLE
Use redis 7 in lando to match our prod redis

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -22,7 +22,7 @@ services:
     type: postgres:15
     portforward: true
   orangelight_redis:
-    type: redis:6.0.16
+    type: redis:7
     portforward: true
 proxy:
   orangelight_test_solr:


### PR DESCRIPTION
This is an incremental step toward #4609, so we can actually run sidekiq locally