### PR TITLE
[#4666] Remove jquery_ujs from application.js

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,7 +11,7 @@
 // about supported directives.
 //
 //= require jquery3
-//= require jquery_ujs
+//= require rails-ujs
 //= require popper
 //
 //= require bootstrap


### PR DESCRIPTION
to resolve 'Uncaught Error: If you load both jquery_ujs and rails-ujs, use rails-ujs only.' in the dev console
part of #4666