### PR TITLE
Reject known bots from accessing 5 or more facets

### DIFF
--- a/spec/requests/facets_spec.rb
+++ b/spec/requests/facets_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+RSpec.describe 'facets' do
+  it 'can serve a request with many facets' do
+    get '/?f[access_facet][]=In+the+Library&f[format][]=Journal&f[geographic_facet][]=Alsace+%28France%29&' \
+        'f[language_facet][]=French&f[publication_place_facet][]=France&f[subject_topic_facet][]=Antiquities'
+    expect(response).to have_http_status :ok
+  end
+end


### PR DESCRIPTION
closes #4745 

One way to test this is with curl:

An empty user agent should return a 414 URI Too Long:
```
curl -v "localhost:3000/?f%5Baccess_facet%5D%5B%5D%3DIn%2Bthe%2BLibrary%26f%5Bformat%5D%5B%5D%3DJournal%26f%5Bgeographic_facet%5D%5B%5D%3DAlsace%2B%2528France%2529%26f%5Blanguage_facet%5D%5B%5D%3DFrench%26f%5Bpublication_place_facet%5D%5B%5D%3DFrance%26f%5Bsubject_topic_facet%5D%5B%5D%3DAntiquities" 2>&1 | grep "HTTP/1.1\s\d"
```

A good human browser user agent should return a 200:
```
curl -A "Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/42.0" -v "localhost:3000/?f%5Baccess_facet%5D%5B%5D%3DIn%2Bthe%2BLibrary%26f%5Bformat%5D%5B%5D%3DJournal%26f%5Bgeographic_facet%5D%5B%5D%3DAlsace%2B%2528France%2529%26f%5Blanguage_facet%5D%5B%5D%3DFrench%26f%5Bpublication_place_facet%5D%5B%5D%3DFrance%26f%5Bsubject_topic_facet%5D%5B%5D%3DAntiquities" 2>&1 | grep "HTTP/1.1\s\d"
```

Applebot should return a 414:
```
curl -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Applebot/0.1; +http://www.apple.com/go/applebot)" -v "localhost:3000/?f%5Baccess_facet%5D%5B%5D%3DIn%2Bthe%2BLibrary%26f%5Bformat%5D%5B%5D%3DJournal%26f%5Bgeographic_facet%5D%5B%5D%3DAlsace%2B%2528France%2529%26f%5Blanguage_facet%5D%5B%5D%3DFrench%26f%5Bpublication_place_facet%5D%5B%5D%3DFrance%26f%5Bsubject_topic_facet%5D%5B%5D%3DAntiquities" 2>&1 | grep "HTTP/1.1\s\d"
```

Once this branch is rebased on #4786 , gptbot should return a 414:
```
curl -A "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; GPTBot/1.0; +https://openai.com/gptbot)" -v "localhost:3000/?f%5Baccess_facet%5D%5B%5D%3DIn%2Bthe%2BLibrary%26f%5Bformat%5D%5B%5D%3DJournal%26f%5Bgeographic_facet%5D%5B%5D%3DAlsace%2B%2528France%2529%26f%5Blanguage_facet%5D%5B%5D%3DFrench%26f%5Bpublication_place_facet%5D%5B%5D%3DFrance%26f%5Bsubject_topic_facet%5D%5B%5D%3DAntiquities" 2>&1 | grep "HTTP/1.1\s\d"
```