### PR TITLE
Remove friendly_id gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem 'faraday'
 gem 'faraday-cookie_jar'
 gem "ffi", force_ruby_platform: true
 gem 'flipflop'
-gem 'friendly_id', '~> 5.4.2'
 gem 'global'
 # Pinning to 12.4.0 due to Rails 7.1 compatibility issue in 12.4.1
 gem 'health-monitor-rails', '12.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,8 +307,6 @@ GEM
       activesupport (>= 4.0)
       terminal-table (>= 1.8)
     forwardable (1.3.3)
-    friendly_id (5.4.2)
-      activerecord (>= 4.0.0)
     global (3.0.0)
       activesupport (>= 2.0)
     globalid (1.2.1)
@@ -814,7 +812,6 @@ DEPENDENCIES
   faraday-cookie_jar
   ffi
   flipflop
-  friendly_id (~> 5.4.2)
   global
   health-monitor-rails (= 12.4.0)
   high_voltage


### PR DESCRIPTION
We don't use it for anything