### PR TITLE
Source language of translation: show all on the advanced search screen

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -43,13 +43,9 @@ class CatalogController < ApplicationController
     config.advanced_search[:form_solr_parameters]['facet.query'] ||= ''
     config.advanced_search[:form_solr_parameters]['facet.limit'] ||= -1
     config.advanced_search[:form_solr_parameters]['facet.pivot'] ||= ''
-    config.advanced_search[:form_solr_parameters]['f.language_facet.facet.limit'] ||= -1
     config.advanced_search[:form_solr_parameters]['f.language_facet.facet.sort'] ||= 'index'
     # TODO: Remove non-pipe options after re-index with pipe delimiter
-    config.advanced_search[:form_solr_parameters]['f.publication_place_hierarchical_facet.facet.limit'] ||= -1
     config.advanced_search[:form_solr_parameters]['f.publication_place_hierarchical_facet.facet.sort'] ||= 'index'
-
-    config.advanced_search[:form_solr_parameters]['f.publication_place_hierarchical_pipe_facet.facet.limit'] ||= -1
     config.advanced_search[:form_solr_parameters]['f.publication_place_hierarchical_pipe_facet.facet.sort'] ||= 'index'
 
     config.numismatics_search ||= Blacklight::OpenStructWithHashAccess.new

--- a/app/models/advanced_form_search_builder.rb
+++ b/app/models/advanced_form_search_builder.rb
@@ -2,7 +2,7 @@
 # This class is responsible for building a solr query
 # that renders an advanced search form
 class AdvancedFormSearchBuilder < SearchBuilder
-  self.default_processor_chain += %i[use_advanced_configuration only_request_advanced_facets no_documents]
+  self.default_processor_chain += %i[use_advanced_configuration only_request_advanced_facets no_documents do_not_limit_configured_facets]
 
   def use_advanced_configuration(solr_params)
     solr_params.update(solr_params) do |key, value|
@@ -15,7 +15,7 @@ class AdvancedFormSearchBuilder < SearchBuilder
 
   # :reek:FeatureEnvy
   def only_request_advanced_facets(solr_params)
-    solr_params['facet.field'] = blacklight_config.advanced_search[:form_solr_parameters]["facet.field"]
+    solr_params['facet.field'] = facet_fields
     %w[facet.pivot facet.query stats stats.field].each { |unneeded_field| solr_params.delete unneeded_field }
   end
 
@@ -23,4 +23,16 @@ class AdvancedFormSearchBuilder < SearchBuilder
   def no_documents(solr_params)
     solr_params['rows'] = 0
   end
+
+  def do_not_limit_configured_facets(solr_params)
+    # -1 means do not limit
+    limit_configuration = facet_fields.to_h { |field| ["f.#{field}.facet.limit", '-1'] }
+    solr_params.merge! limit_configuration
+  end
+
+  private
+
+    def facet_fields
+      blacklight_config.advanced_search[:form_solr_parameters]['facet.field']
+    end
 end

--- a/spec/models/advanced_form_search_builder_spec.rb
+++ b/spec/models/advanced_form_search_builder_spec.rb
@@ -86,4 +86,24 @@ RSpec.describe AdvancedFormSearchBuilder, advanced_search: true do
       expect(solr_params).to eq({ "rows" => 0 })
     end
   end
+
+  describe '#do_not_limit_configured_facets' do
+    let(:blacklight_config) do
+      Blacklight::Configuration.new do |config|
+        config.advanced_search[:form_solr_parameters] ||= {}
+        config.advanced_search.form_solr_parameters['facet.field'] = %w[access_facet format publication_place_facet language_facet advanced_location_s]
+      end
+    end
+    it 'adds facet limits of -1 for all configured facet fields' do
+      solr_params = {}
+      builder.do_not_limit_configured_facets(solr_params)
+      expect(solr_params).to eq({
+                                  'f.access_facet.facet.limit' => '-1',
+                                  'f.format.facet.limit' => '-1',
+                                  'f.publication_place_facet.facet.limit' => '-1',
+                                  'f.language_facet.facet.limit' => '-1',
+                                  'f.advanced_location_s.facet.limit' => '-1'
+                                })
+    end
+  end
 end


### PR DESCRIPTION
Prior to this commit, only the 10 most popular source languages displayed on the advanced search form.

This commit makes this more general: any facet field configured to display on the advanced search screen will not limit its values.

Helps with #4634 