### PR TITLE
Refactor: Requestable class should accept a Requests::Item, rather than construct a new one

### DIFF
--- a/app/models/requests/form.rb
+++ b/app/models/requests/form.rb
@@ -169,7 +169,7 @@ module Requests
         barcodesort = build_barcode_sort(items: values_items, availability_data:)
         barcodesort.each_value do |item|
           item['location_code'] = location_code
-          params = build_requestable_params(item: item.with_indifferent_access, holding: Holding.new(mfhd_id: id.to_sym.to_s, holding_data: holdings[id]),
+          params = build_requestable_params(item: Item.new(item.with_indifferent_access), holding: Holding.new(mfhd_id: id.to_sym.to_s, holding_data: holdings[id]),
                                             location:)
           requestable_items << Requests::Requestable.new(**params)
         end
@@ -249,7 +249,7 @@ module Requests
         item['status_label'] = barcodesort[item['barcode']][:status_label] unless barcodesort.empty?
         item_current_location = item_current_location(item)
         params = build_requestable_params(
-          item: item.with_indifferent_access,
+          item: Item.new(item.with_indifferent_access),
           holding: Holding.new(mfhd_id: holding_id.to_sym.to_s, holding_data: holding_data(item, holding_id, item_location_code)),
           location: item_current_location
         )
@@ -265,10 +265,10 @@ module Requests
         end
       end
 
-      # This method will always return a Requestable object where .item is a NullItem, because we don't pass an item in
+      # This method will always return a Requestable object where .item is a NullItem
       def build_requestable_from_holding(holding_id, holding)
         return if holding.blank?
-        params = build_requestable_params(holding: Holding.new(mfhd_id: holding_id.to_sym.to_s, holding_data: holding), location:)
+        params = build_requestable_params(holding: Holding.new(mfhd_id: holding_id.to_sym.to_s, holding_data: holding), location:, item: NullItem.new({}))
         Requests::Requestable.new(**params)
       end
 

--- a/app/models/requests/requestable.rb
+++ b/app/models/requests/requestable.rb
@@ -19,15 +19,13 @@ module Requests
 
     # @param bib [Hash] Solr Document of the Top level Request
     # @param holding [Requests::Holding] Bibdata information on where the item is held, created with data from the parsed solr_document[holdings_1display] json
-    # @param item [Hash] Item level data from bib data (https://bibdata.princeton.edu/availability?id= or mfhd=)
+    # @param item [Requests::Item] A Requests::Item or similar object (e.g. NullItem)
     # @param location [Hash] The hash for a bib data holding (https://bibdata.princeton.edu/locations/holding_locations)
     # @param patron [Patron] the patron information about the current user
-    def initialize(bib:, holding: nil, item: nil, location: nil, patron:)
+    def initialize(bib:, holding: nil, item:, location: nil, patron:)
       @bib = bib
       @holding = holding
-      # Item inherits from SimpleDelegator which requires at least one argument
-      # The argument is the Object that SimpleDelegator will delegate to.
-      @item = item.present? ? Item.new(item) : NullItem.new({})
+      @item = item
       @location = location
       @services = []
       @patron = patron

--- a/app/models/requests/requestable_decorator.rb
+++ b/app/models/requests/requestable_decorator.rb
@@ -90,7 +90,7 @@ module Requests
     end
 
     def create_fill_in_requestable
-      fill_in_req = Requestable.new(bib:, holding:, item: nil, location: location.to_h, patron:)
+      fill_in_req = Requestable.new(bib:, holding:, item: NullItem.new({}), location: location.to_h, patron:)
       fill_in_req.replace_existing_services services
       RequestableDecorator.new(fill_in_req, view_context)
     end

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -384,7 +384,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
   context 'A Non-Recap Marquand holding' do
     let(:valid_patron_response) { '{"netid":"foo","first_name":"Foo","last_name":"Request","barcode":"22101007797777","university_id":"9999999","patron_group":"staff","patron_id":"99999","active_email":"foo@princeton.edu"}' }
     let(:user) { FactoryBot.build(:user) }
-    let(:item) { { status_label: "Available", location_code: "scsbnypl" }.with_indifferent_access }
+    let(:item) { Requests::Item.new({ status_label: "Available", location_code: "scsbnypl" }.with_indifferent_access) }
     let(:location) { { "holding_library" => { "code" => "marquand" }, "library" => { "code" => "marquand" } } }
     let(:requestable) { described_class.new(bib: {}, holding: Requests::Holding.new(mfhd_id: 1, holding_data: { 'call_number_browse': 'blah' }), location:, patron:, item:) }
 


### PR DESCRIPTION
This will simplify the constructor slightly and, more importantly, make `Requestable` more flexible to accept other classes similar to `Requests::Item` and `Requests::NullItem`.

Helps with #5176