### PR TITLE
Add a new field: Source language of translation, behind a feature flipper

### DIFF
--- a/app/components/orangelight/advanced_search_form_component.html.erb
+++ b/app/components/orangelight/advanced_search_form_component.html.erb
@@ -35,12 +35,14 @@
             </div>
           </div>
         <% end %>
-        <div class="mb-3 advanced-search-facet row">
-          <%= label_tag pub_date_field.parameterize, :class => "col-sm-4 control-label advanced-facet-label" do %>Publication year<% end %>
-          <div class="col-sm-8">
-            <%= render RangeFormComponent.new(facet_field: pub_date_presenter) %>
+        <% if pub_date_field -%>
+          <div class="mb-3 advanced-search-facet row">
+            <%= label_tag pub_date_field.parameterize, :class => "col-sm-4 control-label advanced-facet-label" do %>Publication year<% end %>
+            <div class="col-sm-8">
+              <%= render RangeFormComponent.new(facet_field: pub_date_presenter) %>
+            </div>
           </div>
-        </div>
+        <% end -%>
       </div>
       <%# End Column 2 %>
   </div>

--- a/app/components/orangelight/advanced_search_form_component.rb
+++ b/app/components/orangelight/advanced_search_form_component.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class Orangelight::AdvancedSearchFormComponent < Blacklight::AdvancedSearchFormComponent
+  # :reek:FeatureEnvy
   def initialize_search_filter_controls
-    fields = blacklight_config.facet_fields.select { |_k, v| v.include_in_advanced_search }
+    blacklight_config.facet_fields.each do |_key, config|
+      next unless config.include_in_advanced_search_if&.call || config.include_in_advanced_search
 
-    fields.each do |_k, config|
       config.advanced_search_component = Orangelight::FacetFieldCheckboxesComponent
       display_facet = @response.aggregations[config.field]
       with_search_filter_control(config:, display_facet:)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -39,7 +39,7 @@ class CatalogController < ApplicationController
     config.advanced_search[:url_key] ||= 'advanced'
     config.advanced_search[:query_parser] ||= 'edismax'
     config.advanced_search[:form_solr_parameters] ||= {}
-    config.advanced_search[:form_solr_parameters]['facet.field'] ||= %w[access_facet format publication_place_hierarchical_facet language_facet advanced_location_s]
+    config.advanced_search[:form_solr_parameters]['facet.field'] ||= %w[access_facet format publication_place_hierarchical_facet language_facet original_language_of_translation_facet advanced_location_s]
     config.advanced_search[:form_solr_parameters]['facet.query'] ||= ''
     config.advanced_search[:form_solr_parameters]['facet.limit'] ||= -1
     config.advanced_search[:form_solr_parameters]['facet.pivot'] ||= ''
@@ -141,6 +141,7 @@ class CatalogController < ApplicationController
       show_missing_link: false
     }
     config.add_facet_field 'language_facet', label: 'Language', limit: true, include_in_advanced_search: true, suggest: true
+    config.add_facet_field 'original_language_of_translation_facet', label: 'Source language of translation', show: false, include_in_advanced_search_if: -> { Flipflop.source_language_of_translation? }
     config.add_facet_field 'subject_topic_facet', label: 'Subject: Topic', limit: true, include_in_advanced_search: false, suggest: true
     config.add_facet_field 'genre_facet', label: 'Subject: Genre', limit: true, include_in_advanced_search: false
     config.add_facet_field 'subject_era_facet', label: 'Subject: Era', limit: true, include_in_advanced_search: false
@@ -166,7 +167,6 @@ class CatalogController < ApplicationController
     config.add_facet_field 'lc_1letter_facet', label: 'Classification', limit: 25, include_in_request: false, sort: 'index'
     config.add_facet_field 'lc_rest_facet', label: 'Full call number code', limit: 25, include_in_request: false, sort: 'index'
     config.add_facet_field 'sudoc_facet', label: 'SuDocs', limit: true, sort: 'index', include_in_advanced_search: false
-    config.add_facet_field 'original_language_of_translation_facet', label: 'Original language of translation', show: false
 
     # The following facet configurations are purely for display purposes. They
     # will not show up in the facet bar, but without them the labels and other

--- a/config/features.rb
+++ b/config/features.rb
@@ -48,4 +48,8 @@ Flipflop.configure do
   feature :blacklight_hierarchy_publication_facet,
   default: true,
   description: "When on / true, use the colon delimited field to display the place of publication facet, when off / false use the pipe delimited field"
+
+  feature :source_language_of_translation,
+  default: false,
+  description: 'When on / true, show the Source Language of Translations dropdown on the advanced search page.  We need a full re-index before turning it on.'
 end

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -536,6 +536,7 @@
    <field name="homoit_subject_facet" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="local_subject_facet" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="siku_subject_facet" type="string" indexed="true" stored="true" multiValued="true" />
+   <field name="original_language_of_translation_facet" type="string" indexed="true" stored="true" multiValued="true" />
    <field name="author_int" type="author" indexed="true" stored="false" multiValued="true"/>
    <field name="title_sort" type="alphaNumSort" indexed="true" stored="false" />
     <!-- pub_date sort uses new trie-based int fields, which are recommended for any int and are displayable, sortable, and range-quer

--- a/spec/components/orangelight/advanced_search_form_component_spec.rb
+++ b/spec/components/orangelight/advanced_search_form_component_spec.rb
@@ -48,4 +48,36 @@ RSpec.describe Orangelight::AdvancedSearchFormComponent, type: :component, advan
       expect(rendered).to have_field 'f[subject_topic_facet][]', type: :hidden, with: 'Manuscripts, Arabic'
     end
   end
+
+  context 'when a facet field has an include_in_advanced_search_if lambda that returns false' do
+    before do
+      allow(view_context).to receive(:blacklight_config).and_return(
+        Blacklight::Configuration.new do |config|
+          config.add_facet_field 'format', label: 'Format', include_in_advanced_search_if: -> { false }
+        end
+      )
+    end
+    let(:response) do
+      Blacklight::Solr::Response.new({ facet_counts: { facet_fields: { format: { 'Book' => 10, 'CD' => 5 } } } }.with_indifferent_access, {})
+    end
+    it 'does not include the facet field in the UI' do
+      expect(rendered).not_to have_selector 'multiselect-combobox[field-name="format"]'
+    end
+  end
+
+  context 'when a facet field has an include_in_advanced_search_if lambda that returns true' do
+    before do
+      allow(view_context).to receive(:blacklight_config).and_return(
+        Blacklight::Configuration.new do |config|
+          config.add_facet_field 'format', label: 'Format', include_in_advanced_search_if: -> { true }
+        end
+      )
+    end
+    let(:response) do
+      Blacklight::Solr::Response.new({ facet_counts: { facet_fields: { format: { 'Book' => 10, 'CD' => 5 } } } }.with_indifferent_access, {})
+    end
+    it 'includes the facet field in the UI' do
+      expect(rendered).to have_selector 'multiselect-combobox[field-name="format"]'
+    end
+  end
 end


### PR DESCRIPTION
This field displays as a dropdown on the advanced search form. It only displays if you have enabled the relevant
FlipFlop feature -- we will not want to do this in production until we have done a full reindex.

If you want to try this locally, you will need to first run: `bundle exec rake cache:clear`.

Advances #4634 