### PR TITLE
Use the icon-book for report resources

### DIFF
--- a/app/assets/stylesheets/icons/icons.scss
+++ b/app/assets/stylesheets/icons/icons.scss
@@ -224,6 +224,13 @@
     }
 }
 
+.icon-report,
+.blacklight-report .document-thumbnail .default {
+    &:before {
+        content: $icon-book;
+    }
+}
+
 .icon-journal,
 .blacklight-journal .document-thumbnail .default {
     &:before {


### PR DESCRIPTION
We will have report resources mainly from ephemera born digital in figgy.

Discussed with @kevinreiss to use the icon book for reports that come from the ephemera born digital resources. 

We're also adding it in the daily schedule in production with https://github.com/pulibrary/bibdata/pull/2913

Deployed on [catalog-staging](https://catalog-staging.princeton.edu/catalog?f%5Bformat%5D%5B%5D=Report&search_field=all_fields&q=fa30780e-dfd8-4545-b1b0-b3eec9fca96b)

<img width="1565" height="566" alt="Screenshot of report facet for the ephemera resources" src="https://github.com/user-attachments/assets/a9a50fed-4aac-4aed-8016-ddfe41308de2" />

