### PR TITLE
Add a dialog warning users that they must log in to save bookmarks

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -38,6 +38,7 @@
 @import 'components/buttons';
 @import 'components/constraints';
 @import 'components/contact';
+@import 'components/dialog';
 @import 'components/dropdown';
 @import 'components/dropdown-help-text';
 @import 'components/facets';

--- a/app/assets/stylesheets/components/dialog.scss
+++ b/app/assets/stylesheets/components/dialog.scss
@@ -1,0 +1,23 @@
+dialog {
+    border: 1px solid var(--color-grayscale-lighter);
+    filter: drop-shadow(0 2px var(--color-grayscale-lighter));
+    width: min(700px, 90%);
+    font-family: var(--font-family-text);
+}
+
+dialog h2 {
+    font-weight: var(--font-weight-semi-bold);
+    font-size: var(--font-size-large);
+    line-height: var(--line-height-heading);
+}
+
+dialog h3 {
+    font-weight: var(--font-weight-semi-bold);
+    font-size: var(--font-size-base);
+    line-height: var(--line-height-heading);
+}
+
+dialog .dialog-title {
+    display: flex;
+    justify-content: space-between;
+}

--- a/app/javascript/orangelight/lux_import.js
+++ b/app/javascript/orangelight/lux_import.js
@@ -3,6 +3,7 @@ import 'lux-design-system/dist/style.css';
 import { LuxAlert, LuxBadge, LuxLibraryFooter } from 'lux-design-system';
 import OrangelightHeader from '../orangelight/vue_components/orangelight_header.vue';
 import OnlineOptions from './vue_components/online_options.vue';
+import BookmarkLoginDialog from './vue_components/bookmark_login_dialog.vue';
 import MultiselectCombobox from './vue_components/multiselect_combobox.vue';
 
 export function luxImport() {
@@ -18,7 +19,7 @@ export function luxImport() {
         .component('lux-library-footer', LuxLibraryFooter)
         .component('online-options', OnlineOptions)
         .component('orangelight-header', OrangelightHeader)
-        // .component('multiselect-combobox', MultiselectCombobox)
+        .component('bookmark-login-dialog', BookmarkLoginDialog)
         .mount(elements[i]);
     }
     const vueapp = createApp({});

--- a/app/javascript/orangelight/vue_components/bookmark_login_dialog.vue
+++ b/app/javascript/orangelight/vue_components/bookmark_login_dialog.vue
@@ -1,0 +1,45 @@
+<template>
+  <dialog id="bookmark-login" ref="dialog">
+    <div tabindex="-1">
+      <div class="dialog-title">
+        <h2>Log in to save bookmarks</h2>
+        <LuxInputButton
+          type="button"
+          variation="text"
+          currentColor="black"
+          @button-clicked="close"
+        >
+          <LuxIconBase height="14" width="14" iconName="close">
+            <LuxIconClose></LuxIconClose>
+          </LuxIconBase>
+        </LuxInputButton>
+      </div>
+      <h3>Library Account Holders</h3>
+      <p>
+        To save bookmarks for future sessions, please
+        <LuxHyperlink :href="loginUrl">log in</LuxHyperlink>
+        using your library account.
+      </p>
+      <h3>Guests</h3>
+      <p>
+        Bookmarks are unable to be saved for future sessions. You can export
+        your bookmarks to a citation manager each session.
+      </p>
+    </div>
+  </dialog>
+</template>
+<script setup>
+import {
+  LuxHyperlink,
+  LuxIconBase,
+  LuxIconClose,
+  LuxInputButton,
+} from 'lux-design-system';
+import { useTemplateRef } from 'vue';
+
+const props = defineProps(['loginUrl']);
+const dialog = useTemplateRef('dialog');
+function close() {
+  dialog.value.close();
+}
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -69,6 +69,9 @@
       </div>
 
     </div>
+    <div class="lux">
+      <bookmark-login-dialog login-url="<%= main_app.new_user_session_path(origin: request.fullpath) %>"></bookmark-login-dialog>
+    </div>
   </main>
   <% if @document && should_show_viewer? %>
     <%= render partial: 'show_digital_content', locals: { document: @document } %>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "blacklight-range-limit": "^9.0.0",
     "chart.js": "^4.4.7",
     "graphql": "^16.10.0",
-    "lux-design-system": "^6.8.2",
+    "lux-design-system": "^6.9.0",
     "serialize-javascript": "^6.0.2",
     "unfetch": "^5.0.0",
     "vue": "^3.4.21"

--- a/spec/javascript/orangelight/vue_components/bookmark_login_dialog.spec.js
+++ b/spec/javascript/orangelight/vue_components/bookmark_login_dialog.spec.js
@@ -1,0 +1,21 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect } from 'vitest';
+import BookmarkLoginDialog from '../../../../app/javascript/orangelight/vue_components/bookmark_login_dialog.vue';
+
+describe('BookmarkLoginDialog', () => {
+  it('calls the native HTMLDialogElement close() method when the user presses the close button', () => {
+    const wrapper = mount(BookmarkLoginDialog);
+    // Unfortunately, we need to mock the HTMLDialogElement's methods,
+    // since JSDOM has not yet implemented HTMLDialogElement at the
+    // time of writing (see https://github.com/jsdom/jsdom/issues/3294)
+    //
+    // It would be nicer to use the real HTMLDialogElement methods and
+    // make assertions about whether or not the modal is visible on the
+    // screen.
+    wrapper.vm.$refs.dialog.close = vi.fn();
+
+    wrapper.find('button').trigger('click');
+
+    expect(wrapper.vm.$refs.dialog.close).toHaveBeenCalled();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1949,10 +1949,10 @@ lru-cache@^10.2.0, lru-cache@^10.4.3:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
-lux-design-system@^6.8.2:
-  version "6.8.2"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-6.8.2.tgz#0748176005e08c4e80095e5a18a4ce58eac77ea4"
-  integrity sha512-J3WG/S9asHDfHyJX7WVQQz8kx8kFTfkQm8EacAZaWWgfnAoa1odviVmQ0oDiBquvz9icQC+eKY0cQk/sKs2AnQ==
+lux-design-system@^6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-6.9.0.tgz#683eaba63cbd4078dd58ac097b58c6058b4006ec"
+  integrity sha512-0N5Xvo7DEZnc21pqDvtmhMkmOCsyHe/n0KLSydxRWsBQlCGF8woSMQVzhSjDTz847iKv65M413vfRt7606blyA==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"


### PR DESCRIPTION
The dialog does not yet show unless you call the following in your browser console:

```
document.getElementById('bookmark-login').showModal()
```

Here is the current look:
![A large modal that says Log in to save bookmarks.  The headings look quite bold](https://github.com/user-attachments/assets/a9c280d8-2088-4879-9250-2254fb940210)


Helps with #4927