### PR TITLE
Add Chicago Notes Bibliography citation format

### DIFF
--- a/app/components/orangelight/document/citation_component.rb
+++ b/app/components/orangelight/document/citation_component.rb
@@ -4,7 +4,8 @@ class Orangelight::Document::CitationComponent < Blacklight::Document::CitationC
   DEFAULT_FORMATS = {
     'blacklight.citation.mla': :export_as_mla,
     'blacklight.citation.apa': :export_as_apa,
-    'blacklight.citation.chicago_author_date': :export_as_chicago_author_date
+    'blacklight.citation.chicago_author_date': :export_as_chicago_author_date,
+    'blacklight.citation.chicago_notes_bibliography': :export_as_chicago_notes_bibliography
   }.freeze
 
   def initialize(document:, formats: DEFAULT_FORMATS)

--- a/app/components/orangelight/document/citation_component.rb
+++ b/app/components/orangelight/document/citation_component.rb
@@ -4,7 +4,7 @@ class Orangelight::Document::CitationComponent < Blacklight::Document::CitationC
   DEFAULT_FORMATS = {
     'blacklight.citation.mla': :export_as_mla,
     'blacklight.citation.apa': :export_as_apa,
-    'blacklight.citation.chicago': :export_as_chicago
+    'blacklight.citation.chicago_author_date': :export_as_chicago_author_date
   }.freeze
 
   def initialize(document:, formats: DEFAULT_FORMATS)

--- a/app/models/concerns/blacklight/document/chicago_author_date.rb
+++ b/app/models/concerns/blacklight/document/chicago_author_date.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-# Creates an html Chicago citation for non-Marc records
-module Blacklight::Document::Chicago
+# Creates an html ChicagoAuthorDate citation for non-Marc records
+module Blacklight::Document::ChicagoAuthorDate
   def self.extended(document)
-    Blacklight::Document::Chicago.register_export_formats(document)
+    Blacklight::Document::ChicagoAuthorDate.register_export_formats(document)
   end
 
   def self.register_export_formats(document)
-    document.will_export_as(:chicago, 'text/html')
+    document.will_export_as(:chicago_author_date, 'text/html')
   end
 
-  def export_as_chicago
+  def export_as_chicago_author_date
     cp = CiteProc::Processor.new style: 'chicago-author-date', format: 'html'
     item = CiteProc::Item.new(properties)
     cp.import(item)

--- a/app/models/concerns/blacklight/document/chicago_notes_bibliography.rb
+++ b/app/models/concerns/blacklight/document/chicago_notes_bibliography.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Creates an html ChicagoNoteBibliography citation for non-Marc records
+module Blacklight::Document::ChicagoNotesBibliography
+  def self.extended(document)
+    Blacklight::Document::ChicagoNotesBibliography.register_export_formats(document)
+  end
+
+  def self.register_export_formats(document)
+    document.will_export_as(:chicago_notes_bibliography, 'text/html')
+  end
+
+  def export_as_chicago_notes_bibliography
+    cp = CiteProc::Processor.new style: 'chicago-note-bibliography', format: 'html'
+    item = CiteProc::Item.new(properties)
+    cp.import(item)
+    cp.render(:bibliography, id:).first
+  end
+end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -61,7 +61,7 @@ class SolrDocument
   use_extension(Blacklight::Document::Apa)
 
   # Adds Chicago html
-  use_extension(Blacklight::Document::Chicago)
+  use_extension(Blacklight::Document::ChicagoAuthorDate)
 
   def identifier_data
     values = identifiers.each_with_object({}) do |identifier, hsh|

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -60,8 +60,11 @@ class SolrDocument
   # Adds APA html
   use_extension(Blacklight::Document::Apa)
 
-  # Adds Chicago html
+  # Adds Chicago Author Date html
   use_extension(Blacklight::Document::ChicagoAuthorDate)
+
+  # Adds Chicago Note Bibliography html
+  use_extension(Blacklight::Document::ChicagoNotesBibliography)
 
   def identifier_data
     values = identifiers.each_with_object({}) do |identifier, hsh|

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -121,6 +121,7 @@ en:
     citation:
       apa: APA
       chicago_author_date: Chicago (Author-Date Style)
+      chicago_notes_bibliography: Chicago (Notes Bibliography Style)
       mla: MLA
     tools:
       librarian_view: 'Staff view'

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -118,7 +118,10 @@ en:
       related_records:
         display_more: "Show %{count} more related records"
         display_less: "Show fewer related records"
-
+    citation:
+      apa: APA
+      chicago_author_date: Chicago (Author-Date Style)
+      mla: MLA
     tools:
       librarian_view: 'Staff view'
     pagination_compact:

--- a/spec/models/chicago_author_date_spec.rb
+++ b/spec/models/chicago_author_date_spec.rb
@@ -2,8 +2,8 @@
 
 require 'rails_helper'
 
-RSpec.describe Blacklight::Document::Chicago, citation: true do
-  let(:document) { SolrDocument.new(properties).export_as_chicago }
+RSpec.describe Blacklight::Document::ChicagoAuthorDate, citation: true do
+  let(:document) { SolrDocument.new(properties).export_as_chicago_author_date }
 
   context 'with a SCSB record' do
     context 'with a book' do

--- a/spec/models/chicago_notes_bibliography_spec.rb
+++ b/spec/models/chicago_notes_bibliography_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Blacklight::Document::ChicagoNotesBibliography, citation: true do
+  let(:document) { SolrDocument.new(properties).export_as_chicago_notes_bibliography }
+
+  context 'with a SCSB record' do
+    context 'with a book' do
+      let(:properties) do
+        {
+          id: "SCSB-2635660",
+          format: ['Book'],
+          author_citation_display: ["Saer, Juan José"],
+          edition_display: ['1a edición.'],
+          title_citation_display: ['El entenado'],
+          pub_citation_display: ["Barcelona: Destino"],
+          pub_date_start_sort: 1988
+        }
+      end
+
+      it 'includes the author' do
+        expect(document).to include('Saer')
+        expect(document).to include('Juan José. ')
+      end
+
+      it 'includes the author with the proper delimiter' do
+        expect(document).to include('Saer, Juan José. ')
+      end
+
+      it 'includes the title in italics' do
+        expect(document).to include('<i>El Entenado</i>')
+      end
+
+      it 'includes the publisher' do
+        expect(document).to include('Destino')
+      end
+
+      it 'includes the place of publication' do
+        expect(document).to include('Barcelona')
+      end
+
+      it 'includes the publication date' do
+        expect(document).to include('1988')
+      end
+
+      it 'includes the edition' do
+        expect(document).to include('1a edición')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Chicago Notes Bibliography format is more commonly used in the humanities, Chicago Author-Date is more commonly used in the sciences, so include both.

Closes #4866