### PR TITLE
Refactor: move numismatics-specific search building logic into the NumismaticsFormSearchBuilder

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -193,9 +193,7 @@ detectors:
     - Requests::Submissions::Recap#handle_item
     - SearchBuilder#add_edismax
     - SearchBuilder#advanced_search?
-    - SearchBuilder#facets_for_advanced_search_form
     - SearchBuilder#numismatics_advanced
-    - SearchBuilder#numismatics_facets
     - SearchBuilder#parslet_trick
     - SolrDocument#electronic_access_uris
     - SolrDocument#holdings_all_display
@@ -286,7 +284,6 @@ detectors:
     - Requests::Submission#selected_items
     - Requests::Submissions::HoldItem#payload
     - Requests::Submissions::Service#error_hash
-    - SearchBuilder#facets_for_advanced_search_form
     - SearchBuilder#numismatics_advanced
     - SolrDocument#electronic_access_uris
     - SolrDocument#holdings_with_host_id
@@ -519,7 +516,6 @@ detectors:
     - Blacklight::Document::Ris#export_as_ris
     - Blacklight::Marc::DocumentExtension#get_author_list
     - Requests::Location#build_delivery_locations
-    - SearchBuilder#facets_for_advanced_search_form
     - SolrDocument#identifiers
   NilCheck:
     exclude:
@@ -813,7 +809,6 @@ detectors:
     - ApplicationHelper#current_year
     - ApplicationHelper#format_render
     - ApplicationHelper#holding_location
-    - ApplicationHelper#holding_request_block
     - ApplicationHelper#html_safe
     - ApplicationHelper#location_full_display
     - ApplicationHelper#rails_env?

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -767,11 +767,7 @@ class CatalogController < ApplicationController
   end
 
   def numismatics
-    unless request.method == :post
-      @response = search_service.search_results do |search_builder|
-        search_builder.except(:add_advanced_search_to_solr).append(:facets_for_advanced_search_form)
-      end
-    end
+    @response = search_service.search_results
     respond_to do |format|
       format.html { render "advanced/numismatics" }
       format.json { render plain: "Format not supported", status: :bad_request }

--- a/app/models/numismatics_form_search_builder.rb
+++ b/app/models/numismatics_form_search_builder.rb
@@ -1,10 +1,29 @@
 # frozen_string_literal: true
 class NumismaticsFormSearchBuilder < SearchBuilder
-  self.default_processor_chain += %i[do_not_limit_configured_facets]
+  self.default_processor_chain += %i[fetch_configured_facets do_not_limit_configured_facets ensure_format_coin_is_the_only_fq]
+
+  def fetch_configured_facets(solr_params)
+    solr_params['facet.field'] = facet_config
+  end
 
   def do_not_limit_configured_facets(solr_params)
     # -1 means do not limit
-    limit_configuration = blacklight_config.numismatics_search[:facet_fields].to_h { |field| ["f.#{field}.facet.limit", '-1'] }
+    limit_configuration = facet_config.to_h { |field| ["f.#{field}.facet.limit", '-1'] }
     solr_params.merge! limit_configuration
   end
+
+  # :reek:UtilityFunction
+  def ensure_format_coin_is_the_only_fq(solr_params)
+    # We want a fq of format:Coin, so that we only fetch facet values relevant to numismatics
+    # We don't want any other fq, since those would restrict the facet values and counts displayed
+    # on the screen to only those relevant to the supplied fq, meaning that a user would not have
+    # the opportunity to broaden their search
+    solr_params[:fq] = ['format:Coin']
+  end
+
+  private
+
+    def facet_config
+      blacklight_config.numismatics_search[:facet_fields]
+    end
 end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -11,7 +11,7 @@ class SearchBuilder < Blacklight::SearchBuilder
                                      cjk_mm wildcard_char_strip
                                      only_home_facets prepare_left_anchor_search
                                      series_title_results pul_holdings html_facets
-                                     numismatics_facets numismatics_advanced
+                                     numismatics_advanced
                                      adjust_mm remove_unneeded_facets]
 
   # mutate the solr_parameters to remove words that are
@@ -35,23 +35,6 @@ class SearchBuilder < Blacklight::SearchBuilder
     return unless blacklight_params[:advanced_type] == 'numismatics'
     solr_parameters[:fq] ||= []
     solr_parameters[:fq] << "format:Coin"
-  end
-
-  def numismatics_facets(solr_parameters)
-    return unless blacklight_params[:action] == 'numismatics'
-    blacklight_config.advanced_search[:form_solr_parameters]['facet.field'] = blacklight_config.numismatics_search['facet_fields']
-    solr_parameters['facet.field'] = blacklight_config.numismatics_search['facet_fields']
-  end
-
-  def facets_for_advanced_search_form(solr_p)
-    # Reject any facets that are meant to display on the advanced
-    # search form, so that the form displays accurate counts for
-    # them in its dropdowns
-    advanced_search_facets = blacklight_config.advanced_search.form_solr_parameters['facet.field']
-    solr_p[:fq]&.compact!
-    solr_p[:fq]&.reject! do |facet_from_query|
-      advanced_search_facets.any? { |facet_to_exclude| facet_from_query.include? facet_to_exclude }
-    end
   end
 
   def only_home_facets(solr_parameters)

--- a/spec/models/numismatics_form_search_builder_spec.rb
+++ b/spec/models/numismatics_form_search_builder_spec.rb
@@ -4,28 +4,38 @@ require 'rails_helper'
 RSpec.describe NumismaticsFormSearchBuilder, advanced_search: true do
   subject(:builder) { described_class.new([], scope) }
 
-  let(:blacklight_config) { Blacklight::Configuration.new }
+  let(:blacklight_config) do
+    Blacklight::Configuration.new do |config|
+      config.numismatics_search ||= Blacklight::OpenStructWithHashAccess.new
+      config.numismatics_search[:facet_fields] ||= %w[issue_metal_s issue_city_s find_place_s]
+    end
+  end
   let(:scope) { Blacklight::SearchService.new config: blacklight_config, search_state: state }
   let(:state) { Blacklight::SearchState.new({}, blacklight_config) }
 
+  describe '#fetch_configured_facets' do
+    it 'sets the facet.field' do
+      solr_params = {}
+      builder.fetch_configured_facets(solr_params)
+      expect(solr_params['facet.field']).to eq %w[issue_metal_s issue_city_s find_place_s]
+    end
+  end
   describe '#do_not_limit_configured_facets' do
-    context 'when fields are configured' do
-      let(:blacklight_config) do
-        Blacklight::Configuration.new do |config|
-          config.numismatics_search ||= Blacklight::OpenStructWithHashAccess.new
-          config.numismatics_search[:facet_fields] ||= %w[issue_metal_s issue_city_s find_place_s]
-        end
-      end
-
-      it 'adds facet limits of -1 for all configured facet fields' do
-        solr_params = {}
-        builder.do_not_limit_configured_facets(solr_params)
-        expect(solr_params).to eq({
-                                    'f.issue_metal_s.facet.limit' => '-1',
-                                    'f.issue_city_s.facet.limit' => '-1',
-                                    'f.find_place_s.facet.limit' => '-1'
-                                  })
-      end
+    it 'adds facet limits of -1 for all configured facet fields' do
+      solr_params = {}
+      builder.do_not_limit_configured_facets(solr_params)
+      expect(solr_params).to eq({
+                                  'f.issue_metal_s.facet.limit' => '-1',
+                                  'f.issue_city_s.facet.limit' => '-1',
+                                  'f.find_place_s.facet.limit' => '-1'
+                                })
+    end
+  end
+  describe '#ensure_format_coin_is_the_only_fq' do
+    it 'sets removes all fq except format:Coin' do
+      solr_params = { fq: ['{!tag=pub_date_start_sort_single}pub_date_start_sort:[-91 TO 9999]', '{!term f=issue_metal_s}copper', 'format:Coin'] }
+      builder.ensure_format_coin_is_the_only_fq(solr_params)
+      expect(solr_params[:fq]).to eq ['format:Coin']
     end
   end
 end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -79,20 +79,6 @@ RSpec.describe SearchBuilder do
     end
   end
 
-  describe '#facets_for_advanced_search_form', advanced_search: true do
-    before do
-      blacklight_config.advanced_search.form_solr_parameters = { 'facet.field' => ["issue_denomination_s"] }
-    end
-
-    context 'with the built-in advanced search form', advanced_search: true do
-      it 'includes the advanced search facets' do
-        solr_p = { fq: ["{!lucene}{!query v=$f_inclusive.issue_denomination_s.0} OR {!query v=$f_inclusive.issue_denomination_s.1}", nil, "format:Coin"] }
-        search_builder.facets_for_advanced_search_form(solr_p)
-        expect(solr_p[:fq]).to eq(['format:Coin'])
-      end
-    end
-  end
-
   describe '#only_home_facets' do
     let(:blacklight_params) do
       { q: 'Douglas fir' }


### PR DESCRIPTION
Prior to this commit, this logic was in the general `SearchBuilder` class, but only used for the numismatics form.

This commit moves the logic to `NumismaticsFormSearchBuilder`, allowing us to simplify the numismatics action in the `CatalogController`, remove some Reek ignores, and make the general `SearchBuilder` class a bit smaller and more approachable.