### PR TITLE
Disallow google adsense bot in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,8 @@
+# Google AdSense bots, they only are beneficial for sites that display Google's Adsense ads, which we don't
+User-agent: Google-Display-Ads-Bot
+User-agent: Mediapartners-Google
+Disallow: /
+
 User-agent: *
 Crawl-delay: 10
 Sitemap: https://catalog.princeton.edu/sitemap


### PR DESCRIPTION
We get a moderate amount of traffic from this bot, about 4 requests/minute.  It is not useful to us -- it crawls your site to determine which ads to display if the site displays AdSense ads.

See [documentation from google](https://support.google.com/adsense/answer/99376?hl=en)