### PR TITLE
Don't send SignalException to honeybadger

### DIFF
--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -9,3 +9,4 @@ exceptions:
     - 'RedisClient::CannotConnectError'
     - 'RedisClient::ReadTimeoutError'
     - 'RSolr::Error::ConnectionRefused'
+    - 'SignalException'


### PR DESCRIPTION
This exception when sneakers is stopped and then restarted.  We don't need this noise in Honeybadger, so we can ignore this exception class.