### PR TITLE
Remove timecop in favor of Rails TimeHelpers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,6 @@ group :test do
   gem 'rails-controller-testing'
   gem 'rspec_junit_formatter'
   gem 'selenium-webdriver'
-  gem 'timecop'
   gem 'vcr'
   gem 'webmock', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -739,7 +739,6 @@ GEM
     tilt (2.6.0)
     time (0.4.1)
       date
-    timecop (0.9.10)
     timeout (0.4.3)
     tins (1.38.0)
       bigdecimal
@@ -899,7 +898,6 @@ DEPENDENCIES
   string_rtl
   stringex!
   terser
-  timecop
   vcr
   view_component
   vite_rails

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe User do
     end
     context "when there are guest users older than 3 days" do
       before do
-        Timecop.freeze(Time.now.utc - 10.days) do
+        travel_to(Time.now.utc - 10.days) do
           100.times do
             FactoryBot.create(:guest_patron, guest: true)
           end
@@ -30,7 +30,7 @@ RSpec.describe User do
     context 'when a guest user older than 3 days has bookmarks' do
       let(:guest) { FactoryBot.create(:guest_patron, guest: true) }
       before do
-        Timecop.freeze(Time.now.utc - 3.days) do
+        travel_to(Time.now.utc - 3.days) do
           (1..5).each do |document_id|
             bookmark = Bookmark.new
             bookmark.user = guest


### PR DESCRIPTION
This removes a dependency in favor of a feature built-in to rails. I followed [this blog post](https://andycroll.com/ruby/replace-timecop-with-rails-time-helpers-in-rspec/)