### PR TITLE
Update DOM to be data-temp-location-code="RES_SHARE$IN_RS_REQ" when

### DIFF
--- a/app/components/holdings/holding_availability_component.html.erb
+++ b/app/components/holdings/holding_availability_component.html.erb
@@ -1,7 +1,11 @@
 <td class="holding-status" data-availability-record="true"
   data-record-id="<%= doc_id %>" data-holding-id="<%= holding_id %>"
   <% if aeon_location? %>data-aeon="true"<% end %>
-  <% if temp_location_code %>data-temp-location-code="true"<% end %>
+  <% if temp_location_code == "RES_SHARE$IN_RS_REQ"%>
+     data-temp-location-code="RES_SHARE$IN_RS_REQ"
+  <% else %>
+     data-temp-location-code="true"
+  <% end %>
   >
   <span class="availability-icon"></span>
 </td>

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -201,7 +201,7 @@ export default class AvailabilityUpdater {
   process_single(holding_records) {
     this.update_single(holding_records, this.id);
     // Availability response in bibdata should be refactored not to include the host holdings under the mms_id of the record page.
-    // problematic availability response behaviour for constituent record page with host records.
+    // problematic availability response behavior for constituent record page with host records.
     // It treats host records as holdings of the constituent record. see: https://github.com/pulibrary/bibdata/issues/1739
     if (this.host_id.length > 0) {
       this.host_id.forEach((mms_id) => {

--- a/spec/components/holdings/holding_availability_component_spec.rb
+++ b/spec/components/holdings/holding_availability_component_spec.rb
@@ -25,4 +25,37 @@ RSpec.describe Holdings::HoldingAvailabilityComponent, type: :component do
     )
     expect(render_inline(holding_availability).css('td span').attribute('class').value).to include 'availability-icon'
   end
+
+  context "temp_location_code is RES_SHARE$IN_RS_REQ" do
+    it "renders data-temp-location-code RES_SHARE$IN_RS_REQ" do
+      holding_availability = described_class.new(
+        '994831543506421', # doc_id
+        '22549882290006421', # holding_id
+        {}, # location_rules
+        "RES_SHARE$IN_RS_REQ" # temp_location_code
+      )
+      expect(render_inline(holding_availability).css('td').length).to eq 1
+      expect(render_inline(holding_availability).css('td').attribute('class').value).to eq 'holding-status'
+      expect(render_inline(holding_availability).css('td').attribute('data-availability-record').value).to eq 'true'
+      expect(render_inline(holding_availability).css('td').attribute('data-record-id').value).to eq '994831543506421'
+      expect(render_inline(holding_availability).css('td').attribute('data-holding-id').value).to eq '22549882290006421'
+      expect(render_inline(holding_availability).css('td').attribute('data-temp-location-code').value).to eq 'RES_SHARE$IN_RS_REQ'
+    end
+  end
+  context "temp_location_code is not RES_SHARE$IN_RS_REQ" do
+    it "renders temp_location_code true" do
+      holding_availability = described_class.new(
+        '994831543506421', # doc_id
+        '22549882290006421', # holding_id
+        {}, # location_rules
+        "commons$stacks" # temp_location_code
+      )
+      expect(render_inline(holding_availability).css('td').length).to eq 1
+      expect(render_inline(holding_availability).css('td').attribute('class').value).to eq 'holding-status'
+      expect(render_inline(holding_availability).css('td').attribute('data-availability-record').value).to eq 'true'
+      expect(render_inline(holding_availability).css('td').attribute('data-record-id').value).to eq '994831543506421'
+      expect(render_inline(holding_availability).css('td').attribute('data-holding-id').value).to eq '22549882290006421'
+      expect(render_inline(holding_availability).css('td').attribute('data-temp-location-code').value).to eq 'true'
+    end
+  end
 end


### PR DESCRIPTION
temp_location_code = RES_SHARE$IN_RS_REQ

Fixes display of RES_SHARE$IN_RS_REQ in the show page

## Notes
The availability.es6 file expects to find an element that has [`data-temp-location-code="RES_SHARE$IN_RS_REQ"`](https://github.com/pulibrary/orangelight/pull/5088/files#diff-52fd92c77c489439dea19b902c8d599cc81400f8f6f8a9ee5fce2c5dd67a036cR153) when the holding has a 'temp_location_code' value.
The current code would build an element with data-temp-location-code="true".  The availability.es6 code would fail to find the expected element `data-temp-location-code="RES_SHARE$IN_RS_REQ" so the show page would not display a status for this location `RES_SHARE$IN_RS_REQ`.