### PR TITLE
[Show page] Render the thumbnail component for the ephemera born digital resources

### DIFF
--- a/app/components/thumbnail_component.html.erb
+++ b/app/components/thumbnail_component.html.erb
@@ -1,6 +1,15 @@
+<% if document.uuid? && document["thumbnail_display"].present? %>
+  <a href="#viewer-container">
+    <div class="document-thumbnail has-viewer-link" data-bib-id="<%= document['id'] %>">
+      <span class="visually-hidden">Go to viewer</span>
+      <img alt="" src="<%= document["thumbnail_display"]&.first %>">
+    </div>
+  </a>
+<% else %>
 <%= helpers.content_tag(
   :div,
   helpers.content_tag(:div, nil, class: "default"),
   class: 'document-thumbnail',
   data: identifier_data)
 %>
+<% end %>

--- a/app/components/thumbnail_component.rb
+++ b/app/components/thumbnail_component.rb
@@ -23,4 +23,8 @@ class ThumbnailComponent < ViewComponent::Base
         all_identifiers
       end
     end
+
+    def thumbnail_display
+      document.thumbnail_display
+    end
 end

--- a/spec/components/thumbnail_component_spec.rb
+++ b/spec/components/thumbnail_component_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ThumbnailComponent, type: :component, thumbnails: true do
   it "includes identifiers for google books retrieval if the document is not in special collections" do
     document = instance_double(SolrDocument)
     allow(document).to receive_messages(
+      uuid?: false,
       in_a_special_collection?: false,
       identifier_data: { oclc: ["40810988"], 'bib-id': "9969113523506421" }
     )
@@ -16,9 +17,25 @@ RSpec.describe ThumbnailComponent, type: :component, thumbnails: true do
     expect(rendered.css('.document-thumbnail').attribute('data-bib-id').to_s).to eq('9969113523506421')
   end
 
+  it "renders a viewer link and thumbnail image when document has uuid and thumbnail_display" do
+    document = instance_double(SolrDocument)
+    allow(document).to receive(:uuid?).and_return(true)
+    allow(document).to receive(:[]).with("thumbnail_display").and_return(["/thumb.jpg"])
+    allow(document).to receive(:[]).with("id").and_return("123")
+    allow(document).to receive(:in_a_special_collection?).and_return(false)
+    allow(document).to receive(:identifier_data).and_return({ oclc: ["40810988"], 'bib-id': "123" })
+
+    rendered = render_inline(described_class.new(document:))
+    expect(rendered.css('a[href="#viewer-container"]')).not_to be_empty
+    expect(rendered.css('.document-thumbnail.has-viewer-link').attribute('data-bib-id').to_s).to eq('123')
+    expect(rendered.css('img').attribute('src').to_s).to eq('/thumb.jpg')
+    expect(rendered.css('span.visually-hidden').text).to eq('Go to viewer')
+  end
+
   it "includes only the bib-id identifier for figgy retrieval if the document is in special collections" do
     document = instance_double(SolrDocument)
     allow(document).to receive_messages(
+      uuid?: false,
       in_a_special_collection?: true,
       identifier_data: { oclc: ["40810988"], 'bib-id': "9969113523506421" }
     )
@@ -31,6 +48,7 @@ RSpec.describe ThumbnailComponent, type: :component, thumbnails: true do
   it 'includes a div.default within a div.document-thumbnail' do
     document = instance_double(SolrDocument)
     allow(document).to receive_messages(
+      uuid?: false,
       in_a_special_collection?: true,
       identifier_data: { oclc: ["40810988"], 'bib-id': "9969113523506421" }
     )

--- a/spec/fixtures/raw/ephemera_born_digital.json
+++ b/spec/fixtures/raw/ephemera_born_digital.json
@@ -156,6 +156,7 @@
         "title_citation_display": "බොරුකීම හා විකෘති කිරීම පිලිබඳ සමසමාජ ගුරුකුලය",
         "title_display": "බොරුකීම හා විකෘති කිරීම පිලිබඳ සමසමාජ ගුරුකුලය",
         "title_sort": "බොරුකීම හා විකෘති කිරීම පිලිබඳ සමසමාජ ගුරුකුලය",
-        "title_t": null
+        "title_t": null,
+        "thumbnail_display": "https://iiif-cloud.princeton.edu/iiif/2/62%2F81%2Fa5%2F6281a515a5c945039bcfb7e4847507ea%2Fintermediate_file/full/!200,150/0/default.jpg"
     }
 ]


### PR DESCRIPTION
Adds a commit to render in the record page the thumbnail component when we render an ephemera born digital uuid. 

Follow up ticket related to this one https://github.com/pulibrary/orangelight/issues/5204