### PR TITLE
Remove special conditionals for Internet Explorer and IEMobile

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!--[if !IE]><!--><html lang="en" class="no-js"><!--<![endif]-->
+<html lang="en" class="no-js">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
@@ -10,11 +10,6 @@
 
     <!-- OpenGraph metadata when sharing links, e.g., on FB -->
     <meta property="og:title" content="<%= render_page_title %>" />
-
-    <!-- Mobile IE allows us to activate ClearType technology for smoothing fonts for easy reading -->
-    <!--[if IEMobile]>
-      <meta http-equiv="cleartype" content="on">
-    <![endif]-->
 
     <title><%= render_page_title %></title>
     <%= opensearch_description_tag application_name, main_app.opensearch_catalog_url(:format => 'xml') %>
@@ -40,10 +35,6 @@
     <%= javascript_include_tag "https://www.google.com/books/jsapi.js", defer: true %>
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>
-    <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
-    <!--[if lt IE 9]>
-      <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>
-    <![endif]-->
     <%= render 'shared/analytics' if rails_env? %>
   </head>
 

--- a/app/views/layouts/requests/mailer.html.erb
+++ b/app/views/layouts/requests/mailer.html.erb
@@ -202,12 +202,6 @@
     }
   </style>
 
-  <!-- Targeting Windows Mobile -->
-  <!--[if IEMobile 7]>
-	<style type="text/css">
-	</style>
-	<![endif]-->
-
   <!--[if gte mso 9]>
 	<style>
 		/* Target Outlook 2007 and 2010 */


### PR DESCRIPTION
Internet Explorer and IEMobile have not been supported for years.  We no longer need these Internet Explorer conditional comments.