### PR TITLE
Fix spacing in 'Copies in library' box so location and call number don't appear so far apart

### DIFF
--- a/app/assets/stylesheets/components/details.scss
+++ b/app/assets/stylesheets/components/details.scss
@@ -35,8 +35,8 @@ details:not([open]) summary .when-open {
     display: none;
 }
 
-details>* {
-    padding: var(--space-small) var(--space-base);
+details > * {
+    padding: var(--space-x-small) var(--space-base);
 }
 
 summary .side-by-side {


### PR DESCRIPTION
Resolves #5069