### PR TITLE
I4765 edit advanced search

### DIFF
--- a/app/components/range_form_component.html.erb
+++ b/app/components/range_form_component.html.erb
@@ -1,5 +1,4 @@
-<%= render hidden_search_state %>
-
+<%# This version of the range_form_component should only be used on the advanced search and numismatics search pages %>
 <div class="range-limit-input-group">
     <div class="d-flex justify-content-between align-items-end">
       <div class="d-flex flex-column mr-1 me-1">

--- a/spec/features/advanced_searching_spec.rb
+++ b/spec/features/advanced_searching_spec.rb
@@ -204,14 +204,6 @@ describe 'advanced searching', advanced_search: true do
       expect(page).not_to have_content('Seeking sanctuary')
       expect(page).to have_content('Dancing Black')
     end
-
-    it 'can do an advanced search from an assumed url' do
-      visit '/advanced?advanced_type=advanced&boolean_operator1=AND&boolean_operator2=AND&clause%5B0%5D%5Bfield%5D=all_fields&clause%5B0%5D%5Bquery%5D=gay&clause%5B1%5D%5Bfield%5D=author&clause%5B1%5D%5Bquery%5D=&clause%5B2%5D%5Bfield%5D=title&clause%5B2%5D%5Bquery%5D=&commit=Search&range%5Bpub_date_start_sort%5D%5Bbegin%5D=&range%5Bpub_date_start_sort%5D%5Bend%5D='
-      fill_in('clause_0_query', with: 'dance', fill_options: { clear: :backspace })
-      click_button 'Search'
-      expect(page).not_to have_content('Seeking sanctuary')
-      expect(page).to have_content('Dancing Black')
-    end
   end
 
   it 'can edit a facet-only search' do

--- a/spec/features/advanced_searching_spec.rb
+++ b/spec/features/advanced_searching_spec.rb
@@ -191,6 +191,27 @@ describe 'advanced searching', advanced_search: true do
 
       expect(page).to have_field('Format', with: /Audio/)
     end
+
+    it 'can do an advanced search with updated criteria' do
+      visit '/advanced'
+      fill_in 'clause_0_query', with: 'gay'
+      click_button 'Search'
+      expect(page).to have_content('Seeking sanctuary')
+      click_link('Edit search')
+      expect(page).to have_content('Keyword:gay')
+      fill_in('clause_0_query', with: 'dance', fill_options: { clear: :backspace })
+      click_button 'Search'
+      expect(page).not_to have_content('Seeking sanctuary')
+      expect(page).to have_content('Dancing Black')
+    end
+
+    it 'can do an advanced search from an assumed url' do
+      visit '/advanced?advanced_type=advanced&boolean_operator1=AND&boolean_operator2=AND&clause%5B0%5D%5Bfield%5D=all_fields&clause%5B0%5D%5Bquery%5D=gay&clause%5B1%5D%5Bfield%5D=author&clause%5B1%5D%5Bquery%5D=&clause%5B2%5D%5Bfield%5D=title&clause%5B2%5D%5Bquery%5D=&commit=Search&range%5Bpub_date_start_sort%5D%5Bbegin%5D=&range%5Bpub_date_start_sort%5D%5Bend%5D='
+      fill_in('clause_0_query', with: 'dance', fill_options: { clear: :backspace })
+      click_button 'Search'
+      expect(page).not_to have_content('Seeking sanctuary')
+      expect(page).to have_content('Dancing Black')
+    end
   end
 
   it 'can edit a facet-only search' do


### PR DESCRIPTION
The hidden search state was being duplicated, meaning duplicate parameters were being sent, and only one set of parameters were being used, meaning that editing the advanced search was not working.

Connected to #4765 