### PR TITLE
exclude vite server from connect_src so that we resolve

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -9,7 +9,8 @@ Rails.application.configure do
   config.content_security_policy do |policy|
     policy.default_src :self
     policy.frame_ancestors :self, 'https://princeton.libwizard.com', 'https://princeton.instructure.com'
-    policy.connect_src :self, '*.princeton.edu', 'http://localhost:*', :https
+
+    policy.connect_src :self, '*.princeton.edu', 'http://localhost:*', :https, 'ws://localhost:3036/vite-dev/'
     policy.font_src    :self, :https, :data
     policy.img_src     :self, :https, :data
     policy.media_src   :self, :data


### PR DESCRIPTION
Refused to connect to 'ws://localhost:3036/vite-dev/' because it violates the following Content Security Policy directive: "connect-src 'self' *.princeton.edu http://localhost:* https:".


@sandbergja thanks for catching the extra comma. 