### PR TITLE
Remove unused font css

### DIFF
--- a/app/assets/stylesheets/components/font-face.scss
+++ b/app/assets/stylesheets/components/font-face.scss
@@ -11,16 +11,6 @@
 }
 
 @font-face {
-  font-family: 'Droid Serif';
-  src: font-url('Droid_Serif/droidserif-webfont.eot'); /* IE9 Compat Modes */
-  src: font-url('Droid_Serif/droidserif-webfont.eot?#iefix') format('embedded-opentype'), /* IE6-IE8 */
-       font-url('Droid_Serif/droidserif-webfont.woff2') format('woff2'), /* Super Modern Browsers */
-       font-url('Droid_Serif/droidserif-webfont.woff') format('woff'), /* Pretty Modern Browsers */
-       font-url('Droid_Serif/droidserif-webfont.ttf')  format('truetype'), /* Safari, Android, iOS */
-       font-url('Droid_Serif/droidserif-webfont.svg#svgFontName') format('svg'); /* Legacy iOS */
-}
-
-@font-face {
      font-family: 'Roboto Mono';
      src: font-url('RobotoMono/RobotoMono-Regular.ttf') format('truetype');
 }

--- a/app/assets/stylesheets/variables/typography.scss
+++ b/app/assets/stylesheets/variables/typography.scss
@@ -1,7 +1,5 @@
-$font-serif: 'Droid Serif', Georgia, Times, serif !default;
 $font-sans: 'Dejavu Sans', Helvetica, sans-serif !default;
 $font-sans-alt: praxis-next-condensed, Helvetica, sans-serif !default;
-$font-mono: 'Lucida Console', Monaco, monospace !default;
 $text-color: #000 !default;
 
 $text-small: 12px;


### PR DESCRIPTION
Just a small cleanup piece: the Droid Serif font is never used in the catalog, so we don't need the `@font-face` rule for it.  At the end of the day, this doesn't actually save any network calls, since modern browsers are smart enough to not download unused fonts.  It still offers a slight reduction in how much CSS the user needs to download and that we need to maintain.