### PR TITLE
Don't display a hyphen in holding group names if location name is empty

### DIFF
--- a/app/models/requests/holding.rb
+++ b/app/models/requests/holding.rb
@@ -20,7 +20,7 @@ module Requests
       if location_name.starts_with? library_name
         location_name
       else
-        "#{library_name} - #{location_name}"
+        [library_name, location_name].compact_blank.join(' - ')
       end
     end
 

--- a/spec/models/requests/holding_spec.rb
+++ b/spec/models/requests/holding_spec.rb
@@ -62,6 +62,14 @@ RSpec.describe Requests::Holding, requests: true do
       expect(holding.full_location_name).to eq 'Lewis Library - Course Reserve'
     end
 
+    it 'does not include the hyphen if location name is empty' do
+      holding = described_class.new(
+        mfhd_id: "22749747440006421",
+        holding_data: JSON.parse('{"location_code":"eastasian$cjk","location":"","library":"East Asian Library","call_number":"DS747.45 .S673 2025"}')
+      )
+      expect(holding.full_location_name).to eq 'East Asian Library'
+    end
+
     it 'does not repeat the library name if it is also included in the location name' do
       holding = described_class.new(
         mfhd_id: "22749747440006421",


### PR DESCRIPTION
Previously, the location eastasian appeared as 'East Asian Library -'.  With this commit, it simply appears on the show page as 'East Asian Library'.

Resolves https://github.com/pulibrary/orangelight/issues/5074