### PR TITLE
Remove feature flipper for Source Language of Translations

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -137,7 +137,7 @@ class CatalogController < ApplicationController
       show_missing_link: false
     }
     config.add_facet_field 'language_facet', label: 'Language', limit: true, include_in_advanced_search: true, suggest: true
-    config.add_facet_field 'original_language_of_translation_facet', label: 'Source language of translation', show: false, include_in_advanced_search_if: -> { Flipflop.source_language_of_translation? }
+    config.add_facet_field 'original_language_of_translation_facet', label: 'Source language of translation', show: false, include_in_advanced_search: true
     config.add_facet_field 'subject_topic_facet', label: 'Subject: Topic', limit: true, include_in_advanced_search: false, suggest: true
     config.add_facet_field 'genre_facet', label: 'Subject: Genre', limit: true, include_in_advanced_search: false
     config.add_facet_field 'subject_era_facet', label: 'Subject: Era', limit: true, include_in_advanced_search: false

--- a/config/features.rb
+++ b/config/features.rb
@@ -48,8 +48,4 @@ Flipflop.configure do
   feature :blacklight_hierarchy_publication_facet,
   default: true,
   description: "When on / true, use the colon delimited field to display the place of publication facet, when off / false use the pipe delimited field"
-
-  feature :source_language_of_translation,
-  default: false,
-  description: 'When on / true, show the Source Language of Translations dropdown on the advanced search page.  We need a full re-index before turning it on.'
 end

--- a/spec/features/advanced_searching_spec.rb
+++ b/spec/features/advanced_searching_spec.rb
@@ -108,7 +108,7 @@ describe 'advanced searching', advanced_search: true do
 
     it 'has the expected facets', js: true do
       visit '/advanced'
-      expect(page.find_all('.advanced-facet-label').map(&:text)).to match_array(["Access", "Format", "Language", "Holding location", "Publication year", "Place of publication"])
+      expect(page.find_all('.advanced-facet-label').map(&:text)).to match_array(["Access", "Format", "Language", "Source language of translation", "Holding location", "Publication year", "Place of publication"])
     end
 
     it 'renders an accessible button for starting over the search' do


### PR DESCRIPTION
We have done a full reindex, so this flipper is now true in production and no longer needed.

Closes #4634