### PR TITLE
[#5143] Use access restriction note as Aeon ItemInfo1 if available

### DIFF
--- a/app/models/concerns/requests/aeon.rb
+++ b/app/models/concerns/requests/aeon.rb
@@ -26,7 +26,7 @@ module Requests
         Site: site,
         Location: shelf_location_code,
         SubLocation: sub_location,
-        ItemInfo1: I18n.t("requests.aeon.access_statement")
+        ItemInfo1: bib[:access_restrictions_note_display]&.first || I18n.t("requests.aeon.access_statement")
       }.compact
     end
 

--- a/app/models/requests/aeon_url.rb
+++ b/app/models/requests/aeon_url.rb
@@ -47,7 +47,7 @@ module Requests
           Site: site,
           Location: shelf_location_code,
           SubLocation: sub_location,
-          ItemInfo1: I18n.t("requests.aeon.access_statement"),
+          ItemInfo1: document['access_restrictions_note_display']&.first || I18n.t("requests.aeon.access_statement"),
           ItemNumber: item&.barcode,
           'rft.aucorp': document['pub_citation_display']&.first
         }.compact

--- a/spec/fixtures/alma/9947247893506421.json
+++ b/spec/fixtures/alma/9947247893506421.json
@@ -1,0 +1,232 @@
+{
+    "id": [
+        "9947247893506421"
+    ],
+    "numeric_id_b": [
+        true
+    ],
+    "cjk_all": [
+        ""
+    ],
+    "cjk_notes": [
+        ""
+    ],
+    "author_display": [
+        "Collins, B. (Benjamin), 1715-1785"
+    ],
+    "author_sort": [
+        "Collins, B. (Benjamin), 1715-1785"
+    ],
+    "author_citation_display": [
+        "Collins, B."
+    ],
+    "author_roles_1display": [
+        "{\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[],\"primary_author\":\"Collins, B.\"}"
+    ],
+    "author_s": [
+        "Collins, B. (Benjamin), 1715-1785"
+    ],
+    "marc_relator_display": [
+        "Author"
+    ],
+    "title_display": [
+        "Directions for playing with a set of squares, newly invented for the use of children ... upon the plan of Mr.Locke."
+    ],
+    "title_a_index": [
+        "Directions for playing with a set of squares, newly invented for the use of children ... upon the plan of Mr.Locke"
+    ],
+    "title_sort": [
+        "Directions for playing with a set of squares, newly invented for the use of children ... upon the plan of Mr.Locke."
+    ],
+    "title_no_h_index": [
+        "Directions for playing with a set of squares, newly invented for the use of children ... upon the plan of Mr.Locke."
+    ],
+    "title_t": [
+        "Directions for playing with a set of squares, newly invented for the use of children ... upon the plan of Mr.Locke."
+    ],
+    "title_citation_display": [
+        "Directions for playing with a set of squares, newly invented for the use of children ... upon the plan of Mr.Locke"
+    ],
+    "compiled_created_t": [
+        "Directions for playing with a set of squares, newly invented for the use of children ... upon the plan of Mr.Locke."
+    ],
+    "edition_display": [
+        "7th ed."
+    ],
+    "pub_created_display": [
+        "London. J. Newbery, at the Bible and Sun ... and. ; B. Collins, in Salisbury [between June. 1743 and March. ; 1744]."
+    ],
+    "pub_created_s": [
+        "London. J. Newbery, at the Bible and Sun ... and. ; B. Collins, in Salisbury [between June. 1743 and March. ; 1744]."
+    ],
+    "pub_citation_display": [
+        "London: B. Collins, in Salisbury [between June"
+    ],
+    "publication_location_citation_display": [
+        "London"
+    ],
+    "publisher_citation_display": [
+        "J. Newbery, at the Bible and Sun ... and"
+    ],
+    "pub_date_display": [
+        "1743"
+    ],
+    "pub_date_start_sort": [
+        "1743"
+    ],
+    "publication_date_citation_display": [
+        "1743"
+    ],
+    "cataloged_tdt": [
+        "2021-07-13T05:09:32Z"
+    ],
+    "format": [
+        "Book"
+    ],
+    "description_display": [
+        "32 p. 6 cm. + 24 ill. cards 5.1 x 6 cm."
+    ],
+    "description_t": [
+        "32 p. 6 cm. + 24 ill. cards 5.1 x 6 cm."
+    ],
+    "number_of_pages_citation_display": [
+        "32 p."
+    ],
+    "notes_index": [
+        "Princeton copy 1 For conservation reasons, access is granted for compelling reasons only: please consult the curator of the Cotsen Children's Library. NjP",
+        "The simplest games, where children shuffle and deal cards and spell words, can be played with the 24 alphabet cards (present here). The more advanced games require the use of 26 cards consisting of an italic alphabet with moral sentences (not present here). The set could also include 6 additional vowel cards and rules for spelling (not present here) The suggestion is also made that as additional incentive a \"Paper of Plumbs\" be played for. ... \" -- Sotheby's description.",
+        "DIRECTIONS: collation by signature: demy 64o (60x 50 mm). A-B8 (A1r title, A1v blank, A2r Intro, B2r Directions for playing, B8r Advertisement. To this 7th edition the author has added six squares). 16 ll. Roman type 55 mm. 19 lines. (A few page-numerals and catchwords shaved, slight spotting.",
+        "Cards: Laid paper mounted on thin card and divided into 24 squares. Each card with a lower and upper case letter (aA-zZ omitting jJ and vV), an Arabic numeral (1-24) at the bottom and a framed woodcut illustration in the centre, all printed in black; above each cut one line from an alphabet rhyme, incipit: \"A was an Admiral over the Main\", ending: \"Z was a Zealot, and full of Devotion\", printed in red. (Lacking 32 squares; cards 9 and 23 bent in half and now backed with modern paper, lower edge of cards 16 and 21 ink-stained, corners rounded, some soiling, but the set in fine condition.).",
+        "A UNIQUE SURVIVAL recently brought to light in a small New England town -- from the incunable period of English children's literature. It is probably the first game of entertainment printed specially for very small children and JOHN NEWBERY'S EARLIEST PUBLICATION FOR CHILDREN. The game has hitherto been known only from the 1\\21st March 1744 of the\"Penny London orning Advertiser\", where \"A Sett of Fifty-six Squares\" printed for J. Newbery is advertised at one shilling. Christine Ferdinand, Fellow Librarian of Magdalen College, Oxford, who is currently preparing a study of the career and output of Benjamin Collins, has kindly searched for us the pages of the \"Salisbury Journal\", which was owned by Collins, and found in its 28th June 1843 issue and advertisement for a 50-square versison of the same game printed for J. Robinson in London and sold by B. Collins in Salisbury.",
+        "This important discovery not only dates the 7th edition (the first with 56 squares) to within nine months before March 1744, but also redefines the relative contributions of the two entrepreneurs, Collins and Newbery, to their joint publications for children. In the June 1744 and all later editions of his celebrated \"A Little Pretty Pocket-Book\" Newbery so effectively publicized the game of Squares under the heading \"The great Q play\" that until now all sets had disappeared without a trace.",
+        "It now appears that the game was originally Benjamin Collins's conception. This is perhaps not surprising, because two years later Collins was able to claim that other instrument of learning and play, the battledore, as \"my own invention\".",
+        "Finally, with the surfacing of this group of cards together with its miniature book of rules, the nature and appearance of the game are now establlished. The primary purpose of the Squares is to teach infants to read by the Lockean principle of \"cozening children into a knowledge of the letters' by making leaarning a \"sort of play or recreation\". This principle ... is here realised by providing parents -- to whom the \"Directions\" are addressed -- with a game somewhat akin to Scrabble.",
+        "cont mrbld wraps;",
+        "BIBDATA.LEVEL: Volume 3 -- Ready."
+    ],
+    "restrictions_note_display": [
+        "Princeton copy 1 For conservation reasons, access is granted for compelling reasons only: please consult the curator of the Cotsen Children's Library."
+    ],
+    "notes_display": [
+        "The simplest games, where children shuffle and deal cards and spell words, can be played with the 24 alphabet cards (present here). The more advanced games require the use of 26 cards consisting of an italic alphabet with moral sentences (not present here). The set could also include 6 additional vowel cards and rules for spelling (not present here) The suggestion is also made that as additional incentive a \"Paper of Plumbs\" be played for. ... \" -- Sotheby's description.",
+        "DIRECTIONS: collation by signature: demy 64o (60x 50 mm). A-B8 (A1r title, A1v blank, A2r Intro, B2r Directions for playing, B8r Advertisement. To this 7th edition the author has added six squares). 16 ll. Roman type 55 mm. 19 lines. (A few page-numerals and catchwords shaved, slight spotting.",
+        "Cards: Laid paper mounted on thin card and divided into 24 squares. Each card with a lower and upper case letter (aA-zZ omitting jJ and vV), an Arabic numeral (1-24) at the bottom and a framed woodcut illustration in the centre, all printed in black; above each cut one line from an alphabet rhyme, incipit: \"A was an Admiral over the Main\", ending: \"Z was a Zealot, and full of Devotion\", printed in red. (Lacking 32 squares; cards 9 and 23 bent in half and now backed with modern paper, lower edge of cards 16 and 21 ink-stained, corners rounded, some soiling, but the set in fine condition.).",
+        "A UNIQUE SURVIVAL recently brought to light in a small New England town -- from the incunable period of English children's literature. It is probably the first game of entertainment printed specially for very small children and JOHN NEWBERY'S EARLIEST PUBLICATION FOR CHILDREN. The game has hitherto been known only from the 1\\21st March 1744 of the\"Penny London orning Advertiser\", where \"A Sett of Fifty-six Squares\" printed for J. Newbery is advertised at one shilling. Christine Ferdinand, Fellow Librarian of Magdalen College, Oxford, who is currently preparing a study of the career and output of Benjamin Collins, has kindly searched for us the pages of the \"Salisbury Journal\", which was owned by Collins, and found in its 28th June 1843 issue and advertisement for a 50-square versison of the same game printed for J. Robinson in London and sold by B. Collins in Salisbury.",
+        "This important discovery not only dates the 7th edition (the first with 56 squares) to within nine months before March 1744, but also redefines the relative contributions of the two entrepreneurs, Collins and Newbery, to their joint publications for children. In the June 1744 and all later editions of his celebrated \"A Little Pretty Pocket-Book\" Newbery so effectively publicized the game of Squares under the heading \"The great Q play\" that until now all sets had disappeared without a trace.",
+        "It now appears that the game was originally Benjamin Collins's conception. This is perhaps not surprising, because two years later Collins was able to claim that other instrument of learning and play, the battledore, as \"my own invention\".",
+        "Finally, with the surfacing of this group of cards together with its miniature book of rules, the nature and appearance of the game are now establlished. The primary purpose of the Squares is to teach infants to read by the Lockean principle of \"cozening children into a knowledge of the letters' by making leaarning a \"sort of play or recreation\". This principle ... is here realised by providing parents -- to whom the \"Directions\" are addressed -- with a game somewhat akin to Scrabble."
+    ],
+    "binding_note_display": [
+        "cont mrbld wraps;"
+    ],
+    "language_name_display": [
+        "English"
+    ],
+    "language_facet": [
+        "English"
+    ],
+    "publication_place_facet": [
+        "England"
+    ],
+    "language_iana_s": [
+        "en"
+    ],
+    "mult_languages_iana_s": [
+        "en"
+    ],
+    "lc_subject_display": [
+        "Miniature books—Specimens",
+        "Alphabets"
+    ],
+    "lc_subject_include_archaic_search_terms_index": [
+        "Miniature books—Specimens",
+        "Alphabets"
+    ],
+    "subject_unstem_search": [
+        "Miniature books—Specimens",
+        "Alphabets"
+    ],
+    "local_subject_unstem_search": null,
+    "siku_subject_unstem_search": null,
+    "homoit_subject_unstem_search": null,
+    "fast_subject_unstem_search": null,
+    "subject_facet": [
+        "Miniature books—Specimens",
+        "Alphabets"
+    ],
+    "lc_subject_facet": [
+        "Miniature books",
+        "Miniature books—Specimens",
+        "Alphabets"
+    ],
+    "publication_place_hierarchical_pipe_facet": [
+        "United Kingdom",
+        "United Kingdom|||England"
+    ],
+    "publication_place_hierarchical_facet": [
+        "United Kingdom",
+        "United Kingdom:England"
+    ],
+    "subject_topic_facet": [
+        "Miniature books",
+        "Alphabets"
+    ],
+    "genre_facet": [
+        "Specimens"
+    ],
+    "other_title_index": [
+        "Set of squares"
+    ],
+    "other_title_display": [
+        "Set of squares"
+    ],
+    "alt_title_246_display": [
+        "Set of squares"
+    ],
+    "oclc_s": [
+        "177780344"
+    ],
+    "standard_no_index": [
+        "177780344",
+        "16451",
+        "69074",
+        "4724789-princetondb"
+    ],
+    "other_version_s": [
+        "ocn177780344"
+    ],
+    "holdings_1display": [
+        "{\"22630042340006421\":{\"location_code\":\"rare$ctsn\",\"location\":\"Cotsen Children's Library\",\"library\":\"Special Collections\",\"call_number\":\"16451 Eng 18Q\",\"call_number_browse\":\"16451 Eng 18Q\",\"sub_location\":[\"Eng 18Q\"],\"location_has\":[\"Princeton copy 1\"],\"supplements\":[null],\"indexes\":[null]}}"
+    ],
+    "access_restrictions_note_display": [
+        "For conservation reasons, access is granted for compelling reasons only: please consult the curator of the Cotsen Children's Library."
+    ],
+    "location_code_s": [
+        "rare$ctsn"
+    ],
+    "location": [
+        "Special Collections"
+    ],
+    "location_display": [
+        "Cotsen Children's Library"
+    ],
+    "advanced_location_s": [
+        "rare$ctsn",
+        "Special Collections"
+    ],
+    "name_title_browse_s": [
+        "Collins, B. (Benjamin), 1715-1785. Directions for playing with a set of squares, newly invented for the use of children ... upon the plan of Mr.Locke"
+    ],
+    "call_number_display": [
+        "Eng 18Q 16451"
+    ],
+    "call_number_browse_s": [
+        "16451 Eng 18Q"
+    ],
+    "call_number_locator_display": [
+        "16451"
+    ],
+    "access_facet": [
+        "In the Library"
+    ]
+}

--- a/spec/models/concerns/requests/aeon_spec.rb
+++ b/spec/models/concerns/requests/aeon_spec.rb
@@ -12,6 +12,12 @@ class ObjectWithAeon
   end
 end
 
+class ObjectWithAeonAndAccessRestrictions < ObjectWithAeon
+  def bib
+    { id: 1234, access_restrictions_note_display: ["For conservation reasons, access is granted for compelling reasons only."] }
+  end
+end
+
 describe Requests::Aeon, requests: true do
   subject { ObjectWithAeon.new }
   let(:location) do
@@ -27,6 +33,17 @@ describe Requests::Aeon, requests: true do
 
     it 'takes its SubLocation from the holdings_1display' do
       expect(subject.aeon_basic_params[:SubLocation]).to eq('Euro 20Q')
+    end
+
+    it 'uses a default text for ItemInfo1' do
+      expect(subject.aeon_basic_params[:ItemInfo1]).to eq('Reading Room Access Only')
+    end
+  end
+
+  context 'when document has access restrictions' do
+    subject { ObjectWithAeonAndAccessRestrictions.new }
+    it 'takes ItemInfo1 from access restrictions' do
+      expect(subject.aeon_basic_params[:ItemInfo1]).to eq('For conservation reasons, access is granted for compelling reasons only.')
     end
   end
 end

--- a/spec/models/requests/aeon_url_spec.rb
+++ b/spec/models/requests/aeon_url_spec.rb
@@ -51,6 +51,9 @@ RSpec.describe Requests::AeonUrl, requests: true do
   it 'includes publisher as a publisher' do
     expect(subject).to include('rft.pub=Random+House')
   end
+  it 'uses the text "Reading Room Access Only" for the ItemInfo1 by default' do
+    expect(subject).to include("ItemInfo1=Reading+Room+Access+Only")
+  end
   context 'when the location is at a Mudd location' do
     let(:holdings) do
       { "12345" => {
@@ -111,6 +114,19 @@ RSpec.describe Requests::AeonUrl, requests: true do
     end
     it('takes enumeration from the item') do
       expect(subject).to include('rft.volume=Vol+1%3A+no.+1+-+4')
+    end
+  end
+  context 'when the document has access_restrictions_note_display' do
+    let(:document) do
+      SolrDocument.new({
+                         id: '9999999',
+                         pub_citation_display: ['Random House'],
+                         holdings_1display: holdings.to_json,
+                         access_restrictions_note_display: ["For conservation reasons, access is granted for compelling reasons only."]
+                       })
+    end
+    it 'includes the restriction note in ItemInfo1' do
+      expect(subject).to include("ItemInfo1=For+conservation+reasons%2C+access+is+granted+for+compelling+reasons+only.")
     end
   end
 end

--- a/spec/system/catalog_show_spec.rb
+++ b/spec/system/catalog_show_spec.rb
@@ -207,6 +207,12 @@ describe 'Viewing Catalog Documents', type: :system, js: true do
         expect(page).to have_link('Reading Room Request', href: Regexp.new('princeton\.aeon\.atlas-sys.*title=The\+reply\+of\+a\+member\+of\+Parliament.*CallNumber=HJ5118\+\.H4\+1733'))
       end
     end
+    context 'aeon record with access restriction' do
+      it 'includes access restriction in aeon link' do
+        visit 'catalog/9947247893506421'
+        expect(page).to have_link('Reading Room Request', href: Regexp.new('ItemInfo1=For\+conservation\+reasons%2C\+access\+is\+granted\+for\+compelling\+reasons\+only'))
+      end
+    end
     context 'aeon holding with multiple items' do
       it 'links to the requests form so user can select the item they want' do
         visit("catalog/9930960283506421")


### PR DESCRIPTION
With this commit, if a user visits a record with an access restrictions note and presses the Reading Room Request button, they will get to an Aeon form with the 'Restrictions' field pre-filled with the restriction note.

If the record does not have an access restrictions note, the field will be pre-filled with 'Reading Room Access Only', as it has been previously.

Closes #5143