### PR TITLE
Search result holding cards: add line break suggestions

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -81,7 +81,7 @@ module ApplicationHelper
     location = holding_library_label(holding)
     pin = content_tag(:span, "", class: 'icon icon-location')
     location_display = content_tag(:div, pin.html_safe + location, class: 'results_location row') + " " +
-                       content_tag(:div, holding['call_number'], class: 'call-number')
+                       content_tag(:div, CallNumber.new(holding['call_number']).with_line_break_suggestions, class: 'call-number')
     location_display.html_safe
   end
 

--- a/app/models/call_number.rb
+++ b/app/models/call_number.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# This class is responsible for preparing a call number for display
+class CallNumber
+  def initialize(label)
+    @label = label
+  end
+
+  def with_line_break_suggestions
+    sanitize label.gsub('.', '<wbr>.')
+  end
+
+    private
+
+      attr_reader :label
+
+      def sanitize(html)
+        ActionController::Base.helpers.sanitize html, scrubber:
+      end
+
+      # :reek:FeatureEnvy
+      def scrubber
+        @scrubber ||= Loofah::Scrubber.new do |node|
+          node.remove unless node.text? || node.name == 'wbr'
+        end
+      end
+end

--- a/app/models/call_number.rb
+++ b/app/models/call_number.rb
@@ -12,7 +12,9 @@ class CallNumber
 
     private
 
-      attr_reader :label
+      def label
+        @label || ''
+      end
 
       def sanitize(html)
         ActionController::Base.helpers.sanitize html, scrubber:

--- a/spec/models/call_number_spec.rb
+++ b/spec/models/call_number_spec.rb
@@ -12,5 +12,9 @@ RSpec.describe CallNumber do
       expect(described_class.new('G4312<script><p><div>').with_line_break_suggestions).to eq 'G4312'
       expect(described_class.new('G4312<script>alert("HI!")</script>').with_line_break_suggestions).to eq 'G4312'
     end
+
+    it 'returns an empty string if call number label is nil' do
+      expect(described_class.new(nil).with_line_break_suggestions).to eq ''
+    end
   end
 end

--- a/spec/models/call_number_spec.rb
+++ b/spec/models/call_number_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe CallNumber do
+  describe '#with_line_break_suggestions' do
+    it 'adds line break suggestions (<wbr>) before periods' do
+      expect(described_class.new('G4312.S6C18.1943.D4I5').with_line_break_suggestions).to eq 'G4312<wbr>.S6C18<wbr>.1943<wbr>.D4I5'
+      expect(described_class.new('G4312.S6C18.1943.D4I5').with_line_break_suggestions).to be_html_safe
+    end
+
+    it 'removes unnecessary html' do
+      expect(described_class.new('G4312<script><p><div>').with_line_break_suggestions).to eq 'G4312'
+      expect(described_class.new('G4312<script>alert("HI!")</script>').with_line_break_suggestions).to eq 'G4312'
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit, long call numbers without spaces overflowed out of holding cards.  This commit adds line break suggestions (HTML <wbr> tag) in front of each period so the browser can safely break up the call numbers if they don't fit in a card.

Before:
<img width="492" height="216" alt="a search result called Soda Canyon.  The call number is G4312.S6C18.1943.D4I5  It does not break and overflows outside its block" src="https://github.com/user-attachments/assets/8086cff6-0a67-4f92-bc33-7204636d9e8b" />

After:
<img width="519" height="239" alt="The same search result as above, but the call number has a line break before .1943" src="https://github.com/user-attachments/assets/68033b1b-190f-43c7-af02-65a775ff160f" />
