### PR TITLE
Use small circleci resource class for jobs that need fewer resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ executors:
       - image: cimg/ruby:3.4.1-browsers
         environment:
           RAILS_ENV: test
-    resource_class: large
+    resource_class: small
     working_directory: ~/orangelight
 
 commands:


### PR DESCRIPTION
Still use the large resource class for rspec tests and lighthouse.

This will save around 120 circleci credits per CI run, assuming that the timings are relatively consistent and the [pricing here](https://circleci.com/pricing/price-list/#docker)