### PR TITLE
Remove unused method end_of_list

### DIFF
--- a/app/services/holding_requests_adapter.rb
+++ b/app/services/holding_requests_adapter.rb
@@ -210,10 +210,4 @@ class HoldingRequestsAdapter
     return false if %w[thesis numismatics visuals].include? holding_id
     true
   end
-
-  # When the holding location code is invalid, the holding should appear last
-  # @return Integer
-  def end_of_list
-    999
-  end
 end


### PR DESCRIPTION
This was previously used by a method named `sorted_physical_holdings`, which no longer exists (replaced by `grouped_physical_holdings`)