### PR TITLE
Don't generate an external icon when there is an empty external label

### DIFF
--- a/app/services/online_holdings_markup_builder.rb
+++ b/app/services/online_holdings_markup_builder.rb
@@ -33,7 +33,7 @@ class OnlineHoldingsMarkupBuilder < HoldingRequestsBuilder
                  link_to(texts.first, ::Regexp.last_match(0), class: 'electronic-access-link')
                end
              else
-               link_text = new_tab_icon(texts.first)
+               link_text = new_tab_icon(texts.first) if texts.first.present?
                link_to(link_text, EzProxyService.ez_proxy_url(url), target: '_blank', rel: 'noopener', class: 'electronic-access-link')
              end
     markup

--- a/spec/fixtures/alma/9946093213506421.json
+++ b/spec/fixtures/alma/9946093213506421.json
@@ -135,8 +135,8 @@
     "113.2"
   ],
   "electronic_portfolio_s": [
-    "{\"desc\":null,\"title\":null,\"url\":\"https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true\u0026portfolio_pid=53356055290006421\u0026Force_direct=true\",\"start\":null,\"end\":\"latest\"}",
-    "{\"desc\":null,\"title\":null,\"url\":\"https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true\u0026portfolio_pid=53356055310006421\u0026Force_direct=true\",\"start\":null,\"end\":\"latest\"}"
+    "{\"desc\":null,\"title\":\"Online Content\",\"url\":\"https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true\u0026portfolio_pid=53356055290006421\u0026Force_direct=true\",\"start\":null,\"end\":\"latest\"}",
+    "{\"desc\":null,\"title\":\"Online Content\",\"url\":\"https://na07.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true\u0026portfolio_pid=53356055310006421\u0026Force_direct=true\",\"start\":null,\"end\":\"latest\"}"
   ],
   "timestamp": "2021-04-14T13:28:36.105Z"
 }

--- a/spec/fixtures/raw/ephemera_born_digital.json
+++ b/spec/fixtures/raw/ephemera_born_digital.json
@@ -18,7 +18,7 @@
         "description_display": [
             "pages: 598"
         ],
-        "electronic_access_1display": "{\"https://figgy.princeton.edu/catalog/fa30780e-dfd8-4545-b1b0-b3eec9fca96b\":[\"Online Content\",\"Born Digital Monographic Reports and Papers\"],\"https://catalog-staging.princeton.edu/catalog/fa30780e-dfd8-4545-b1b0-b3eec9fca96b#view\":[\"Digital content\"],\"iiif_manifest_paths\":{\"ephemera_ark\":\"https://figgy.princeton.edu/concern/scanned_resources/f4ca996b-cd14-4179-aa4d-acd35edcc840/manifest\",\"ephemera_ark1\":\"https://figgy.princeton.edu/concern/scanned_resources/465998ec-5dd4-4dd8-a0fe-0934008b9df8/manifest\"}}",
+        "electronic_access_1display": "{\"\":[\"\"],\"https://catalog-staging.princeton.edu/catalog/fa30780e-dfd8-4545-b1b0-b3eec9fca96b#view\":[\"Digital content\"],\"iiif_manifest_paths\":{\"ephemera_ark\":\"https://figgy.princeton.edu/concern/scanned_resources/f4ca996b-cd14-4179-aa4d-acd35edcc840/manifest\",\"ephemera_ark1\":\"https://figgy.princeton.edu/concern/scanned_resources/465998ec-5dd4-4dd8-a0fe-0934008b9df8/manifest\"}}",
         "format": [
             "Report"
         ],

--- a/spec/services/online_holdings_markup_builder_spec.rb
+++ b/spec/services/online_holdings_markup_builder_spec.rb
@@ -50,6 +50,15 @@ RSpec.describe OnlineHoldingsMarkupBuilder do
 
   describe '.electronic_access_link' do
     let(:link_markup) { described_class.electronic_access_link('http://arks.princeton.edu/ark:/88435/dsp01ft848s955', ['Full text']) }
+    context 'when label - texts.first - for an external icon is an empty string' do
+      it 'does not generate an icon for an empty string key and value' do
+        # "electronic_access_1display": "{\"\":[\"\"], ... }"
+        url = ''
+        texts = ['']
+        markup = described_class.electronic_access_link(url, texts)
+        expect(markup).not_to include 'fa fa-external-link new-tab-icon-padding'
+      end
+    end
 
     it 'generates electronic access links for a catalog record' do
       parsed = Nokogiri::HTML link_markup


### PR DESCRIPTION
Don't display an external icon only, for cases where the external link is indexed but there is no label. 
I've seen this in production but couldn't find an example quickly.

I'm adding this to cover cases from ephemera resources with the addition in https://github.com/pulibrary/bibdata/pull/2917/ and also cases where for any reason we may not have a label for an external link url. The link_text in ElectronicAccess is indexed as an empty string and not a None so it returns an [""] for a label.
```
"electronic_access_1display":"{\"\":[\"\"],\"https://catalog-staging.princeton.edu/catalog/f4e58e9f-623d-41aa-9a8c-0919f3f7d4ed#view\":[\"Digital content\"],\"iiif_manifest_paths\":{\"ephemera_ark\":\"https://figgy.princeton.edu/concern/ephemera_folders/f4e58e9f-623d-41aa-9a8c-0919f3f7d4ed/manifest\"}}"
```