### PR TITLE
Refine display of Marquand Contact info on the requests form

### DIFF
--- a/app/components/requests/requestable_form_marquand_contact_info_component.html.erb
+++ b/app/components/requests/requestable_form_marquand_contact_info_component.html.erb
@@ -1,7 +1,7 @@
 <tr id='<%= "request_#{requestable.preferred_request_id}" %>'>
   <td></td>
   <%= render partial: 'requestable_enum', locals: { requestable: } %>
-  <td><span class="availability--label badge bg-warning">Item in Use, Ask Staff for Access</span></td>
+  <td><span class="availability--label badge bg-warning"><%= status_label %></span></td>
   <td class='delivery--options'>
     <a href="<%= href %>">Email marquand@princeton.edu for access</a>
   </td>

--- a/app/components/requests/requestable_form_marquand_contact_info_component.rb
+++ b/app/components/requests/requestable_form_marquand_contact_info_component.rb
@@ -29,6 +29,19 @@ module Requests
           requestable.item&.fetch 'barcode', nil
         end
 
+        def status_label
+          if process_type == 'LOAN'
+            'Item in use'
+          else
+            'Item unavailable'
+          end
+        end
+
+        # Process type will be something like MISSING or LOAN
+        def process_type
+          requestable.item&.fetch 'process_type', nil
+        end
+
         attr_reader :requestable, :single_item_request
   end
 end

--- a/spec/components/requests/requestable_form_marquand_contact_info_component_spec.rb
+++ b/spec/components/requests/requestable_form_marquand_contact_info_component_spec.rb
@@ -17,4 +17,26 @@ RSpec.describe Requests::RequestableFormMarquandContactInfoComponent, :requests,
       expect(rendered.css('a').attribute('href').value).to include(URI.encode_uri_component(expected_body))
     end
   end
+  it 'says Item In Use if item is LOAN' do
+    with_controller_class Requests::FormController do
+      requestable = double(Requests::Requestable)
+      item = Requests::Item.new({ 'barcode' => '32101032980649', 'process_type' => 'LOAN' })
+      allow(requestable).to receive_messages(preferred_request_id: '23490315030006421', item:, title: 'Das druckgraphische Werk von Matthaeus Merian d. Ae.')
+      component = described_class.new(requestable:, single_item_request: false)
+      rendered = render_inline component
+
+      expect(rendered.text).to include('Item in use')
+    end
+  end
+  it 'says Item Unavailable if item is not LOAN' do
+    with_controller_class Requests::FormController do
+      requestable = double(Requests::Requestable)
+      item = Requests::Item.new({ 'barcode' => '32101032980649', 'process_type' => 'MISSING' })
+      allow(requestable).to receive_messages(preferred_request_id: '23490315030006421', item:, title: 'Das druckgraphische Werk von Matthaeus Merian d. Ae.')
+      component = described_class.new(requestable:, single_item_request: false)
+      rendered = render_inline component
+
+      expect(rendered.text).to include('Item unavailable')
+    end
+  end
 end

--- a/spec/components/requests/requestable_form_option_component_spec.rb
+++ b/spec/components/requests/requestable_form_option_component_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Requests::RequestableFormOptionComponent, :requests, type: :compo
     with_controller_class Requests::FormController do
       mfhd = '22701449030006421'
       holding = Requests::Holding.new(mfhd_id: mfhd, holding_data: { 'location_code' => 'firestone$stacks' })
-      item = Requests::Item.new({ 'barcode' => '32101064185703' })
+      item = Requests::Item.new({ 'barcode' => '32101064185703', 'process_type' => 'LOAN' })
       bib = SolrDocument.new
       status_badge = '<span class=\"availability--label badge bg-success\">Available</span>'.html_safe
       requestable = double Requests::Requestable
@@ -58,7 +58,7 @@ RSpec.describe Requests::RequestableFormOptionComponent, :requests, type: :compo
       component = described_class.new(requestable:, mfhd:, default_pick_ups:, form:, patron:)
       rendered = render_inline component
 
-      expect(rendered.text).to include 'Item in Use, Ask Staff for Access'
+      expect(rendered.text).to include 'Item in use'
       expect(rendered.text).to include 'Email marquand@princeton.edu for access'
     end
   end


### PR DESCRIPTION
Follow up to #5200, from Feedback from Marquand.

* If the item is on loan, say "Item in use"
* If the item has any other process type, or no process type, say "Item unavailable"