### PR TITLE
Adjust spacing of globe icon

### DIFF
--- a/app/javascript/orangelight/vue_components/online_options.vue
+++ b/app/javascript/orangelight/vue_components/online_options.vue
@@ -35,7 +35,7 @@ a {
 }
 
 .icon {
-  padding-right: 0px;
+  padding-right: var(--space-xx-small);
 
   &.icon-external {
     margin-left: 6px;


### PR DESCRIPTION
Helps with #5031

Before:

<img width="112" height="31" alt="the text begins immediately to the right of the globe icon" src="https://github.com/user-attachments/assets/f57d2ad1-f882-4f17-84f1-6b3b5f035ede" />


After:
<img width="136" height="47" alt="there are a few pixels of space between the globe icon and the start of the text" src="https://github.com/user-attachments/assets/dba187fb-16b8-49f3-8491-b50c3264226a" />
