### PR TITLE
Adjust spacing for advanced search facets

### DIFF
--- a/app/assets/stylesheets/components/search--advanced.scss
+++ b/app/assets/stylesheets/components/search--advanced.scss
@@ -126,7 +126,7 @@
     display: inline;
     position: absolute;
     right: 5px;
-    top: .8em;
+    top: calc(50% - .6rem);
   }
 }
 

--- a/app/javascript/orangelight/vue_components/multiselect_combobox.vue
+++ b/app/javascript/orangelight/vue_components/multiselect_combobox.vue
@@ -270,4 +270,12 @@ inputModel.value = inputValue.value;
   margin: 0px;
   transform: translate(0px, 42px);
 }
+
+.advanced-search-facet {
+  min-height: 3rem;
+
+  .combobox-multiselect {
+    align-self: center;
+  }
+}
 </style>


### PR DESCRIPTION
This makes the spacing less uneven when facet labels are a mix of one-line labels and two-line labels.

Helps with #4634 

Before:

There is no space between the first few facets, then more space between "source language", "place of publication", and "Holding location"

<img width="563" height="424" alt="facets on the advanced search page as described above" src="https://github.com/user-attachments/assets/822098f1-6ba3-468e-86ff-421fa6376d54" />


After:

The spacing is more even between facets:
<img width="535" height="445" alt="improved display of facets on the advanced search page as described above" src="https://github.com/user-attachments/assets/208a3ef8-c67f-4525-8577-4c2a7b12d509" />

