### PR TITLE
Don't show the text Location has

### DIFF
--- a/app/components/holdings/holding_notes_component.html.erb
+++ b/app/components/holdings/holding_notes_component.html.erb
@@ -7,9 +7,13 @@
     render_list label: 'Location note', list_class: 'location-note', notes: holding['location_note']
   end %>
 
-  <%= if render_location_has?
-    render_list label: 'Location has', list_class: 'location-has', notes: holding['location_has']
-  end %>
+  <% if render_location_has? -%>
+    <ul class="location-has">
+      <% holding['location_has'].each do |note| %>
+        <li><lux-show-more v-bind:character-limit="150" show-label="See more" hide-label="See less"><%= note %></lux-show-more></li>
+      <% end %>
+    </ul>
+  <% end -%>
 
   <ul class="item-status" data-record-id="<%= doc_id %>" data-holding-id="<%= holding_id %>"></ul>
 

--- a/spec/components/holdings/holding_notes_component_spec.rb
+++ b/spec/components/holdings/holding_notes_component_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe Holdings::HoldingNotesComponent, type: :component do
 
     it "renders location has list" do
       expect(rendered.css("ul.location-has")).to be_present
-      expect(rendered.text).to include("Location has")
       expect(rendered.text).to include("Has 1")
     end
   end


### PR DESCRIPTION
This makes it compatible with the figma

Before:
<img width="890" height="221" alt="holding group on the show page shows a science call number, call no browse, the text location has, then information about which journal volumes are at Forrestal" src="https://github.com/user-attachments/assets/d77bd5f3-73ed-4a96-8928-64d1ec802b6b" />


After:

<img width="898" height="204" alt="all data is the same except there is no text location has under call no browse" src="https://github.com/user-attachments/assets/b25907b1-d9e2-41ef-9ad2-d80d617ae4ee" />
