### PR TITLE
Address deprecation warning for render_document_partials method

### DIFF
--- a/app/views/catalog/_show_main_content.html.erb
+++ b/app/views/catalog/_show_main_content.html.erb
@@ -3,7 +3,9 @@
 
 <div id="document" class="document <%= render_document_class %>" itemscope  itemtype="<%= @document.itemtype %>" data-location="<%= Array.wrap(@document["advanced_location_s"]) %>">
   <div id="doc_<%= @document.id.to_s.parameterize %>">
-    <%= render_document_partials @document, blacklight_config.view_config(:show).partials %>
+    <% blacklight_config.view_config(:show).partials.each do |partial| %>
+      <%= render_document_partial(@document, partial) %>
+    <% end %>
   </div>
 </div>
 


### PR DESCRIPTION
This method will be removed in Blacklight 9.  We should probably eventually move from these partials to our own interpretation of a `Blacklight::DocumentComponent` or something similar, but this at least gets us past the deprecation warning noise.