### PR TITLE
Keep holding group open when user returns from the request form

### DIFF
--- a/app/components/holdings/location_services_component.rb
+++ b/app/components/holdings/location_services_component.rb
@@ -3,17 +3,19 @@
 # which services are available for a holding, given
 # its location (typically some type of Request button)
 # :reek:TooManyMethods
+# :reek:TooManyInstanceVariables
 class Holdings::LocationServicesComponent < ViewComponent::Base
-  def initialize(adapter, holding_id, location_rules, holding)
+  def initialize(adapter, holding_id, location_rules, holding, open_holdings = nil)
     @adapter = adapter
     @holding_id = holding_id
     @location_rules = location_rules
     @holding = holding
+    @open_holdings = open_holdings
   end
 
     private
 
-      attr_reader :adapter, :holding_id, :location_rules, :holding
+      attr_reader :adapter, :holding_id, :location_rules, :holding, :open_holdings
 
       def doc_id
         holding["mms_id"] || adapter.doc_id
@@ -29,16 +31,16 @@ class Holdings::LocationServicesComponent < ViewComponent::Base
         if holding_id == 'thesis' || numismatics?
           AeonRequestButtonComponent.new(document:, holding: holding_hash, url_class: Requests::NonAlmaAeonUrl)
         elsif items && items.length > 1
-          RequestButtonComponent.new(doc_id:, holding_id:, location: location_rules)
+          RequestButtonComponent.new(doc_id:, holding_id:, location: location_rules, open_holdings:)
         elsif aeon_location?
           AeonRequestButtonComponent.new(document:, holding: holding_hash)
         elsif scsb_location?
-          RequestButtonComponent.new(doc_id:, location: location_rules, holding:)
+          RequestButtonComponent.new(doc_id:, location: location_rules, holding:, open_holdings:)
         elsif temporary_holding_id?
           holding_identifier = temporary_location_holding_id_first
-          RequestButtonComponent.new(doc_id:, holding_id: holding_identifier, location: location_rules)
+          RequestButtonComponent.new(doc_id:, holding_id: holding_identifier, location: location_rules, open_holdings:)
         else
-          RequestButtonComponent.new(doc_id:, holding_id:, location: location_rules)
+          RequestButtonComponent.new(doc_id:, holding_id:, location: location_rules, open_holdings:)
         end
       end
       # rubocop:enable Lint/DuplicateBranch

--- a/app/components/holdings/physical_holding_component.html.erb
+++ b/app/components/holdings/physical_holding_component.html.erb
@@ -17,7 +17,7 @@
       <%= render Holdings::HoldingAvailabilityComponent.new(doc_id, holding_id, location_rules, temp_location_code) %>
     <% end %>
 
-    <%= render(Holdings::LocationServicesComponent.new(adapter, holding_id, location_rules, holding)) %>
+    <%= render(Holdings::LocationServicesComponent.new(adapter, holding_id, location_rules, holding, open_holdings)) %>
 </tr>
 
 

--- a/app/components/holdings/physical_holding_component.rb
+++ b/app/components/holdings/physical_holding_component.rb
@@ -3,15 +3,16 @@
 # This component is responsible for showing the details of a physical
 # holding (such as on the show page)
 class Holdings::PhysicalHoldingComponent < ViewComponent::Base
-  def initialize(adapter, holding_id, holding)
+  def initialize(adapter, holding_id, holding, open_holdings = nil)
     @adapter = adapter
     @holding_id = holding_id
     @holding = holding
+    @open_holdings = open_holdings
   end
 
   private
 
-    attr_reader :adapter, :holding_id, :holding
+    attr_reader :adapter, :holding_id, :holding, :open_holdings
 
     def cn_value
       adapter.call_number(holding)

--- a/app/components/holdings/physical_holding_group_component.html.erb
+++ b/app/components/holdings/physical_holding_group_component.html.erb
@@ -23,7 +23,7 @@
         </tr>
       </thead>
       <% group.holdings.each do |holding| %>
-        <%= render Holdings::PhysicalHoldingComponent.new(adapter, holding.mfhd_id, holding.holding_data) %>
+        <%= render Holdings::PhysicalHoldingComponent.new(adapter, holding.mfhd_id, holding.holding_data, group.group_name) %>
       <% end %>
     </table>
   </div>

--- a/app/components/request_button_component.rb
+++ b/app/components/request_button_component.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 # ViewComponent that displays a request button on the show page
+# :reek:TooManyInstanceVariables
 class RequestButtonComponent < ViewComponent::Base
-  def initialize(location:, doc_id:, holding: nil, holding_id: nil)
+  def initialize(location:, doc_id:, holding: nil, holding_id: nil, open_holdings: nil)
     @location = location
     @doc_id = doc_id
     @holding = holding
     @holding_id = holding_id
+    @open_holdings = open_holdings
   end
 
   def label
@@ -15,11 +17,13 @@ class RequestButtonComponent < ViewComponent::Base
   end
 
   def url
-    query = { mfhd: @holding_id, aeon: aeon?.to_s }.compact.to_query
+    query = { mfhd: @holding_id, aeon: aeon?.to_s, open_holdings: }.compact.to_query
     URI::HTTP.build(path: "/requests/#{@doc_id}", query:).request_uri
   end
 
   private
+
+    attr_reader :open_holdings
 
     def aeon?
       @aeon ||= (@location&.dig(:aeon_location) || scsb_supervised_items?)

--- a/app/controllers/requests/form_controller.rb
+++ b/app/controllers/requests/form_controller.rb
@@ -15,6 +15,7 @@ module Requests
       system_id = sanitize(params[:system_id])
       mfhd = sanitize(params[:mfhd])
       params.require(:mfhd) unless system_id.starts_with?("SCSB") # there are not multiple locations for shared items so no MFHD is passed
+      @back_to_record_url = BackToRecordUrl.new(params)
 
       @user = current_or_guest_user
 
@@ -25,9 +26,8 @@ module Requests
       @title = "Request ID: #{system_id}"
 
       # needed to see if we can suppress login for this item
-      @request = FormDecorator.new(Requests::Form.new(system_id:, mfhd:, patron: @patron), view_context)
+      @request = FormDecorator.new(Requests::Form.new(system_id:, mfhd:, patron: @patron), view_context, @back_to_record_url)
     rescue ActionController::ParameterMissing
-      @system_id = system_id
       render 'requests/form/no_location_specified'
     end
 

--- a/app/models/requests/back_to_record_url.rb
+++ b/app/models/requests/back_to_record_url.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+# This class is responsible for assembling the URL for the user
+# to return to the record they were viewing prior to entering the
+# requests system
+class Requests::BackToRecordUrl
+  def initialize(input_params)
+    @input_params = input_params.permit(:system_id, :open_holdings)
+  end
+
+  def to_s
+    Rails.application.routes.url_helpers.solr_document_path output_params
+  end
+
+    private
+
+      attr_reader :input_params
+
+      def output_params
+        { id: system_id, open_holdings: }.compact
+      end
+
+      def system_id
+        input_params[:system_id]
+      end
+
+      def open_holdings
+        input_params[:open_holdings]
+      end
+end

--- a/app/models/requests/form_decorator.rb
+++ b/app/models/requests/form_decorator.rb
@@ -11,21 +11,18 @@ module Requests
 
     alias bib_id system_id
 
-    attr_reader :request, :view_context, :first_filtered_requestable, :non_requestable_message
-    def initialize(request, view_context)
+    attr_reader :request, :view_context, :first_filtered_requestable, :non_requestable_message, :back_to_record_url
+    def initialize(request, view_context, back_to_record_url)
       @request = request
       @view_context = view_context
       @requestable_list = request.requestable.map { |req| RequestableDecorator.new(req, view_context) }
       @first_filtered_requestable = RequestableDecorator.new(request.first_filtered_requestable, view_context)
       @non_requestable_message = "See Circulation Desk, there are no requestable items for this record"
+      @back_to_record_url = back_to_record_url
     end
 
     def requestable
       @requestable_list
-    end
-
-    def catalog_url
-      "/catalog/#{system_id}"
     end
 
     # rubocop:disable Rails/OutputSafety

--- a/app/views/requests/form/_return_to_record_link.html.erb
+++ b/app/views/requests/form/_return_to_record_link.html.erb
@@ -1,5 +1,5 @@
 <a class="btn btn-primary" id="returnToRecordLink"
-  href="<%= record_url %>">
+  href="<%= back_to_record_url %>">
   <span class="icon-refresh"></span>
   <span class="d-lg-inline">
     Return to record

--- a/app/views/requests/form/generate.erb
+++ b/app/views/requests/form/generate.erb
@@ -1,6 +1,6 @@
 <% document = @request.try(:request)&.doc %>
 <div class="col-12">
-    <%= render partial: 'return_to_record_link', locals: {record_url: @request.catalog_url} %>
+    <%= render partial: 'return_to_record_link', locals: {back_to_record_url: @request.back_to_record_url} %>
     <div class="doc-<%= @request.system_id %>">
         <h1>
           <%= request_title %>

--- a/app/views/requests/form/no_location_specified.html.erb
+++ b/app/views/requests/form/no_location_specified.html.erb
@@ -1,4 +1,4 @@
 <div class="col-12">
-  <%= render partial: 'return_to_record_link', locals: {record_url: "/catalog/#{@system_id}"} %>
+  <%= render partial: 'return_to_record_link', locals: {back_to_record_url: @back_to_record_url} %>
   <p>Please choose a specific location on the Record Page!</p>    
 </div>

--- a/spec/components/request_button_component_spec.rb
+++ b/spec/components/request_button_component_spec.rb
@@ -59,4 +59,11 @@ RSpec.describe RequestButtonComponent, type: :component do
       end
     end
   end
+  context 'when open_holdings is provided' do
+    subject { render_inline(described_class.new(location:, doc_id: '123', holding_id: '456', open_holdings: 'Firestone Library - Stacks')) }
+
+    it 'includes it in the link url' do
+      expect(subject.css('a').attribute('href').text).to eq('/requests/123?aeon=false&mfhd=456&open_holdings=Firestone+Library+-+Stacks')
+    end
+  end
 end

--- a/spec/features/login_account_spec.rb
+++ b/spec/features/login_account_spec.rb
@@ -94,7 +94,7 @@ describe 'Account login' do
         expect(page).to have_link('Log in with netID')
         click_link('Log in with netID')
         expect(page).to have_content('Library Material Request')
-        expect(page).to have_current_path('/requests/SCSB-2143785?aeon=false')
+        expect(page.current_path).to start_with('/requests/SCSB-2143785')
         expect(page).to have_selector('#request_3270290')
       end
 

--- a/spec/helpers/requests/application_helper_spec.rb
+++ b/spec/helpers/requests/application_helper_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
     let(:default_pick_ups) do
       [{ label: "Firestone Library", gfa_pickup: "PA", staff_only: false }, { label: "Architecture Library", gfa_pickup: "PW", staff_only: false }, { label: "East Asian Library", gfa_pickup: "PL", staff_only: false }, { label: "Lewis Library", gfa_pickup: "PN", staff_only: false }, { label: "Marquand Library of Art and Archaeology", gfa_pickup: "PJ", staff_only: false }, { label: "Mendel Music Library", gfa_pickup: "PK", staff_only: false }, { label: "Plasma Physics Library", gfa_pickup: "PQ", staff_only: false }, { label: "Stokes Library", gfa_pickup: "PM", staff_only: false }]
     end
-    let(:lewis_request_with_multiple_requestable) { Requests::FormDecorator.new(Requests::Form.new(**params), self) }
+    let(:lewis_request_with_multiple_requestable) { Requests::FormDecorator.new(Requests::Form.new(**params), self, '/catalog/12345') }
     let(:requestable_list) { lewis_request_with_multiple_requestable.requestable }
     let(:submit_button_disabled) { helper.submit_button_disabled?(requestable_list) }
     it 'lewis is a submitable request' do
@@ -110,7 +110,7 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
     let(:default_pick_ups) do
       [{ label: "Firestone Library", gfa_pickup: "PA", staff_only: false }, { label: "Architecture Library", gfa_pickup: "PW", staff_only: false }, { label: "East Asian Library", gfa_pickup: "PL", staff_only: false }, { label: "Lewis Library", gfa_pickup: "PN", staff_only: false }, { label: "Marquand Library of Art and Archaeology", gfa_pickup: "PJ", staff_only: false }, { label: "Mendel Music Library", gfa_pickup: "PK", staff_only: false }, { label: "Plasma Physics Library", gfa_pickup: "PQ", staff_only: false }, { label: "Stokes Library", gfa_pickup: "PM", staff_only: false }]
     end
-    let(:lewis_request_with_multiple_requestable) { Requests::FormDecorator.new(Requests::Form.new(**params), self) }
+    let(:lewis_request_with_multiple_requestable) { Requests::FormDecorator.new(Requests::Form.new(**params), self, '/catalog/12345') }
     let(:requestable_list) { lewis_request_with_multiple_requestable.requestable }
     let(:submit_button_disabled) { helper.submit_button_disabled?(requestable_list) }
     let(:availability_response) { File.read("spec/fixtures/scsb_availability_994264203506421.json") }
@@ -135,7 +135,7 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
         patron:
       }
     end
-    let(:aeon_only_request) { Requests::FormDecorator.new(Requests::Form.new(**params), nil) }
+    let(:aeon_only_request) { Requests::FormDecorator.new(Requests::Form.new(**params), nil, '/catalog/12345') }
     let(:login_suppressed) { helper.suppress_login?(aeon_only_request) }
 
     it 'returns a boolean to disable/enable submit' do

--- a/spec/models/requests/back_to_record_url_spec.rb
+++ b/spec/models/requests/back_to_record_url_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Requests::BackToRecordUrl do
+  it 'goes to the desired catalog record' do
+    params = ActionController::Parameters.new(system_id: 'SCSB-1234')
+    expect(described_class.new(params).to_s).to eq '/catalog/SCSB-1234'
+  end
+
+  it 'includes open_holdings if provided' do
+    params = ActionController::Parameters.new(system_id: 'SCSB-1234', open_holdings: 'Firestone Library - Stacks')
+    expect(described_class.new(params).to_s).to eq '/catalog/SCSB-1234?open_holdings=Firestone+Library+-+Stacks'
+  end
+
+  it 'does not include irrelevant params' do
+    params = ActionController::Parameters.new(system_id: 'SCSB-1234', dogs: 'Malamute')
+    expect(described_class.new(params).to_s).to eq '/catalog/SCSB-1234'
+  end
+end

--- a/spec/models/requests/form_decorator_spec.rb
+++ b/spec/models/requests/form_decorator_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 describe Requests::FormDecorator, requests: true do
   include ActionView::TestCase::Behavior
 
-  subject(:decorator) { described_class.new(request, view) }
+  subject(:decorator) { described_class.new(request, view, '/catalog/123abc') }
   let(:user) { FactoryBot.build(:user) }
   let(:test_patron) do
     { "netid" => "foo", "first_name" => "Foo", "last_name" => "Request",
@@ -34,12 +34,6 @@ describe Requests::FormDecorator, requests: true do
   describe "#bib_id" do
     it 'is the system id' do
       expect(decorator.bib_id).to eq('123abc')
-    end
-  end
-
-  describe "#catalog_url" do
-    it 'points to the catalog' do
-      expect(decorator.catalog_url).to eq('/catalog/123abc')
     end
   end
 
@@ -193,7 +187,7 @@ describe Requests::FormDecorator, requests: true do
       request2 = instance_double(Requests::RequestableDecorator, aeon?: true)
       request = instance_double(Requests::Form, system_id: '123abc', mfhd: '112233', ctx: solr_context, requestable: [request1, request2], patron:, first_filtered_requestable: requestable,
                                                 hidden_field_metadata: { title: 'title', author: 'author', isbn: 'isbn' })
-      decorator = described_class.new(request, view)
+      decorator = described_class.new(request, view, '/catalog/123abc')
       expect(decorator.only_aeon?).to be_truthy
     end
 
@@ -202,7 +196,7 @@ describe Requests::FormDecorator, requests: true do
       request2 = instance_double(Requests::RequestableDecorator, aeon?: false)
       request = instance_double(Requests::Form, system_id: '123abc', mfhd: '112233', ctx: solr_context, requestable: [request1, request2], patron:, first_filtered_requestable: requestable,
                                                 hidden_field_metadata: { title: 'title', author: 'author', isbn: 'isbn' })
-      decorator = described_class.new(request, view)
+      decorator = described_class.new(request, view, '/catalog/123abc')
       expect(decorator.only_aeon?).to be_falsey
     end
   end
@@ -211,21 +205,21 @@ describe Requests::FormDecorator, requests: true do
     it "shows the library name" do
       request = instance_double(Requests::Form, system_id: '123abc', mfhd: '112233', ctx: solr_context, requestable: [], patron:, first_filtered_requestable: requestable,
                                                 hidden_field_metadata: { title: 'title', author: 'author', isbn: 'isbn' }, holdings: { '112233' => { "library" => 'abc' } })
-      decorator = described_class.new(request, view)
+      decorator = described_class.new(request, view, '/catalog/123abc')
       expect(decorator.location_label).to eq('abc')
     end
 
     it "shows the library name and location" do
       request = instance_double(Requests::Form, system_id: '123abc', mfhd: '112233', ctx: solr_context, requestable: [], patron:, first_filtered_requestable: requestable,
                                                 hidden_field_metadata: { title: 'title', author: 'author', isbn: 'isbn' }, holdings: { '112233' => { "library" => 'abc', "location" => "123" } })
-      decorator = described_class.new(request, view)
+      decorator = described_class.new(request, view, '/catalog/123abc')
       expect(decorator.location_label).to eq('abc - 123')
     end
 
     it "shows the nothing if the holding is empty" do
       request = instance_double(Requests::Form, system_id: '123abc', mfhd: '112233', ctx: solr_context, requestable: [], patron:, first_filtered_requestable: requestable,
                                                 hidden_field_metadata: { title: 'title', author: 'author', isbn: 'isbn' }, holdings: {})
-      decorator = described_class.new(request, view)
+      decorator = described_class.new(request, view, '/catalog/123abc')
       expect(decorator.location_label).to eq('')
     end
   end

--- a/spec/system/catalog_show_spec.rb
+++ b/spec/system/catalog_show_spec.rb
@@ -210,7 +210,7 @@ describe 'Viewing Catalog Documents', type: :system, js: true do
     context 'aeon holding with multiple items' do
       it 'links to the requests form so user can select the item they want' do
         visit("catalog/9930960283506421")
-        expect(page).to have_link('Reading Room Request', href: '/requests/9930960283506421?aeon=true&mfhd=22632199160006421')
+        expect(page).to have_link('Reading Room Request', href: '/requests/9930960283506421?aeon=true&mfhd=22632199160006421&open_holdings=Special+Collections+-+East+Asian+Library+Rare+Books')
       end
     end
   end

--- a/spec/views/requests/request/no_location_specified.html.erb_spec.rb
+++ b/spec/views/requests/request/no_location_specified.html.erb_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'requests/form/no_location_specified.html.erb', requests: true do
   it 'includes a link back to the record' do
-    assign(:system_id, '9922486553506421')
+    assign(:back_to_record_url, '/catalog/9922486553506421')
     render
     expect(rendered).to have_selector('a[href="/catalog/9922486553506421"]')
   end


### PR DESCRIPTION
Before this commit, when a user opened a holding group on the show page, pressed the Request button, then pressed the Return to Record button, the holding group was no longer open.

This commit adds a param to the requests form that allows this Return button to take the user back to the show page with the desired groups open.

Resolves #5062 