### PR TITLE
[#5176] Don't display status badge on requests form for titles with 500+ items

### DIFF
--- a/app/models/requests/form.rb
+++ b/app/models/requests/form.rb
@@ -265,10 +265,10 @@ module Requests
         end
       end
 
-      # This method will always return a Requestable object where .item is a NullItem
+      # This method will always return a Requestable object where .item is some kind of placeholder item, like NullItem
       def build_requestable_from_holding(holding_id, holding)
         return if holding.blank?
-        params = build_requestable_params(holding: Holding.new(mfhd_id: holding_id.to_sym.to_s, holding_data: holding), location:, item: NullItem.new({}))
+        params = build_requestable_params(holding: Holding.new(mfhd_id: holding_id.to_sym.to_s, holding_data: holding), location:, item: placeholder_item_class.new({}))
         Requests::Requestable.new(**params)
       end
 
@@ -323,6 +323,15 @@ module Requests
                               end
         get_current_location(item_location_code:)
       end
+
+      def placeholder_item_class
+        if too_many_items?
+          TooManyItemsPlaceholderItem
+        else
+          NullItem
+        end
+      end
+
       attr_reader :item_location_code
   end
 end

--- a/app/models/requests/requestable_decorator.rb
+++ b/app/models/requests/requestable_decorator.rb
@@ -107,7 +107,7 @@ module Requests
     end
 
     def status_badge
-      content_tag(:span, requestable.status, class: "availability--label badge #{css_class}")
+      content_tag(:span, status, class: "availability--label badge #{css_class}") if status
     end
 
     def css_class

--- a/app/models/requests/too_many_items_placeholder_item.rb
+++ b/app/models/requests/too_many_items_placeholder_item.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Requests
+  # This class is responsible for behaving as an item in cases where there
+  # are far too many items to load
+  class TooManyItemsPlaceholderItem < NullItem
+    def status
+      # Don't display a status, since we can't tell what the status actually is
+      # without loading hundreds and hundreds of items
+    end
+  end
+end

--- a/spec/models/requests/form_no_vcr_spec.rb
+++ b/spec/models/requests/form_no_vcr_spec.rb
@@ -38,6 +38,11 @@ RSpec.describe Requests::Form, type: :model, requests: true do
         expect(request.requestable.size).to eq(1)
         expect(request.requestable[0].item?).to be_falsey
       end
+
+      it 'does not provide a status for display' do
+        requestable_decorator = Requests::RequestableDecorator.new request.requestable.first, ApplicationController.new.view_context
+        expect(requestable_decorator.status_badge).not_to be_present
+      end
     end
   end
 end


### PR DESCRIPTION
Previously, rather than consulting the status on all 500+ items, we were defaulting to the status message from the `NullItem` class, which is "Unavailable".  In the case of a title with 500+ items, however, this was not a good default, since many/all items could be available, and this could discourage users from requesting the item at all.

Thanks to @christinach for discussing this approach!

This is currently deployed in staging, you can see the difference on MMS ID 9930682063506421:
- [On prod](https://catalog.princeton.edu/requests/9930682063506421?aeon=false&mfhd=22707844130006421&open_holdings=Special+Collections+-+East+Asian), it shows "Unavailable" even though all the items are actually Available in Alma
- [On staging with this branch deployed](https://catalog-staging.princeton.edu/requests/9930682063506421?aeon=false&mfhd=22707844130006421&open_holdings=Special+Collections+-+East+Asian), there is no misleading status badge.

Closes #5176