### PR TITLE
Add fix to right-align the icon/book jacket and the bookmark button in search results (#5021 checkbox 9)

### DIFF
--- a/app/assets/stylesheets/components/record--sidebar.scss
+++ b/app/assets/stylesheets/components/record--sidebar.scss
@@ -18,7 +18,7 @@
     display: block;
     // height: 110px;
     // width: 100%;
-    margin: 0 auto;
+    margin: 0 .25rem;
     padding: 0;
 
     img {

--- a/app/assets/stylesheets/components/search-results.scss
+++ b/app/assets/stylesheets/components/search-results.scss
@@ -83,6 +83,9 @@ dd.blacklight-electronic_access_display {
 }
 
 .thumbnail-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   width: 120px;
   padding-left: 10px;
 }


### PR DESCRIPTION
Resolves ninth checkbox of #5021 