### PR TITLE
Display holding notes and details in gray

### DIFF
--- a/app/assets/stylesheets/components/record.scss
+++ b/app/assets/stylesheets/components/record.scss
@@ -86,10 +86,6 @@
         color: $blacklight-gray;
       }
 
-      .holding-details li {
-        color: $black;
-      }
-
       .item-status:empty {
         display: none;
       }


### PR DESCRIPTION
Helps with #5031

Before
<img width="259" height="68" alt="journal holding years are in black text" src="https://github.com/user-attachments/assets/1e2517b8-745a-4d50-be88-75dcc4faeeef" />


After
<img width="266" height="70" alt="journal holding years are in a gray color" src="https://github.com/user-attachments/assets/3eed75ce-0a73-42ff-9e76-db03018969ec" />
