### PR TITLE
Fix format icon centering on Firefox

### DIFF
--- a/app/assets/stylesheets/components/record--sidebar.scss
+++ b/app/assets/stylesheets/components/record--sidebar.scss
@@ -21,9 +21,12 @@
     margin: 0 auto;
     padding: 0;
 
+    img {
+        display: block;
+    }
+
     img,
     .default {
-        display: block;
         margin: 0 auto;
         border: 1px solid #E1E1E1;
         border-radius: 10px;


### PR DESCRIPTION
This is a small follow-up to #5022.  Firefox and Chromium calculated the specifity slightly differently, leading to Firefox getting `display: block` rather than `display: flex` (and the icon was not centered as a result).

This commit removes the conflicting rule, so we can be confident that we'll have `display: flex` in Firefox or Chromium.

Before (on Firefox):
<img width="215" height="238" alt="the journal icon is hugging the left edge" src="https://github.com/user-attachments/assets/9a86bbf5-1cf0-4ff5-a251-997921ec8582" />


After (on Firefox):
<img width="216" height="251" alt="the journal icon is centered horizontally" src="https://github.com/user-attachments/assets/47acbd26-b849-429b-a2fa-1413325e732e" />
