### PR TITLE
[#4429] Call solr once to render citations

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -19,6 +19,12 @@ class BookmarksController < CatalogController
     render('orangelight/record_mailer/email_record', formats: [:text])
   end
 
+  def citation
+    bookmarks = token_or_current_or_guest_user.bookmarks
+    bookmark_ids = bookmarks.collect { |bookmark| bookmark.document_id.to_s }
+    @documents = search_service.fetch(bookmark_ids, { rows: bookmark_ids.count, fl: "author_citation_display, title_citation_display, pub_citation_display, number_of_pages_citation_display, pub_date_start_sort, edition_display" })
+  end
+
   def csv
     fetch_bookmarked_documents
     send_data csv_output, type: 'text/csv', filename: "bookmarks-#{Time.zone.today}.csv"

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -767,14 +767,9 @@ class CatalogController < ApplicationController
   def citation
     if agent_is_crawler?
       basic_response
-    elsif Orangelight.using_blacklight7?
-      # Taken from Blacklight::ActionBuilder#build, which would
-      # otherwise generate the citation method dynamically
-      #
-      # See https://github.com/projectblacklight/blacklight/blob/f6bdb20248c0eee91dbd480b20d1b60f93783b3e/app/builders/blacklight/action_builder.rb#L29-L53
-      @response, @documents = action_documents
     else
-      @documents = action_documents
+      @documents = search_service.fetch(Array(params[:id]), { fl: "author_citation_display, title_citation_display, pub_citation_display, number_of_pages_citation_display, pub_date_start_sort, edition_display" })
+      raise Blacklight::Exceptions::RecordNotFound if @documents.blank?
     end
   end
 

--- a/app/models/concerns/blacklight/document/cite_proc.rb
+++ b/app/models/concerns/blacklight/document/cite_proc.rb
@@ -35,7 +35,7 @@ module Blacklight::Document::CiteProc
 
     # Can remove after https://github.com/pulibrary/bibdata/issues/2646 is completed & re-indexed
     def cleaned_authors
-      citation_fields_from_solr[:author_citation_display]&.map do |author|
+      self[:author_citation_display]&.map do |author|
         # remove any parenthetical statements from author, as used for Corporate authors in Marc
         author.sub(/ \(.*\)/, '')
       end
@@ -43,32 +43,24 @@ module Blacklight::Document::CiteProc
 
     def cite_proc_edition
       @cite_proc_edition ||= begin
-        str = citation_fields_from_solr[:edition_display]&.first
+        str = self[:edition_display]&.first
         str&.dup&.sub!(/[[:punct:]]?$/, '')
       end
     end
 
     def cite_proc_title
-      @cite_proc_title ||= citation_fields_from_solr[:title_citation_display]&.first
+      @cite_proc_title ||= self[:title_citation_display]&.first
     end
 
     def cite_proc_publisher
-      @cite_proc_publisher ||= citation_fields_from_solr[:pub_citation_display]&.first&.split(': ').try(:[], 1)
+      @cite_proc_publisher ||= self[:pub_citation_display]&.first&.split(': ').try(:[], 1)
     end
 
     def cite_proc_publisher_place
-      @cite_proc_publisher_place ||= citation_fields_from_solr[:pub_citation_display]&.first&.split(': ').try(:[], 0)
+      @cite_proc_publisher_place ||= self[:pub_citation_display]&.first&.split(': ').try(:[], 0)
     end
 
     def cite_proc_issued
-      @cite_proc_issued ||= citation_fields_from_solr[:pub_date_start_sort]
-    end
-
-    def citation_fields_from_solr
-      @citation_fields_from_solr ||= begin
-        params = { q: "id:#{RSolr.solr_escape(id)}", fl: "author_citation_display, title_citation_display, pub_citation_display, number_of_pages_citation_display, pub_date_start_sort, edition_display" }
-        solr_response = Blacklight.default_index.connection.get('select', params:)
-        solr_response["response"]["docs"].first.with_indifferent_access
-      end
+      @cite_proc_issued ||= self[:pub_date_start_sort]
     end
 end


### PR DESCRIPTION
Prior to this commit, we called solr twice: once in the controller via Blacklight's `#action_documents` methods (which do not include the correct fields), and again in our `#citation_fields_from_solr` method (which does).

Neither `#action_documents` implementation allows us to pass in specific solr options, so this commit instead brings the `#action_documents` methods' logic into the `#citation` actions.

Also, remove some Blacklight 7 backwards compatibility that is no longer needed.

Closes #4429 