### PR TITLE
Fix search results thumbnail. Move class lux in its own div so that the selector of the thumbnail element does not include lux

### DIFF
--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -15,10 +15,12 @@
   </div>
 </div>
 
-  <div class="thumbnail-wrapper lux">
+  <div class="thumbnail-wrapper">
+    <div class="lux">
     <bookmark-button
       v-bind:in-bookmarks="<%= bookmarked? document %>"
       v-bind:logged-in="<%= !!current_user %>"
       document-id="<%= document.id %>"></bookmark-button>
+    </div>
       <%= render ThumbnailComponent.new document: %>
   </div>


### PR DESCRIPTION
closes #5204

Fix search results thumbnail. Move class lux in its own div so that the selector of the thumbnail element does not include lux

