### PR TITLE
Only in the search results, display specific label for in library use locations

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -61,6 +61,7 @@ detectors:
   DuplicateMethodCall:
     exclude:
     - Holdings::OnlineHoldingsComponent#marc_links
+    - Holdings::SearchLocationComponent#library_in_use
     - NumismaticsSearchFormComponent#initialize_constraints
     - Orangelight::AdvancedSearchFormComponent#fields_for_etc
     - Orangelight::ConstraintComponent#constraint_value
@@ -221,6 +222,7 @@ detectors:
     - StackmapService::Url#url
   FeatureEnvy:
     exclude:
+    - Holdings::SearchLocationComponent#library_in_use
     - Orangelight::ConstraintsComponent#guided_search_value
     - Orangelight::FacetFieldCheckboxesComponent#values
     - Orangelight::ProcessVocabularyComponent#fast_subjects_value?
@@ -745,7 +747,6 @@ detectors:
     - Orangelight::LinkToFacetProcessor#link
   UncommunicativeVariableName:
     exclude:
-    - Orangelight::AdvancedSearchFormComponent#initialize_search_filter_controls
     - Orangelight::ConstraintsComponent#remove_guided_query_path
     - Orangelight::ProcessVocabularyComponent#build_search_subject_links
     - BookmarksController#csv_bom

--- a/.reek.yml
+++ b/.reek.yml
@@ -61,7 +61,6 @@ detectors:
   DuplicateMethodCall:
     exclude:
     - Holdings::OnlineHoldingsComponent#marc_links
-    - Holdings::SearchLocationComponent#library_in_use
     - NumismaticsSearchFormComponent#initialize_constraints
     - Orangelight::AdvancedSearchFormComponent#fields_for_etc
     - Orangelight::ConstraintComponent#constraint_value
@@ -222,7 +221,6 @@ detectors:
     - StackmapService::Url#url
   FeatureEnvy:
     exclude:
-    - Holdings::SearchLocationComponent#library_in_use
     - Orangelight::ConstraintsComponent#guided_search_value
     - Orangelight::FacetFieldCheckboxesComponent#values
     - Orangelight::ProcessVocabularyComponent#fast_subjects_value?
@@ -747,6 +745,7 @@ detectors:
     - Orangelight::LinkToFacetProcessor#link
   UncommunicativeVariableName:
     exclude:
+    - Orangelight::AdvancedSearchFormComponent#initialize_search_filter_controls
     - Orangelight::ConstraintsComponent#remove_guided_query_path
     - Orangelight::ProcessVocabularyComponent#build_search_subject_links
     - BookmarksController#csv_bom

--- a/app/components/holdings/search_location_component.rb
+++ b/app/components/holdings/search_location_component.rb
@@ -28,7 +28,7 @@ class Holdings::SearchLocationComponent < ViewComponent::Base
           'mendel$pk': "Mendel (Remote Storage)",
           'stokes$pm': "Stokes (Remote Storage)"
         }.freeze
-        library_in_use_locations[location_code.to_sym] if library_in_use_locations.key?(location_code.to_sym)
+        library_in_use_locations[location_code.to_sym]
       end
 
       def call_number

--- a/app/components/holdings/search_location_component.rb
+++ b/app/components/holdings/search_location_component.rb
@@ -8,13 +8,30 @@ class Holdings::SearchLocationComponent < ViewComponent::Base
 
     private
 
+      attr_reader :holding_hash
+
       def location
+        return library_in_use if library_in_use
         helpers.holding_library_label(holding_hash)
+      end
+
+      def library_in_use
+        location_code = holding_hash['location_code']
+        library_in_use_locations = {
+          'arch$pw': "Archictecture (Remote Storage)",
+          'eastasian$pl': "East Asian (Remote Storage)",
+          'engineer$pt': "Engineering (Remote Storage)",
+          'firestone$pb': "Firestone (Remote Storage)",
+          'firestone$pf': "Firestone (Remote Storage)",
+          'lewis$pn': "Lewis (Remote Storage)",
+          'lewis$ps': "Lewis (Remote Storage)",
+          'mendel$pk': "Mendel (Remote Storage)",
+          'stokes$pm': "Stokes (Remote Storage)"
+        }.freeze
+        library_in_use_locations[location_code.to_sym] if library_in_use_locations.key?(location_code.to_sym)
       end
 
       def call_number
         CallNumber.new(holding_hash['call_number']).with_line_break_suggestions
       end
-
-      attr_reader :holding_hash
 end

--- a/app/components/holdings/search_location_component.rb
+++ b/app/components/holdings/search_location_component.rb
@@ -28,7 +28,7 @@ class Holdings::SearchLocationComponent < ViewComponent::Base
           'mendel$pk': "Mendel (Remote Storage)",
           'stokes$pm': "Stokes (Remote Storage)"
         }.freeze
-        library_in_use_locations[location_code.to_sym]
+        library_in_use_locations[location_code&.to_sym]
       end
 
       def call_number

--- a/spec/components/holdings/search_location_component_spec.rb
+++ b/spec/components/holdings/search_location_component_spec.rb
@@ -37,4 +37,10 @@ RSpec.describe Holdings::SearchLocationComponent, type: :component do
     expect(rendered.css('.results_location').length).to eq 1
     expect(rendered.css('.call-number').length).to eq 1
   end
+
+  it "renders the in library use label when the location code is for library in use" do
+    holding_hash['location_code'] = 'firestone$pf'
+    rendered = render_inline(described_class.new(holding_hash))
+    expect(rendered.css('.results_location').text).to include("Firestone (Remote Storage)")
+  end
 end

--- a/spec/components/holdings/search_location_component_spec.rb
+++ b/spec/components/holdings/search_location_component_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe Holdings::SearchLocationComponent, type: :component do
   let(:holding_hash) do
     {
       "call_number" => "QA76.73.R83",
-      "library" => "firestone"
+      "library" => "firestone",
+      "location_code" => "firestone$stacks"
     }
   end
 


### PR DESCRIPTION
Only in the search results, display specific label for in library use locations.

'arch$pw': "Archictecture (Remote Storage)",
'eastasian$pl': "East Asian (Remote Storage)",
'engineer$pt': "Engineering (Remote Storage)",
'firestone$pb': "Firestone (Remote Storage)",
'firestone$pf': "Firestone (Remote Storage)",
'lewis$pn': "Lewis (Remote Storage)",
'lewis$ps': "Lewis (Remote Storage)",
'mendel$pk': "Mendel (Remote Storage)",
'stokes$pm': "Stokes (Remote Storage)"

part of #5167

I also need to change the javascript . Will do in a second PR