### PR TITLE
Fix error when there are no authors in Solr doc

### DIFF
--- a/app/models/concerns/blacklight/document/cite_proc.rb
+++ b/app/models/concerns/blacklight/document/cite_proc.rb
@@ -23,7 +23,7 @@ module Blacklight::Document::CiteProc
     end
 
     def cite_proc_authors
-      @cite_proc_authors ||= cleaned_authors.map do |author|
+      @cite_proc_authors ||= cleaned_authors&.map do |author|
         if author.include?(', ')
           family, given = author.split(', ')
           CiteProc::Name.new(family:, given:)
@@ -35,7 +35,7 @@ module Blacklight::Document::CiteProc
 
     # Can remove after https://github.com/pulibrary/bibdata/issues/2646 is completed & re-indexed
     def cleaned_authors
-      citation_fields_from_solr[:author_citation_display].map do |author|
+      citation_fields_from_solr[:author_citation_display]&.map do |author|
         # remove any parenthetical statements from author, as used for Corporate authors in Marc
         author.sub(/ \(.*\)/, '')
       end

--- a/spec/models/apa_spec.rb
+++ b/spec/models/apa_spec.rb
@@ -3,8 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe Blacklight::Document::Apa, citation: true do
-  let(:document) { SolrDocument.new(properties).export_as_apa }
+  let(:solr_document) { SolrDocument.new(properties) }
+  let(:document) { solr_document.export_as_apa }
 
+  before do
+    allow(SolrDocument).to receive(:new).and_return(solr_document)
+    allow(solr_document).to receive(:citation_fields_from_solr).and_return(properties)
+  end
   context 'with a SCSB record' do
     context 'with a book' do
       let(:properties) do
@@ -45,6 +50,22 @@ RSpec.describe Blacklight::Document::Apa, citation: true do
 
       it 'includes the edition' do
         expect(document).to include('(1a edición)')
+      end
+    end
+    context 'with no author' do
+      let(:properties) do
+        {
+          id: "SCSB-2635660",
+          format: ['Book'],
+          edition_display: ['1a edición.'],
+          title_citation_display: ['El entenado'],
+          pub_citation_display: ["Barcelona: Destino"],
+          pub_date_start_sort: 1988
+        }
+      end
+
+      it 'does not raise an error' do
+        expect { document }.not_to raise_error
       end
     end
   end


### PR DESCRIPTION
Was raising [Honeybadger error](https://app.honeybadger.io/projects/54399/faults/118028630) when there was no author

```ruby
NoMethodError: undefined method 'map' for nil

      citation_fields_from_solr[:author_citation_display].map do |author|
```