### PR TITLE
Add a small Solr core for boolean search testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ executors:
           ORANGELIGHT_HOST: localhost
           ORANGELIGHT_USER: postgres
           SOLR_URL: http://solr:SolrRocks@localhost:8983/solr/orangelight-core-test
+          SOLR_SMALL_URL: http://solr:SolrRocks@localhost:8983/solr/orangelight-core-small-test
           COVERALLS_PARALLEL: true
           VITE_RUBY_AUTO_BUILD: false
       - image: cimg/postgres:15.8
@@ -119,6 +120,7 @@ jobs:
             zip -1 -r solr_config.zip ./*
             curl -H "Content-type:application/octet-stream" --data-binary @solr_config.zip "http://solr:SolrRocks@127.0.0.1:8983/solr/admin/configs?action=UPLOAD&name=orangelight"
             curl -H 'Content-type: application/json' http://solr:SolrRocks@127.0.0.1:8983/api/collections/  -d '{create: {name: orangelight-core-test, config: orangelight, numShards: 1}}'
+            curl -H 'Content-type: application/json' http://solr:SolrRocks@127.0.0.1:8983/api/collections/  -d '{create: {name: orangelight-core-small-test, config: orangelight, numShards: 1}}'
       - run:
           name: Index Test Data
           command: bundle exec rake pulsearch:solr:index

--- a/.lando.yml
+++ b/.lando.yml
@@ -9,6 +9,15 @@ services:
     core: orangelight-core-test
     config:
       dir: "solr/conf"
+  orangelight_small_test_solr:
+    type: solr:custom
+    overrides:
+      image: pulibrary/ci-solr:8.4-v1.0.0
+      command: server/scripts/lando-start.sh
+    portforward: true
+    core: orangelight-core-small-test
+    config:
+      dir: "solr/conf"
   orangelight_development_solr:
     type: solr:custom
     overrides:
@@ -27,5 +36,7 @@ services:
 proxy:
   orangelight_test_solr:
     - orangelight.test.solr.lndo.site:8983
+  orangelight_small_test_solr:
+    - orangelight.test.small.solr.lndo.site:8983
   orangelight_development_solr:
     - orangelight.dev.solr.lndo.site:8983

--- a/spec/system/boolean_searching_spec.rb
+++ b/spec/system/boolean_searching_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# For the rest of the specs, we have our entire example corpus in Solr.
+# For these tests we want a very limited Solr corpus to test complex boolean searching in
+# a more controlled way.
+RSpec.describe 'complex boolean searching', advanced_search: true do
+  let(:solr_url) do
+    ENV['SOLR_SMALL_URL'] || "http://#{ENV['lando_orangelight_small_test_solr_conn_host'] || '127.0.0.1'}:#{ENV['SOLR_TEST_PORT'] || ENV['lando_orangelight_small_test_solr_conn_port'] || 8888}/solr/orangelight-core-small-test"
+  end
+  let(:solr) { RSolr.connect(url: solr_url) }
+  let(:apple_doc) do
+    { 'id': ["1"], 'title_display': ['Apples are delicious'] }
+  end
+  let(:banana_doc) do
+    { 'id': ["2"], 'title_display': ['Bananas are yummy'] }
+  end
+  let(:cantaloupe_doc) do
+    { 'id': ["3"], 'title_display': ['Cantaloupes are sweet'] }
+  end
+  let(:potato) do
+    { 'id': ["4"], 'title_display': ['Only potatoes are good'] }
+  end
+  let(:carrot) do
+    { 'id': ["5"], 'title_display': ['Only carrots are good'] }
+  end
+  let(:potato_and_carrot_doc) do
+    { 'id': ["6"], 'title_display': ['Potatoes and Carrots go well together'] }
+  end
+  let(:date_and_cantaloupe_doc) do
+    { 'id': ["7"], 'title_display': ["Dates are squishy and don't go well with cantaloupes"] }
+  end
+  let(:squishy) do
+    { 'id': ["8"], 'title_display': ["Squishy mushrooms and dates"] }
+  end
+
+  let(:simple_docs) do
+    [
+      apple_doc,
+      banana_doc,
+      cantaloupe_doc,
+      potato_and_carrot_doc,
+      date_and_cantaloupe_doc,
+      squishy
+    ]
+  end
+  around(:all) do |examples|
+    solr.update data: '<delete><query>*:*</query></delete>', headers: { 'Content-Type' => 'text/xml' }
+    solr.update data: '<commit/>', headers: { 'Content-Type' => 'text/xml' }
+    simple_docs.each do |doc|
+      solr.add doc
+    end
+    solr.update data: '<commit/>', headers: { 'Content-Type' => 'text/xml' }
+    examples.run
+  end
+
+  before do
+    stub_holding_locations
+    allow(Blacklight.default_index).to receive(:connection).and_return(solr)
+    # rubocop:disable RSpec/AnyInstance
+    allow_any_instance_of(Blacklight::Configuration).to receive(:connection_config).and_return({ adapter: "solr", url: solr_url })
+    # rubocop:enable RSpec/AnyInstance
+  end
+
+  context 'using advanced search' do
+    before do
+      visit '/advanced'
+    end
+    it 'can find a single entry' do
+      fill_in('clause_0_query', with: 'apple')
+      click_button('advanced-search-submit')
+      expect(page.find('.page_entries').text).to eq('1 entry found')
+      expect(page).to have_content('1 entry found')
+      expect(page).to have_content('Apples are delicious')
+    end
+
+    it 'can find entries using OR in a single field' do
+      fill_in('clause_0_query', with: 'apple OR banana')
+      click_button('advanced-search-submit')
+      expect(page.find('.page_entries').text).to eq('1 - 2 of 2')
+      expect(page).to have_content('1 - 2 of 2')
+      expect(page).to have_content('Apples are delicious')
+      expect(page).to have_content('Bananas are yummy')
+    end
+
+    it 'can find entries using OR across fields' do
+      fill_in('clause_0_query', with: 'apple')
+      choose(id: 'boolean_operator1_OR')
+      select('Title', from: 'clause_1_field')
+      fill_in('clause_1_query', with: 'banana')
+      click_button('advanced-search-submit')
+      expect(page.find('.page_entries').text).to eq('1 - 2 of 2')
+      expect(page).to have_content('1 - 2 of 2')
+      expect(page).to have_content('Apples are delicious')
+      expect(page).to have_content('Bananas are yummy')
+    end
+
+    it 'can eliminate entries using AND' do
+      fill_in('clause_0_query', with: 'apple AND banana')
+      click_button('advanced-search-submit')
+      expect(page.find('.page_entries').text).to eq('No entries found')
+    end
+
+    it 'can include entries using AND' do
+      fill_in('clause_0_query', with: 'potato AND carrot')
+      click_button('advanced-search-submit')
+      expect(page.find('.page_entries').text).to eq('1 entry found')
+
+      expect(page).to have_content('1 entry found')
+      expect(page).to have_content('Potatoes and Carrots go well together')
+    end
+
+    it 'can combine OR and implicit AND queries' do
+      pending('Fixing advanced search')
+      fill_in('clause_0_query', with: 'apple OR squishy')
+      # defaults to AND between fields
+      select('Title', from: 'clause_1_field')
+      # this should be an implicit AND but is being treated as an OR
+      fill_in('clause_1_query', with: 'cantaloupe date')
+      click_button('advanced-search-submit')
+      expect(page).not_to have_content('Squishy mushrooms and dates')
+      expect(page.find('.page_entries').text).to eq('1 entry found')
+      expect(page).to have_content('1 entry found')
+      expect(page).to have_content("Dates are squishy and don't go well with cantaloupes")
+    end
+
+    it 'can combine multiple OR queries with an AND in between' do
+      # "apple OR squishy" AND "cantaloupe OR date"
+      fill_in('clause_0_query', with: 'apple OR squishy')
+      select('Title', from: 'clause_1_field')
+      fill_in('clause_1_query', with: 'cantaloupe OR date')
+      click_button('advanced-search-submit')
+      expect(page.find('.page_entries').text).to eq('1 - 2 of 2')
+    end
+  end
+end


### PR DESCRIPTION
It is hard to test complex boolean queries with our current large test corpus, so we create a new, small corpus in its own solr core for complex boolean testing.