### PR TITLE
[#4774] Disregard question marks at the end of words in advanced search

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -14,11 +14,6 @@ module BlacklightHelper
     field[:link_field]
   end
 
-  def wildcard_char_strip(solr_parameters)
-    return unless solr_parameters[:q]
-    solr_parameters[:q] = solr_parameters[:q].delete('?')
-  end
-
   # Escape all whitespace characters within Solr queries specifying left anchor query facets
   # Ends all left-anchor searches with wildcards for matches that begin with search string
   # @param solr_parameters [Blacklight::Solr::Request] the parameters for the Solr query

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -114,6 +114,10 @@ class SearchBuilder < Blacklight::SearchBuilder
     solr_parameters.delete('facet.query') unless solr_parameters['facet.query']&.any? { |query| query.partition(':').first == facet }
   end
 
+  def wildcard_char_strip(solr_parameters)
+    transform_queries!(solr_parameters) { |query| query.delete('?') }
+  end
+
   private
 
     def search_query_present?

--- a/spec/features/advanced_searching_spec.rb
+++ b/spec/features/advanced_searching_spec.rb
@@ -266,4 +266,16 @@ describe 'advanced searching', advanced_search: true do
     click_button 'Search'
     expect(page).not_to have_content 'Ahmet Kutsi Tecer sempozyum bildirileri : Sıvas 24 - 27 Nisan 2018'
   end
+  it 'does not treat a question mark at the end of a phrase as a keyword' do
+    visit '/advanced'
+    select('Keyword', from: 'clause_0_field')
+    fill_in(id: 'clause_0_query', with: 'Parrish')
+    select('Author', from: 'clause_1_field')
+    fill_in(id: 'clause_1_query', with: 'Trollope, Anthony​​​')
+    select('Title', from: 'clause_2_field')
+    fill_in(id: 'clause_2_query', with: 'Can You Forgive Her?​​​')
+    click_button 'Search'
+
+    expect(page).to have_content('Can you forgive her? / by Anthony Trollope ... ; with 40 illustrations.')
+  end
 end

--- a/spec/fixtures/alma/992784263506421.json
+++ b/spec/fixtures/alma/992784263506421.json
@@ -1,0 +1,127 @@
+{
+    "id": "992784263506421",
+    "numeric_id_b": true,
+    "author_display": [
+        "Trollope, Anthony, 1815-1882"
+    ],
+    "author_citation_display": [
+        "Trollope, Anthony"
+    ],
+    "author_roles_1display": "{\"secondary_authors\":[\"Trollope, Anthony\"],\"translators\":[],\"editors\":[],\"compilers\":[],\"primary_author\":\"Trollope, Anthony\"}",
+    "author_s": [
+        "Trollope, Anthony, 1815-1882"
+    ],
+    "marc_relator_display": [
+        "Author"
+    ],
+    "title_display": "Can you forgive her? / by Anthony Trollope ... ; with 40 illustrations.",
+    "title_t": [
+        "Can you forgive her? / by Anthony Trollope ... ; with 40 illustrations."
+    ],
+    "title_citation_display": [
+        "Can you forgive her?"
+    ],
+    "compiled_created_t": [
+        "Can you forgive her? / by Anthony Trollope ... ; with 40 illustrations."
+    ],
+    "edition_display": [
+        "Fifth edition."
+    ],
+    "pub_created_display": [
+        "London ; New York : George Routledge \u0026 Sons, 1871."
+    ],
+    "pub_created_s": [
+        "London ; New York : George Routledge \u0026 Sons, 1871."
+    ],
+    "pub_citation_display": [
+        "New York: George Routledge \u0026 Sons"
+    ],
+    "pub_date_display": [
+        "1871"
+    ],
+    "pub_date_start_sort": 1871,
+    "cataloged_tdt": "2021-07-13T06:11:11Z",
+    "format": [
+        "Book"
+    ],
+    "description_display": [
+        "2 v. in 1 ([1] leaf, [3], 320 p., [20] leaves of plates; 320 p., [20] leaves of plates) : 40 ill. ; 23 cm. (8vo)"
+    ],
+    "description_t": [
+        "2 v. in 1 ([1] leaf, [3], 320 p., [20] leaves of plates; 320 p., [20] leaves of plates) : 40 ill. ; 23 cm. (8vo)"
+    ],
+    "number_of_pages_citation_display": [
+        "2 v. in 1 ([1] leaf, [3], 320 p., [20] leaves of plates; 320 p., [20] leaves of plates)"
+    ],
+    "geocode_display": [
+        "Great Britain"
+    ],
+    "notes_display": [
+        "First of the Palliser novels.",
+        "In dark green cloth, blocked in black and gold.",
+        "Princeton copy 1: T.p. followed by a single list of contents and illustrations for both vols. Neither vol. has separate t.p. The illustrations are those of the first edition. Very dark green diagonal dot and line cloth, front cover and spine blocked in black and gold, back cover blocked in blind.",
+        "Princeton copy 1: Signed in ms. on free front endpaper: E.G. de Capell Brooke. Xmas 1915. From May."
+    ],
+    "language_name_display": [
+        "English"
+    ],
+    "language_facet": [
+        "English"
+    ],
+    "language_iana_s": [
+        "en"
+    ],
+    "references_display": [
+        "Princeton copy 1: Wainwright (Parrish), Trollope, 62"
+    ],
+    "references_url_display": [
+        "Princeton copy 1: Wainwright (Parrish), Trollope, 62"
+    ],
+    "lc_subject_display": [
+        "Great Britain—Social life and customs—19th century—Fiction"
+    ],
+    "subject_facet": [
+        "Great Britain—Social life and customs—19th century—Fiction",
+        "Fiction"
+    ],
+    "lcgft_s": [
+        "Fiction"
+    ],
+    "related_works_1display": "[[\"Trollope, Anthony, 1815-1882.\",\"Palliser novels.\"]]",
+    "oclc_s": [
+        "3049769"
+    ],
+    "other_version_s": [
+        "ocm03049769"
+    ],
+    "subject_era_facet": [
+        "19th century"
+    ],
+    "holdings_1display": "{\"22673459850006421\":{\"location_code\":\"rare$expa\",\"location\":\"Morris L. Parrish Collection\",\"library\":\"Special Collections\",\"call_number\":\"PR5684 .C27 1871\",\"call_number_browse\":\"PR5684 .C27 1871\",\"location_has\":[\"Princeton copy 1\"],\"supplements\":[null],\"indexes\":[null]}}",
+    "location_code_s": [
+        "rare$expa"
+    ],
+    "location": [
+        "Special Collections"
+    ],
+    "location_display": [
+        "Morris L. Parrish Collection"
+    ],
+    "advanced_location_s": [
+        "rare$expa",
+        "Special Collections"
+    ],
+    "name_title_browse_s": [
+        "Trollope, Anthony, 1815-1882. Palliser novels",
+        "Trollope, Anthony, 1815-1882. Can you forgive her?"
+    ],
+    "call_number_display": [
+        "PR5684 .C27 1871"
+    ],
+    "call_number_browse_s": [
+        "PR5684 .C27 1871"
+    ],
+    "call_number_locator_display": [
+        "PR5684 .C27 1871"
+    ]
+}

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -149,14 +149,6 @@ describe BlacklightHelper do
     end
   end
 
-  describe '#wildcard_char_strip', left_anchor: true do
-    it 'strips question marks which are wildcard characters before sending :q to solr' do
-      query = { q: '{!qf=$left_anchor_qf pf=$left_anchor_pf}China and Angola: a marriage of convenience?' }
-      wildcard_char_strip(query)
-      expect(query[:q]).to eq '{!qf=$left_anchor_qf pf=$left_anchor_pf}China and Angola: a marriage of convenience'
-    end
-  end
-
   describe '#render_facet_partials' do
     let(:blacklight_config) { Blacklight::Configuration.new }
 

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -250,4 +250,20 @@ RSpec.describe SearchBuilder do
       end
     end
   end
+  describe '#wildcard_char_strip' do
+    it 'strips question marks which are wildcard characters before sending :q to solr' do
+      query = { q: '{!qf=$left_anchor_qf pf=$left_anchor_pf}China and Angola: a marriage of convenience?' }
+      search_builder.wildcard_char_strip(query)
+      expect(query[:q]).to eq '{!qf=$left_anchor_qf pf=$left_anchor_pf}China and Angola: a marriage of convenience'
+    end
+    it 'strips question marks from json query DSL queries' do
+      query = { "json" =>
+      { "query" =>
+        { "bool" =>
+          { "must" =>
+            [{ edismax: { query: "China and Angola: a marriage of convenience?" } }] } } } }
+      search_builder.wildcard_char_strip(query)
+      expect(query['json']['query']['bool']['must'][0][:edismax][:query]).to eq 'China and Angola: a marriage of convenience'
+    end
+  end
 end


### PR DESCRIPTION
This extends the fix in #653 to apply to json query DSL query strings as well.

Closes #4774 