### PR TITLE
[#4743] Remove unneeded padding underneath Lux Header

### DIFF
--- a/app/assets/stylesheets/components/header.scss
+++ b/app/assets/stylesheets/components/header.scss
@@ -4,5 +4,8 @@
    there is no layout shift or sudden color change. */
 .pul_header {
     background-color: var(--color-gray-100);
-    height: calc(2rem + 54px);
+    min-height: calc((var(--lux-library-logo-width-large) * .221) + 2rem);
+    @media (max-width: 899px) {
+        min-height: calc((var(--lux-library-logo-width-large) * .14) + 2rem);
+    }
 }


### PR DESCRIPTION
We reserve space on the screen for the Lux Header to avoid layout shifts when the header loads.  In newer versions of Lux, the header is a different size, so we were reserving too much space and it looked odd!

Before (large screen):
![large gap underneath the orange line and above the search box](https://github.com/user-attachments/assets/08d5e6c0-1bca-4a8d-85e7-7e7feb27ef40)

After (large screen):
![no gap](https://github.com/user-attachments/assets/507ae85c-5e62-4265-8b5e-460c5d592ff8)

Before (small screen):
![large gap underneath the orange line and above the search box](https://github.com/user-attachments/assets/d5750bb8-a1d0-46ca-962a-1c8d0a933d9c)

After (small screen):
![no gap, and we can see the rack performance profiler as well](https://github.com/user-attachments/assets/7d6e72bf-042a-4992-b277-9dca23d7ae2a)

Closes #4743 