### PR TITLE
[feature branch] Show page regression: call number needs to be in a readable font

### DIFF
--- a/app/assets/stylesheets/components/availability.scss
+++ b/app/assets/stylesheets/components/availability.scss
@@ -484,13 +484,6 @@
   }
 }
 
-.holding-call-number {
-  font-family: 'Roboto Mono', monospace;
-  a {
-    font-family: initial
-  }
-}
-
 .record-availability, .document {
   h3 {
       margin-top: 1rem;

--- a/app/components/holdings/call_number_link_component.html.erb
+++ b/app/components/holdings/call_number_link_component.html.erb
@@ -1,6 +1,6 @@
 <div>
 <% unless cn_value.nil? %>
-  <%= holding['call_number'] %>
+  <span class="call-number"><%= holding['call_number'] %></span>
   <a href="<%= browse_url %>" class="browse-cn"
     data-original-title="<%= original_title %>">
     <span class="link-text"><%= I18n.t('blacklight.holdings.browse') %></span>

--- a/spec/components/holdings/call_number_link_component_spec.rb
+++ b/spec/components/holdings/call_number_link_component_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 
 RSpec.describe Holdings::CallNumberLinkComponent, type: :component do
   let :holding do
-    { call_number: 'East 45/GC073/Box 06/Oversize' }
+    { call_number: 'East 45/GC073/Box 06/Oversize' }.with_indifferent_access
   end
   let(:call_number) { 'East 45/GC073/Box 06/Oversize' }
   let :rendered do
@@ -17,6 +17,10 @@ RSpec.describe Holdings::CallNumberLinkComponent, type: :component do
 
   it 'is a table cell' do
     expect(rendered.css('div').length).to eq 1
+  end
+
+  it 'puts the call number in a .call-number class' do
+    expect(rendered.css('.call-number').text).to eq 'East 45/GC073/Box 06/Oversize'
   end
 
   context 'when no call_number is provided' do


### PR DESCRIPTION
#3538 started using a specific font for call numbers, to make a clearer distinction between characters that are easily confused for one another (e.g. 1, l, and I)

I accidentally introduced a regression on this behavior in #4991.  This PR brings back the needed call-number class, and removes some CSS that is no longer used.