### PR TITLE
Turn metadata elements in the search results page gray

### DIFF
--- a/app/assets/stylesheets/components/search-results.scss
+++ b/app/assets/stylesheets/components/search-results.scss
@@ -50,6 +50,10 @@
     font-size: 0.875em;
     text-transform: uppercase;
   }
+
+  .search-metadata {
+    color: $dark-gray;
+  }
 }
 
 .document a:hover {

--- a/app/components/index_metadata_field_layout_component.html.erb
+++ b/app/components/index_metadata_field_layout_component.html.erb
@@ -1,7 +1,7 @@
 <% if values.any? %>
   <ul>
   <% values.each do |value| %>
-    <li><%= value%></li>
+    <li class='search-metadata'><%= value%></li>
   <% end %>
   </ul>
 <% end %>


### PR DESCRIPTION
Addresses issue https://github.com/pulibrary/orangelight/issues/4918. See my comment on the ticket of my choice of gray hex color due to contrast issues. Feel free to change the hex to something better. Note this will turn all textual metadata elements on the page gray. Sometimes we have nested lists i.e. with classes like blacklight-pub_created_display. It seemed the best choice to just give them all the same treatment.

With our $dark-gray value
<img width="904" height="470" alt="Screenshot 2025-07-15 at 5 21 27 PM" src="https://github.com/user-attachments/assets/d37c1ac3-e782-4501-8586-1b7b98cff196" />

With #595959 (the lightest gray that I could get to pass WCAG-AAA)
<img width="887" height="463" alt="Screenshot 2025-07-15 at 5 26 04 PM" src="https://github.com/user-attachments/assets/7e9c083e-fc85-4481-96ea-3c9731e6007a" />

