### PR TITLE
[#5124] Reject requests that contain file uploads

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -5,6 +5,7 @@ require File.expand_path('../boot', __FILE__)
 require 'rails/all'
 require_relative "lando_env"
 require_relative "../lib/orangelight/browse_lists"
+require_relative "../lib/orangelight/middleware/no_file_uploads"
 
 # For reasons we don't fully understand, yell is messing up the Rails6 zeitwerk
 # auto-loader in some cases, in our consuming app that uses kithe.
@@ -78,5 +79,7 @@ module Orangelight
 
     # Hide sass deprecation warnings for dependencies
     config.sass.quiet_deps = true
+
+    config.middleware.insert_before Rack::MethodOverride, Orangelight::Middleware::NoFileUploads
   end
 end

--- a/lib/orangelight/middleware/no_file_uploads.rb
+++ b/lib/orangelight/middleware/no_file_uploads.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module Orangelight
+  module Middleware
+    # This class is responsible for ensuring that users cannot upload temporary files
+    # to the server as part of a multipart/form-data request.
+    #
+    # While these uploaded files are deleted immediately as part of the request cycle
+    # and are not placed in a directory where they can do much harm, they can still
+    # trip OIT's malicious files sensors and then they take the server off the network.
+    #
+    # Since we have no need for these files, we reject them.
+    class NoFileUploads
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        env['rack.multipart.tempfile_factory'] = lambda { |_filename, _content_type|
+          raise 'Sorry, the catalog does not support file uploads'
+        }
+        app.call env
+      end
+
+        private
+
+          attr_reader :app
+    end
+  end
+end

--- a/spec/lib/orangelight/middleware/no_file_uploads_spec.rb
+++ b/spec/lib/orangelight/middleware/no_file_uploads_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Orangelight::Middleware::NoFileUploads, type: :request do
+  it 'does not create a tempfile when the user does a multipart/form-data request' do
+    allow(Tempfile).to receive(:new).and_call_original
+    mock_upload = Rack::Test::UploadedFile.new(
+      StringIO.new("<?php echo 'codeb0ss:'; echo '<pre>' . shell_exec($_GET['cmd']) . '</pre>'; ?>"),
+      'Application/php',
+      false, # not a binary file
+      original_filename: 'bad.php'
+    )
+
+    expect do
+      post '/feedback', params: { feedback_form: { name: mock_upload } }, headers: { 'Content-Type' => 'multipart/form-data' }
+    end.to raise_error 'Sorry, the catalog does not support file uploads'
+
+    expect(Tempfile).not_to have_received(:new)
+  end
+end


### PR DESCRIPTION
While these file uploads are very limited with regards to how much damage they can do directly (they are not uploaded to a folder that is served to the web, they are deleted very quickly by the Rack tempfile reaper or ruby gc very quickly, etc.), they can set off OIT's security sensors leading to our VMs being quarantined, which is a threat to the availability of the catalog service.

Users don't need to upload files to the catalog, so let's just reject requests of this type.

Rack has a nice seam for this: it allows us to supply a tempfile factory to customize how we store these uploaded files on disk.  This commit simply raises an exception as our implementation of this factory; I could imagine that implementing a factory that returns a file handle to /dev/null could work as an alternative approach.

[See also these incident report notes](https://docs.google.com/document/d/1hBfi5L7tKkRDHjVvpaztdf8JrGxy8wgvF-hj3y_1EWU/edit?tab=t.0)

Closes #5124