### PR TITLE
Search results page: fix text overflow on Chrome

### DIFF
--- a/app/assets/stylesheets/components/availability.scss
+++ b/app/assets/stylesheets/components/availability.scss
@@ -46,6 +46,7 @@
   .search-result-library-name {
     margin-left: 6px;
     padding: 0;
+    width: calc(100% - 30px);
   }
 }
 


### PR DESCRIPTION
On Chrome, long library names like Special Collections extended past the edge of the card, thanks to a bootstrap CSS rule for all direct descendants of .row that set this element's width to 100% (which, combined with 30px of offset on the left caused the issue).

Firefox was unaffected.

Closes #5166

Marking as a draft until @ellen-aa and @caroldh have an opportunity to review it on catalog-qa