### PR TITLE
Disable Stackmap

### DIFF
--- a/app/services/stackmap_service.rb
+++ b/app/services/stackmap_service.rb
@@ -79,7 +79,7 @@ class StackmapService
       end
 
       def stackmap_libs
-        %w[arch eastasian engineer lewis mendel plasma stokes firestone]
+        %w[arch eastasian engineer lewis mendel stokes firestone]
       end
 
       def by_title_locations

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,11 +15,15 @@
     <%= opensearch_description_tag application_name, main_app.opensearch_catalog_url(:format => 'xml') %>
     <%= favicon_link_tag 'favicon.ico' %>
     <link rel="stylesheet" href="https://use.typekit.net/yhr7zwc.css">
-    <link rel="stylesheet" media="all" type="text/css" href="https://www.stackmapintegration.com/princeton-blacklight/StackMap.min.css" />
+    <% if !Flipflop.temporary_where_to_find_it? %>
+      <link rel="stylesheet" media="all" type="text/css" href="https://www.stackmapintegration.com/princeton-blacklight/StackMap.min.css" />
+    <% end %>
     <%= stylesheet_link_tag "application", media: "screen" %>
     <%= stylesheet_link_tag "print", media: "print" %>
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-T8Gy5hrqNKT+hzMclPo118YTQO6cYprQmhrYwIiQ/3axmI1hQomh7Ud2hPOy8SP1" crossorigin="anonymous">
-    <script defer src="https://www.stackmapintegration.com/princeton-blacklight/StackMap.min.js" type="text/javascript"></script>
+    <% if !Flipflop.temporary_where_to_find_it? %>
+      <script defer src="https://www.stackmapintegration.com/princeton-blacklight/StackMap.min.js" type="text/javascript"></script>
+    <% end %>
     <% if controller.controller_name == "form" %>
       <%= javascript_include_tag 'requests/application' %>
       <%= vite_javascript_tag 'requests' %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -37,6 +37,10 @@ Flipflop.configure do
       description: "When on / true, a banner will be present to take the user to the search result form"
   end
 
+  feature :temporary_where_to_find_it,
+  default: true,
+  description: "When on / true, the where to find it links will be disabled."
+
   feature :blacklight_hierarchy_facet,
   default: true,
   description: "When on / true, use the colon delimited field to display the classification facet, when off / false use the pipe delimited field"

--- a/spec/system/stackmap_spec.rb
+++ b/spec/system/stackmap_spec.rb
@@ -7,10 +7,23 @@ describe 'stackmap', type: :system, js: true do
     stub_holding_locations
   end
   context 'using the stackmap' do
+    before do
+      allow(Flipflop).to receive(:temporary_where_to_find_it?).and_return(false)
+    end
     it 'has a link to the stackmap on the record page' do
       visit '/catalog/99125428126306421'
       click_button('Where to find it', wait: 5)
       expect(page).to have_button('zoom in')
+    end
+  end
+
+  context 'not using the stackmap' do
+    before do
+      allow(Flipflop).to receive(:temporary_where_to_find_it?).and_return(true)
+    end
+    it 'has a link to the stackmap on the record page' do
+      visit '/catalog/99125428126306421'
+      expect(page).not_to have_button('Where to find it')
     end
   end
 end


### PR DESCRIPTION
Adds a feature to temporarily disable the 'Where to find it' button. Also remove plasma physics from list of stackmap libs as it doesn't exist any longer.