### PR TITLE
Do not require all clauses when OR is used

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -103,8 +103,16 @@ class SearchBuilder < Blacklight::SearchBuilder
     # don't want to cancel out the boolean OR with
     # an mm configuration that requires all the clauses
     # to be in the document
-    return unless blacklight_params[:q].to_s.split.include? 'OR'
+    return unless includes_written_boolean?
     solr_parameters['mm'] = 0
+  end
+
+  def includes_written_boolean?
+    if advanced_search? && search_query_present?
+      json_query_dsl_clauses&.any? { |clause| clause&.dig('query')&.include?('OR') }
+    else
+      blacklight_params[:q].to_s.split.include? 'OR'
+    end
   end
 
   # When the user is viewing the values of a specific facet

--- a/spec/features/advanced_searching_spec.rb
+++ b/spec/features/advanced_searching_spec.rb
@@ -76,6 +76,13 @@ describe 'advanced searching', advanced_search: true do
     expect(page).to have_content('Aomen')
   end
 
+  it 'allows users to use booleans within a query' do
+    visit '/advanced'
+    fill_in(id: 'clause_0_query', with: 'history OR abolition')
+    click_button('advanced-search-submit')
+    expect(page).to have_content('Themes and individuals in history')
+  end
+
   context 'when editing the search', js: true do
     it 'shows the selected value in the combobox' do
       visit '/advanced'

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -156,6 +156,18 @@ RSpec.describe SearchBuilder do
         expect { search_builder.adjust_mm(solr_parameters) }.to change { solr_parameters }
         expect(solr_parameters['mm']).to eq(0)
       end
+      context 'with an advanced search' do
+        let(:blacklight_params) do
+          { advanced_type: "advanced", "clause" => { "0" => { "field" => "all_fields", "query" => "history OR abolition", "op" => "must" } } }
+        end
+        it 'sets the mm to 0, meaning that we do not require all search terms to appear in the document' do
+          allow(search_builder).to receive(:blacklight_params).and_return(blacklight_params)
+          solr_parameters = {}
+
+          expect { search_builder.adjust_mm(solr_parameters) }.to change { solr_parameters }
+          expect(solr_parameters['mm']).to eq(0)
+        end
+      end
     end
     context 'when the query does not contain a boolean OR' do
       let(:blacklight_params) do


### PR DESCRIPTION
See [previous PR removing setting `mm` for boolean queries](https://github.com/pulibrary/orangelight/pull/4474) for more context.

Currently deployed to staging - see [example search on staging](https://catalog-staging.princeton.edu/catalog?advanced_type=advanced&boolean_operator1=AND&boolean_operator2=AND&range%5Bpub_date_start_sort%5D%5Bbegin%5D=&range%5Bpub_date_start_sort%5D%5Bend%5D=&clause%5B0%5D%5Bfield%5D=subject&clause%5B0%5D%5Bquery%5D=%22Material+culture%22+OR+toys+OR+dolls+OR+consumers&boolean_operator1=AND&clause%5B1%5D%5Bfield%5D=subject&clause%5B1%5D%5Bquery%5D=child+OR+Children+OR+Youth+OR+Girls+OR+Boys&boolean_operator2=AND&clause%5B2%5D%5Bfield%5D=subject&clause%5B2%5D%5Bquery%5D=&f_inclusive%5Blanguage_facet%5D%5B%5D=English&range%5Bpub_date_start_sort%5D%5Bbegin%5D=&range%5Bpub_date_start_sort%5D%5Bend%5D=&commit=Search)

Closes #4709