### PR TITLE
In Library use - Marquand

### DIFF
--- a/app/components/holdings/search_location_component.rb
+++ b/app/components/holdings/search_location_component.rb
@@ -11,24 +11,9 @@ class Holdings::SearchLocationComponent < ViewComponent::Base
       attr_reader :holding_hash
 
       def location
-        return library_in_use if library_in_use
+        in_library_use_label = InLibraryUse.new(holding_hash['location_code']).label
+        return in_library_use_label if in_library_use_label
         helpers.holding_library_label(holding_hash)
-      end
-
-      def library_in_use
-        location_code = holding_hash['location_code']
-        library_in_use_locations = {
-          'arch$pw': "Archictecture (Remote Storage)",
-          'eastasian$pl': "East Asian (Remote Storage)",
-          'engineer$pt': "Engineering (Remote Storage)",
-          'firestone$pb': "Firestone (Remote Storage)",
-          'firestone$pf': "Firestone (Remote Storage)",
-          'lewis$pn': "Lewis (Remote Storage)",
-          'lewis$ps': "Lewis (Remote Storage)",
-          'mendel$pk': "Mendel (Remote Storage)",
-          'stokes$pm': "Stokes (Remote Storage)"
-        }.freeze
-        library_in_use_locations[location_code&.to_sym]
       end
 
       def call_number

--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -492,6 +492,10 @@ export default class AvailabilityUpdater {
       lewis$ps: 'Lewis (Remote Storage)',
       mendel$pk: 'Mendel (Remote Storage)',
       stokes$pm: 'Stokes (Remote Storage)',
+      marquand$pj: 'Marquand (Remote Storage)',
+      marquand$pjm: 'Marquand (Remote Storage)',
+      marquand$pv: 'Marquand (Remote Storage)',
+      marquand$pz: 'Marquand (Remote Storage)',
     };
     if (location in library_in_use) {
       library_name = library_in_use[location];

--- a/app/models/in_library_use.rb
+++ b/app/models/in_library_use.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+# This class is responsible for providing a label for
+# in library use locations.
+class InLibraryUse
+  def initialize(location_code)
+    @location_code = location_code
+  end
+
+  def label
+    library_in_use_locations = {
+      'arch$pw': "Archictecture (Remote Storage)",
+      'eastasian$pl': "East Asian (Remote Storage)",
+      'engineer$pt': "Engineering (Remote Storage)",
+      'firestone$pb': "Firestone (Remote Storage)",
+      'firestone$pf': "Firestone (Remote Storage)",
+      'lewis$pn': "Lewis (Remote Storage)",
+      'lewis$ps': "Lewis (Remote Storage)",
+      'mendel$pk': "Mendel (Remote Storage)",
+      'stokes$pm': "Stokes (Remote Storage)",
+      'marquand$pj': "Marquand (Remote Storage)",
+      'marquand$pjm': "Marquand (Remote Storage)",
+      'marquand$pv': "Marquand (Remote Storage)",
+      'marquand$pz': "Marquand (Remote Storage)"
+    }.freeze
+    library_in_use_locations[location_code&.to_sym]
+  end
+
+    private
+
+      attr_reader :location_code
+end

--- a/spec/components/holdings/search_location_component_spec.rb
+++ b/spec/components/holdings/search_location_component_spec.rb
@@ -44,4 +44,10 @@ RSpec.describe Holdings::SearchLocationComponent, type: :component do
     rendered = render_inline(described_class.new(holding_hash))
     expect(rendered.css('.results_location').text).to include("Firestone (Remote Storage)")
   end
+
+  it "renders the marquand in library use label when the location code is for library in use" do
+    holding_hash['location_code'] = 'marquand$pv'
+    rendered = render_inline(described_class.new(holding_hash))
+    expect(rendered.css('.results_location').text).to include("Marquand (Remote Storage)")
+  end
 end

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -743,6 +743,12 @@ describe('getLibraryName', () => {
   it('returns the mapped name for an In library use location', () => {
     expect(
       availabilityUpdater.getLibraryName(
+        'Marquand Library - Remote Storage (ReCAP): Firestone Library Use Only',
+        'marquand$pz'
+      )
+    ).toBe('Marquand (Remote Storage)');
+    expect(
+      availabilityUpdater.getLibraryName(
         'Firestone Library - Remote Storage (ReCAP): Firestone Library Use Only',
         'firestone$pb'
       )


### PR DESCRIPTION
related to #5172 

marquand$pj: 'Marquand (Remote Storage)',
marquand$pjm: 'Marquand (Remote Storage)',
marquand$pv: 'Marquand (Remote Storage)',
marquand$pz: 'Marquand (Remote Storage)'

