### PR TITLE
Remove unused locals from render partial call

### DIFF
--- a/app/views/requests/form/_requestable_list_form.html.erb
+++ b/app/views/requests/form/_requestable_list_form.html.erb
@@ -29,7 +29,7 @@
       <% if fill_in_eligible %>
         <%= render partial: "requestable_fill_in_field", locals: { requestable: requestable_list.last.create_fill_in_requestable, default_pick_ups: default_pick_ups, requestable_list: requestable_list } %>
       <% end %>
-      <%= render partial: "requestable_form", collection: requestable_list, as: :requestable, locals: { mfhd: mfhd, holdings: @request.holdings, default_pick_ups: @request.default_pick_ups, fill_in_eligible: fill_in_eligible, requestable_list: requestable_list } %>
+      <%= render partial: "requestable_form", collection: requestable_list, as: :requestable, locals: { mfhd:, default_pick_ups: } %>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
We also already are storing the result of `@request.default_pick_ups` in a local called `default_pick_ups`, there is no need to call `@request.default_pick_ups again`.