### PR TITLE
Updates to bookmark login dialog style and focus indicator

### DIFF
--- a/app/assets/stylesheets/components/dialog.scss
+++ b/app/assets/stylesheets/components/dialog.scss
@@ -1,20 +1,49 @@
 dialog {
     border: 1px solid var(--color-grayscale-lighter);
+    border-radius: 20px;
     filter: drop-shadow(0 2px var(--color-grayscale-lighter));
     width: min(700px, 90%);
     font-family: var(--font-family-text);
+    padding: 0;
 }
 
 dialog h2 {
     font-weight: var(--font-weight-semi-bold);
     font-size: var(--font-size-large);
     line-height: var(--line-height-heading);
+    margin-bottom: 0;
 }
 
 dialog h3 {
     font-weight: var(--font-weight-semi-bold);
     font-size: var(--font-size-base);
     line-height: var(--line-height-heading);
+    margin-bottom: 0;
+}
+
+dialog .dialog-content {
+    padding: 0 0 6px 15px;
+    border-radius: 20px;
+}
+
+dialog .dialog-content:focus {
+    /* Don't display a focus indicator on :focus, only on :focus-visible */
+    outline: none !important;
+}
+
+dialog .dialog-content:focus-visible {
+    outline-offset: -6px !important;
+    outline: .25rem solid var(--color-princeton-orange-on-white) !important;
+}
+
+dialog .dialog-content .close-button:focus-visible {
+    border-radius: 20px;
+    outline: .25rem solid var(--color-princeton-orange-on-white) !important;
+}
+
+dialog .dialog-content a:focus-visible {
+    border-radius: .1rem;
+    outline: .25rem solid var(--color-princeton-orange-on-white) !important;
 }
 
 dialog .dialog-title {

--- a/app/javascript/orangelight/vue_components/bookmark_button.vue
+++ b/app/javascript/orangelight/vue_components/bookmark_button.vue
@@ -53,7 +53,9 @@ function addToBookmarks() {
   });
   if (!props.loggedIn) {
     handleMissingLocalStorageKey('catalog.bookmarks.save_account_alert', () => {
-      document.getElementById('bookmark-login')?.showModal();
+      const dialog = document.getElementById('bookmark-login');
+      dialog?.showModal();
+      setTimeout(() => dialog?.querySelector('.dialog-content').focus());
       return new Date(Date.now()).toISOString();
     });
   }
@@ -96,6 +98,7 @@ function toggle() {
 }
 .bookmark-button button.lux-button.outline {
   display: flex;
+  align-items: center;
   border: 0.125rem solid var(--color-grayscale-light);
   color: var(--color-grayscale-dark);
   width: fit-content;

--- a/app/javascript/orangelight/vue_components/bookmark_login_dialog.vue
+++ b/app/javascript/orangelight/vue_components/bookmark_login_dialog.vue
@@ -1,6 +1,6 @@
 <template>
   <dialog id="bookmark-login" ref="dialog">
-    <div tabindex="-1">
+    <div class="dialog-content" tabindex="-1">
       <div class="dialog-title">
         <h2>Log in to save bookmarks</h2>
         <LuxInputButton


### PR DESCRIPTION
* Set focus on the whole dialog body, rather than the close button
* Adjust spacing in the dialog
* Attempt to only display focus indicator in dialog when the user opens it with keyboard input using focus-visible rather than focus (note that this works for Firefox and Chrome, but not Safari
* Round the edges of the dialog
* Use an orange, lux-style focus indicator