### PR TITLE
Ensure format is included in Solr request for Citations

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -22,7 +22,7 @@ class BookmarksController < CatalogController
   def citation
     bookmarks = token_or_current_or_guest_user.bookmarks
     bookmark_ids = bookmarks.collect { |bookmark| bookmark.document_id.to_s }
-    @documents = search_service.fetch(bookmark_ids, { rows: bookmark_ids.count, fl: "author_citation_display, title_citation_display, pub_citation_display, number_of_pages_citation_display, pub_date_start_sort, edition_display" })
+    @documents = search_service.fetch(bookmark_ids, { rows: bookmark_ids.count, fl: "author_citation_display, title_citation_display, pub_citation_display, number_of_pages_citation_display, pub_date_start_sort, edition_display, format" })
   end
 
   def csv

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -804,7 +804,7 @@ class CatalogController < ApplicationController
     if agent_is_crawler?
       basic_response
     else
-      @documents = search_service.fetch(Array(params[:id]), { fl: "author_citation_display, title_citation_display, pub_citation_display, number_of_pages_citation_display, pub_date_start_sort, edition_display" })
+      @documents = search_service.fetch(Array(params[:id]), { fl: "author_citation_display, title_citation_display, pub_citation_display, number_of_pages_citation_display, pub_date_start_sort, edition_display, format" })
       raise Blacklight::Exceptions::RecordNotFound if @documents.blank?
     end
   end


### PR DESCRIPTION
Ensures book titles are italicized in Chicago format

This does not fix the issue of where the date is located. It's possible that's related to the [style that the CiteProc gem references](https://github.com/citation-style-language/styles/blob/v1.0.2/chicago-author-date.csl), I'm still trying to understand the format.

Connected to #4866