### PR TITLE
Add libcal script embed script to call number component.

### DIFF
--- a/app/views/catalog/_show_availability.html.erb
+++ b/app/views/catalog/_show_availability.html.erb
@@ -9,6 +9,12 @@
 
 <% unless physical.empty? %>
   <div class="availability--physical">
+    <script>
+      let libcalScript = document.createElement('script');
+      libcalScript.type = 'text/javascript';
+      libcalScript.src = 'https://libcal.princeton.edu/libmaps/blacklight';
+      document.head.appendChild(libcalScript);
+    </script>
     <h3><%= t('blacklight.holdings.print') %></h3>
       <%= physical %>
     </table>


### PR DESCRIPTION
Testing out the the new libmaps integration. In theory it will work when the call number exists in the system. Only a limited number of ranges are configured for Firestone A floor (C's and Ds) at the moment. 