### PR TITLE
When Marquand title is checked out, present a way to email Marquand on the request form

### DIFF
--- a/app/components/requests/requestable_form_marquand_contact_info_component.html.erb
+++ b/app/components/requests/requestable_form_marquand_contact_info_component.html.erb
@@ -1,0 +1,8 @@
+<tr id='<%= "request_#{requestable.preferred_request_id}" %>'>
+  <td></td>
+  <%= render partial: 'requestable_enum', locals: { requestable: } %>
+  <td><span class="availability--label badge bg-warning">Item in Use, Ask Staff for Access</span></td>
+  <td class='delivery--options'>
+    <a href="<%= href %>">Email marquand@princeton.edu for access</a>
+  </td>
+</tr>

--- a/app/components/requests/requestable_form_marquand_contact_info_component.rb
+++ b/app/components/requests/requestable_form_marquand_contact_info_component.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+module Requests
+  # This component displays the contact information for Marquand Library, so that patrons can
+  # contact them to request a title that is currently checked out to a carrel.
+  # This is a temporary workflow until Marquand materials are all moved back and we can work
+  # with Marquand staff on a more automated workflow.
+  class RequestableFormMarquandContactInfoComponent < ViewComponent::Base
+    def initialize(requestable:, single_item_request:)
+      @requestable = requestable
+      @single_item_request = single_item_request
+    end
+
+      private
+
+        def href
+          "mailto:marquand@princeton.edu?subject=#{email_subject}&body=#{email_body}"
+        end
+
+        # :reek:UtilityFunction
+        def email_subject
+          URI.encode_uri_component 'Requesting item in use'
+        end
+
+        def email_body
+          URI.encode_uri_component "Hello, could I please use the title #{requestable.title} (barcode #{barcode})?"
+        end
+
+        def barcode
+          requestable.item&.fetch 'barcode', nil
+        end
+
+        attr_reader :requestable, :single_item_request
+  end
+end

--- a/app/components/requests/requestable_form_option_component.rb
+++ b/app/components/requests/requestable_form_option_component.rb
@@ -20,7 +20,7 @@ module Requests
       partial
     end
 
-    delegate :digitize?, :in_library_use_required?, :pick_up?, to: :requestable
+    delegate :digitize?, :in_library_use_required?, :pick_up?, :patron_should_contact_marquand?, to: :requestable
 
       private
 
@@ -30,6 +30,8 @@ module Requests
             'requestable_form_alma_login'
           elsif requestable.aeon?
             'requestable_form_aeon'
+          elsif patron_should_contact_marquand?
+            'requestable_form_marquand_contact_info'
           elsif digitize? && pick_up?
             'requestable_form_digitize_and_pick_up'
           elsif pick_up?

--- a/app/models/requests/requestable_decorator.rb
+++ b/app/models/requests/requestable_decorator.rb
@@ -156,6 +156,15 @@ module Requests
       Location.new requestable.location
     end
 
+    # Return true if the patron needs to reach out to Marquand directly
+    # to use the Requestable.
+    # This is a temporary situation, after Marquand is done moving materials
+    # back into the library, we can work with Marquand staff to automate this
+    # workflow.
+    def patron_should_contact_marquand?
+      services.include? 'marquand_page_charged_item'
+    end
+
     private
 
       def first_delivery_location

--- a/app/models/requests/router.rb
+++ b/app/models/requests/router.rb
@@ -30,6 +30,7 @@ module Requests
     # :clancy_edd - item in the clancy warehouse in a location that permits digitization
     # :marquand_in_library - non clancy marquand item in a location that can be paged to marquand
     # :marquand_edd - non clancy marquand item in a location that is permitted to be scanned
+    # :marquand_page_charged_item - a Marquand item that is charged (checked out) to somebody else's carrel, but marquand staff can retrieve it for you
     # :ask_me - catchall service if the item isn't eligible for anything else.
 
     def routed_request
@@ -45,6 +46,7 @@ module Requests
 
     private
 
+      # rubocop:disable Metrics/AbcSize
       def eligibility_checks
         [
           ServiceEligibility::ILL.new(requestable:, patron:, any_loanable:),
@@ -58,6 +60,7 @@ module Requests
           ServiceEligibility::InProcess.new(requestable:, user:),
           ServiceEligibility::MarquandInLibrary.new(requestable:, user:),
           ServiceEligibility::MarquandEdd.new(requestable:, user:),
+          ServiceEligibility::MarquandPageChargedItem.new(requestable:, user:),
           ServiceEligibility::Recap::NoItems.new(requestable:, user:),
           ServiceEligibility::Recap::InLibrary.new(requestable:, user:),
           ServiceEligibility::Recap::AskMe.new(requestable:, user:),
@@ -66,5 +69,6 @@ module Requests
           ServiceEligibility::Aeon.new(requestable:)
         ]
       end
+    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/app/models/requests/service_eligibility/ill.rb
+++ b/app/models/requests/service_eligibility/ill.rb
@@ -23,6 +23,7 @@ module Requests
 
           def requestable_eligible?
             !requestable.aeon? && requestable.charged? && !requestable.marquand_item? &&
+              !requestable.item_at_clancy? &&
               (!any_loanable || requestable.enumerated? || requestable.preservation_conservation?)
           end
 

--- a/app/models/requests/service_eligibility/marquand_page_charged_item.rb
+++ b/app/models/requests/service_eligibility/marquand_page_charged_item.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+module Requests
+  module ServiceEligibility
+    # This class is responsible for determining if the given requestable and user
+    # can use a service where Marquand staff retrieve the item from another user's
+    # carrel.  The materials in the other user's carrel are charged (checked out),
+    # so this service is only possible for charged materials.
+    class MarquandPageChargedItem
+      def initialize(requestable:, user:)
+        @requestable = requestable
+        @user = user
+      end
+
+      def eligible?
+        correct_status? && correct_location? && user_eligible?
+      end
+
+      def to_s
+        'marquand_page_charged_item'
+      end
+
+          private
+
+            def correct_status?
+              requestable.charged? && !requestable.in_process? && !requestable.on_order?
+            end
+
+            def correct_location?
+              requestable.held_at_marquand_library? || requestable.item_at_clancy?
+            end
+
+            def user_eligible?
+              user.cas_provider? || user.alma_provider?
+            end
+
+            attr_reader :requestable, :user
+    end
+  end
+end

--- a/app/views/requests/form/_requestable_form_marquand_contact_info.html.erb
+++ b/app/views/requests/form/_requestable_form_marquand_contact_info.html.erb
@@ -1,0 +1,1 @@
+<%= render Requests::RequestableFormMarquandContactInfoComponent.new(requestable:, single_item_request:) %>

--- a/spec/components/requests/requestable_form_marquand_contact_info_component_spec.rb
+++ b/spec/components/requests/requestable_form_marquand_contact_info_component_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Requests::RequestableFormMarquandContactInfoComponent, :requests, type: :component do
+  it 'includes the title of the item in the mailto link' do
+    with_controller_class Requests::FormController do
+      requestable = double(Requests::Requestable)
+      item = Requests::Item.new({ 'barcode' => '32101032980649' })
+      allow(requestable).to receive_messages(preferred_request_id: '23490315030006421', item:, title: 'Das druckgraphische Werk von Matthaeus Merian d. Ae.')
+      component = described_class.new(requestable:, single_item_request: false)
+      rendered = render_inline component
+
+      expected_subject = 'Requesting item in use'
+      expected_body = 'Hello, could I please use the title Das druckgraphische Werk von Matthaeus Merian d. Ae. (barcode 32101032980649)?'
+      expect(rendered.css('a').attribute('href').value).to include('mailto:marquand@princeton.edu')
+      expect(rendered.css('a').attribute('href').value).to include(URI.encode_uri_component(expected_subject))
+      expect(rendered.css('a').attribute('href').value).to include(URI.encode_uri_component(expected_body))
+    end
+  end
+end

--- a/spec/components/requests/requestable_form_option_component_spec.rb
+++ b/spec/components/requests/requestable_form_option_component_spec.rb
@@ -11,14 +11,14 @@ RSpec.describe Requests::RequestableFormOptionComponent, :requests, type: :compo
       status_badge = '<span class=\"availability--label badge bg-success\">Available</span>'.html_safe
       requestable = double Requests::Requestable
       allow(requestable).to receive_messages(
-        digitize?: true, pick_up?: true, will_submit_via_form?: true, aeon?: false,
+        digitize?: true, pick_up?: true, will_submit_via_form?: true, aeon?: false, item_at_clancy?: false,
         preferred_request_id: '23701449010006421', bib: bib, holding: holding, item_location_code: 'firestone$stacks',
         item?: true, item:, partner_holding?: false, status_badge:, use_restriction?: false, holding_library: 'firestone',
         services: ['on_shelf_edd', 'on_shelf'], fill_in_pick_up?: true,
         pick_up_locations: [{ "label" => "Firestone Library" }], on_shelf?: true, no_services?: false,
         ill_eligible?: false, pending?: false, location: Requests::Location.new({}), charged?: false,
         off_site_location: 'firestone', enum_value: '', cron_value: '', illiad_request_parameters: {},
-        location_label: 'Firestone Library - Stacks', call_number: 'Q125 .S35 2007'
+        location_label: 'Firestone Library - Stacks', call_number: 'Q125 .S35 2007', patron_should_contact_marquand?: false
       )
       default_pick_ups = [{ label: "Firestone Library", gfa_pickup: "PF", pick_up_location_code: "firestone", staff_only: false }]
       form = double Requests::Form
@@ -29,6 +29,37 @@ RSpec.describe Requests::RequestableFormOptionComponent, :requests, type: :compo
       rendered = render_inline component
 
       expect(rendered.css('label').map(&:text)).to include 'Physical Item Delivery', 'Electronic Delivery'
+    end
+  end
+
+  it 'tells the patron to contact Marquand directly for marquand items in a carrel' do
+    with_controller_class Requests::FormController do
+      mfhd = '22701449030006421'
+      holding = Requests::Holding.new(mfhd_id: mfhd, holding_data: { 'location_code' => 'firestone$stacks' })
+      item = Requests::Item.new({ 'barcode' => '32101064185703' })
+      bib = SolrDocument.new
+      status_badge = '<span class=\"availability--label badge bg-success\">Available</span>'.html_safe
+      requestable = double Requests::Requestable
+      allow(requestable).to receive_messages(
+        patron_should_contact_marquand?: true, digitize?: true, pick_up?: true, will_submit_via_form?: true, aeon?: false,
+        preferred_request_id: '23701449010006421', bib: bib, holding: holding, item_location_code: 'marquand$stacks',
+        item?: true, item:, partner_holding?: false, status_badge:, use_restriction?: false, holding_library: 'marquand',
+        services: ['marquand_page_charged_item'], fill_in_pick_up?: true,
+        pick_up_locations: [{ "label" => "Marquand Library" }], on_shelf?: true, no_services?: false,
+        ill_eligible?: false, pending?: false, location: Requests::Location.new({}), charged?: false,
+        off_site_location: 'marquand', enum_value: '', cron_value: '', illiad_request_parameters: {},
+        location_label: 'Marquand Library - Stacks', call_number: 'Q125 .S35 2007', title: 'My title'
+      )
+      default_pick_ups = [{ label: "Firestone Library", gfa_pickup: "PF", pick_up_location_code: "firestone", staff_only: false }]
+      form = double Requests::Form
+      allow(form).to receive_messages ctx: OpenURL::ContextObject.new, single_item_request?: true
+      patron = double Requests::Patron
+
+      component = described_class.new(requestable:, mfhd:, default_pick_ups:, form:, patron:)
+      rendered = render_inline component
+
+      expect(rendered.text).to include 'Item in Use, Ask Staff for Access'
+      expect(rendered.text).to include 'Email marquand@princeton.edu for access'
     end
   end
 end

--- a/spec/features/requests/marquand_spec.rb
+++ b/spec/features/requests/marquand_spec.rb
@@ -66,7 +66,7 @@ describe 'requests for Marquand items', type: :feature, requests: true do
       it 'does not give the option for ILL' do
         visit("requests/#{bib_id}?aeon=false&mfhd=#{holding_id}")
         expect(page).not_to have_content('Request via Partner Library')
-        expect(page).to have_content('Contact marquand@princeton.edu for use of this item')
+        expect(page).to have_content('Email marquand@princeton.edu for access')
         expect(catalog_raw_stub).to have_been_requested
         expect(availability_stub).to have_been_requested
         expect(holding_location_stub).to have_been_requested

--- a/spec/models/requests/requestable_decorator_spec.rb
+++ b/spec/models/requests/requestable_decorator_spec.rb
@@ -1130,5 +1130,23 @@ describe Requests::RequestableDecorator, requests: true do
       end
     end
   end
+  describe '#patron_should_contact_marquand?' do
+    let(:stubbed_questions) { default_stubbed_questions.merge(services: ['recap_edd']) }
+    it 'defaults to false' do
+      expect(decorator.patron_should_contact_marquand?).to be false
+    end
+    context 'when requestable is charged and eligible for marquand_page_charged_item' do
+      let(:stubbed_questions) do
+        default_stubbed_questions.merge(
+          services: ['marquand_page_charged_item'],
+          held_at_marquand_library?: true, item_at_clancy?: false, alma_managed?: true, aeon?: false,
+          charged?: true, in_process?: false, on_order?: false, recap?: false
+        )
+      end
+      it 'returns true' do
+        expect(decorator.patron_should_contact_marquand?).to be true
+      end
+    end
+  end
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/models/requests/router_spec.rb
+++ b/spec/models/requests/router_spec.rb
@@ -229,6 +229,18 @@ describe Requests::Router, vcr: { cassette_name: 'requests_router', record: :non
         end
       end
 
+      context "marquand_page_charged_item" do
+        before do
+          stubbed_questions[:circulates?] = true
+          stubbed_questions[:item_at_clancy?] = true
+          stubbed_questions[:clancy_available?] = false
+          stubbed_questions[:charged?] = true
+        end
+        it "returns marquand_page_charged_item in the services" do
+          expect(router.calculate_services).to eq(['marquand_page_charged_item'])
+        end
+      end
+
       context "not alma managed or scsb" do
         before do
           stubbed_questions[:alma_managed?] = false

--- a/spec/models/requests/service_eligibility/ill_spec.rb
+++ b/spec/models/requests/service_eligibility/ill_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Requests::ServiceEligibility::ILL, requests: true do
           alma_managed?: true,
           aeon?: false,
           charged?: true,
-          marquand_item?: false
+          marquand_item?: false,
+          item_at_clancy?: false
         )
 
       expect(eligibility.eligible?).to be(true)
@@ -37,7 +38,8 @@ RSpec.describe Requests::ServiceEligibility::ILL, requests: true do
           alma_managed?: true,
           aeon?: false,
           charged?: true,
-          marquand_item?: false
+          marquand_item?: false,
+          item_at_clancy?: false
         )
 
         expect(eligibility.eligible?).to be(false)

--- a/spec/models/requests/service_eligibility/marquand_page_charged_item_spec.rb
+++ b/spec/models/requests/service_eligibility/marquand_page_charged_item_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Requests::ServiceEligibility::MarquandPageChargedItem, :requests do
+  describe '#eligible?' do
+    it 'returns true if all criteria are met' do
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+        held_at_marquand_library?: true,
+        item_at_clancy?: false,
+        alma_managed?: true,
+        aeon?: false,
+        charged?: true,
+        in_process?: false,
+        on_order?: false,
+        recap?: false
+      )
+      eligibility = described_class.new(requestable:, user: FactoryBot.create(:user))
+
+      expect(eligibility.eligible?).to be(true)
+    end
+
+    it 'does not consider in_process items eligible' do
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+        held_at_marquand_library?: true,
+        item_at_clancy?: false,
+        alma_managed?: true,
+        aeon?: false,
+        charged?: false,
+        in_process?: true,
+        on_order?: false,
+        recap?: false
+      )
+      eligibility = described_class.new(requestable:, user: FactoryBot.create(:user))
+
+      expect(eligibility.eligible?).to be(false)
+    end
+
+    it 'does not consider on_order items eligible' do
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+        held_at_marquand_library?: true,
+        item_at_clancy?: false,
+        alma_managed?: true,
+        aeon?: false,
+        charged?: false,
+        in_process?: false,
+        on_order?: true,
+        recap?: false
+      )
+      eligibility = described_class.new(requestable:, user: FactoryBot.create(:user))
+
+      expect(eligibility.eligible?).to be(false)
+    end
+
+    it 'can consider clancy items eligible' do
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+        held_at_marquand_library?: false,
+        item_at_clancy?: true,
+        alma_managed?: true,
+        aeon?: false,
+        charged?: true,
+        in_process?: false,
+        on_order?: false,
+        recap?: false
+      )
+      eligibility = described_class.new(requestable:, user: FactoryBot.create(:user))
+
+      expect(eligibility.eligible?).to be(true)
+    end
+
+    it 'does not consider non-Marquand items eligible' do
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+        held_at_marquand_library?: false,
+        item_at_clancy?: false,
+        alma_managed?: true,
+        aeon?: false,
+        charged?: true,
+        in_process?: false,
+        on_order?: false,
+        recap?: false
+      )
+      eligibility = described_class.new(requestable:, user: FactoryBot.create(:user))
+
+      expect(eligibility.eligible?).to be(false)
+    end
+
+    it 'does not consider non-charged items eligible' do
+      requestable = instance_double(Requests::Requestable)
+      allow(requestable).to receive_messages(
+        held_at_marquand_library?: true,
+        item_at_clancy?: false,
+        alma_managed?: true,
+        aeon?: false,
+        charged?: false,
+        in_process?: false,
+        on_order?: false,
+        recap?: false
+      )
+      eligibility = described_class.new(requestable:, user: FactoryBot.create(:user))
+
+      expect(eligibility.eligible?).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
Advances #3900, although it does not fully automate it since Marquand is in the middle of its large move.

Here is how it looks on a form with multiple holdings: checked out volumes do not get a select checkbox, and the status "Item in Use, Ask Staff for access" is displayed in yellow.  In the Delivery Options column, there is a link to email marquand for access:

<img width="1729" height="1225" alt="the form with 2 checked out marquand items and 1 checked in one, as described above" src="https://github.com/user-attachments/assets/5c1314a1-6435-4ca4-bf6d-c767a743da9a" />
