### PR TITLE
Use darker color for availability

### DIFF
--- a/app/assets/stylesheets/components/availability.scss
+++ b/app/assets/stylesheets/components/availability.scss
@@ -17,7 +17,7 @@
     white-space: normal;
 
     &.bg-secondary {
-      color: $gray-light;
+      color: $black-pul;
       --bs-bg-opacity: 0;
     }
 


### PR DESCRIPTION
- This allows the accessibility test to pass on this element, and I think the placement and size different make it sufficiently distinct from the location heading above it.

![image](https://github.com/user-attachments/assets/29bd3f0d-89ae-4d47-99ea-30d74efa190f)

Closes #4838
