### PR TITLE
Address mobile layout shift

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -77,5 +77,10 @@
     <%= render partial: 'show_digital_content', locals: { document: @document } %>
   <% end %>
   <%= render :partial => 'shared/footer' %>
+  <script>
+    // Intentionally block DOM parsing until we have removed the no-js class,
+    // to avoid layout shifts
+    document.querySelector('html').classList.remove('no-js');
+  </script>
   </body>
 </html>


### PR DESCRIPTION
Prior to this commit, the home page of the catalog had a large layout shift visible on slow connections speeds.  To reproduce:

1. Go to the home page of the catalog
2. In your browser's dev tools, open the network tab
3. Set the throttling to 3g or slower
4. Reload the home page of the catalog
5. Notice that when the content loads, facets are all expanded and at the beginning of the screen.  Later, the facets collapse and move to the top of the screen.

This was due to the blacklight no-js feature, which expands the facets and puts them at the bottom of the screen before it has determined that JS is enabled.  Once it has realized JS is enabled, it moves it back into the expected location.  See https://github.com/projectblacklight/blacklight/pull/2902

This moves the process of determining js support earlier using an inline script tag, which should block DOM parsing so there is never a time that content is displayed on the screen before checking JS support. Thanks to @cbeer for suggesting this approach in https://github.com/projectblacklight/blacklight/pull/2899#issuecomment-1315779289

On my laptop with 3g-speed throttling, lighthouse gave a CLS of 0.81 before this commit, and 0.054 after it.

This should help with our intermittent lighthouse CI failures as well.