### PR TITLE
Use hyphenated prop rather than camel case

### DIFF
--- a/app/components/holdings/holding_notes_component.rb
+++ b/app/components/holdings/holding_notes_component.rb
@@ -64,7 +64,7 @@ class Holdings::HoldingNotesComponent < ViewComponent::Base
           <ul class="<%= list_class %>">
             <li class="holding-label"><%= label %></li>
             <% notes.each do |note| %>
-              <li><lux-show-more v-bind:character-limit="150" show-label="See more" hideLabel="See less"><%= note %></lux-show-more></li>
+              <li><lux-show-more v-bind:character-limit="150" show-label="See more" hide-label="See less"><%= note %></lux-show-more></li>
             <% end %>
           </ul>
         END_TEMPLATE


### PR DESCRIPTION
Otherwise [the browser converts the camel case prop to lower case and Vue no longer knows its a prop](https://vuejs.org/guide/essentials/component-basics.html#in-dom-template-parsing-caveats).

Helps with #4944