### PR TITLE
Different resources render thumbnail with a different element structure in the record and search results page

### DIFF
--- a/app/components/thumbnail_component.html.erb
+++ b/app/components/thumbnail_component.html.erb
@@ -1,15 +1,5 @@
-<% if document.uuid? && thumbnail_display.present? %>
-  <a href="#viewer-container">
-    <div class="document-thumbnail has-viewer-link" data-bib-id="<%= document['id'] %>">
-      <span class="visually-hidden">Go to viewer</span>
-      <img alt="" src="<%= thumbnail_display %>">
-    </div>
-  </a>
-<% else %>
-<%= helpers.content_tag(
-  :div,
-  helpers.content_tag(:div, nil, class: "default"),
-  class: 'document-thumbnail',
-  data: identifier_data)
-%>
+<% if action_name == 'show' %>
+  <%= render ThumbnailShowComponent.new document: %>
+<% elsif action_name == 'index' %>
+  <%= render ThumbnailIndexComponent.new document: %>
 <% end %>

--- a/app/components/thumbnail_index_component.html.erb
+++ b/app/components/thumbnail_index_component.html.erb
@@ -1,0 +1,10 @@
+<% if document.uuid? && thumbnail_display.present? %>
+    <%= content_tag(
+    :div,
+    image_tag(thumbnail_display, alt: ""),
+    class: "document-thumbnail",
+    data: identifier_data)
+   %>
+<% else %>
+  <%= render partial: "catalog/default_thumbnail", locals: { identifier_data: identifier_data } %>
+<% end %>

--- a/app/components/thumbnail_index_component.rb
+++ b/app/components/thumbnail_index_component.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# ThumbnailIndexComponent is a specialized component that inherits from ThumbnailComponent.
+# It is intended to represent and render thumbnail images within search results
+
+class ThumbnailIndexComponent < ThumbnailComponent
+end

--- a/app/components/thumbnail_show_component.html.erb
+++ b/app/components/thumbnail_show_component.html.erb
@@ -1,0 +1,16 @@
+
+<% if document.uuid? && thumbnail_display.present? %>
+<a href="#viewer-container">
+  <%= content_tag(
+    :div,
+    capture do
+      concat content_tag(:span, "Go to viewer", class: "visually-hidden")
+      concat image_tag(thumbnail_display, alt: "")
+    end,
+    class: "document-thumbnail has-viewer-link",
+    data: identifier_data
+  ) %>
+</a>
+<% else %>
+  <%= render partial: "catalog/default_thumbnail", locals: { identifier_data: identifier_data } %>
+<% end %>

--- a/app/components/thumbnail_show_component.rb
+++ b/app/components/thumbnail_show_component.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+# ThumbnailShowComponent is a specialized component that inherits from ThumbnailComponent.
+# It is intended to represent and render thumbnail images within the record page
+
+class ThumbnailShowComponent < ThumbnailComponent
+end

--- a/app/javascript/orangelight/figgy_manifest_manager.js
+++ b/app/javascript/orangelight/figgy_manifest_manager.js
@@ -1,3 +1,22 @@
+// Checks if the current path is a valid record page (catalog/ID)
+// Matches catalog/ followed by:
+// - starts with 99 and ends with 3506421 (Alma)
+// - dsp + 1 or more alphanumeric
+// - UUID (8-4-4-4-12)
+// - SCSB- + digits
+function isRecordPagePath() {
+  const path = window.location.pathname;
+  const regex =
+    /^\/catalog\/(\d{14,}|99\w+3506421|dsp[\w]+|[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}|SCSB-\d+)$/;
+  return regex.test(path);
+}
+
+// Helper to wrap thumbnail element with viewer link and accessibility span
+function wrapWithViewerLink($element) {
+  $element.addClass('has-viewer-link');
+  $element.wrap('<a href="#viewer-container"></a>');
+  $element.append('<span class="visually-hidden">Go to viewer</span>');
+}
 import loadResourcesByFiggyIds from './load-resources-by-figgy-ids';
 import loadResourcesByOrangelightId from './load-resources-by-orangelight-id';
 import loadResourcesByOrangelightIds from './load-resources-by-orangelight-ids';
@@ -248,10 +267,9 @@ class FiggyThumbnailSet {
         return;
       }
       $element.empty();
-      $element.addClass('has-viewer-link');
-      $element
-        .wrap('<a href="#viewer-container"></a>')
-        .append('<span class="visually-hidden">Go to viewer</span>');
+      if (isRecordPagePath()) {
+        wrapWithViewerLink($element);
+      }
       $element.append($thumbnailElement);
     });
   }
@@ -301,4 +319,10 @@ class FiggyManifestManager {
   }
 }
 
-export { FiggyManifestManager, FiggyViewer, FiggyViewerSet };
+export {
+  FiggyManifestManager,
+  FiggyViewer,
+  FiggyViewerSet,
+  wrapWithViewerLink,
+  isRecordPagePath,
+};

--- a/app/views/catalog/_default_thumbnail.html.erb
+++ b/app/views/catalog/_default_thumbnail.html.erb
@@ -1,0 +1,6 @@
+<%= content_tag(
+  :div,
+  content_tag(:div, nil, class: "default"),
+  class: 'document-thumbnail',
+  data: identifier_data)
+%>

--- a/spec/components/thumbnail_component_spec.rb
+++ b/spec/components/thumbnail_component_spec.rb
@@ -1,60 +1,92 @@
 # frozen_string_literal: true
-
 require "rails_helper"
 
-RSpec.describe ThumbnailComponent, type: :component, thumbnails: true do
+RSpec.shared_examples "thumbnail identifier checks" do |action|
   it "includes identifiers for google books retrieval if the document is not in special collections" do
-    document = instance_double(SolrDocument)
     allow(document).to receive_messages(
       uuid?: false,
       in_a_special_collection?: false,
       identifier_data: { oclc: ["40810988"], 'bib-id': "9969113523506421" }
     )
-
-    rendered = render_inline(described_class.new(document:))
-
+    allow(document).to receive(:[]).with("electronic_access_1display").and_return(nil)
+    allow(component).to receive(:action_name).and_return(action)
+    rendered = render_inline(component)
     expect(rendered.css('.document-thumbnail').attribute('data-oclc').to_s).to eq('["40810988"]')
     expect(rendered.css('.document-thumbnail').attribute('data-bib-id').to_s).to eq('9969113523506421')
   end
 
-  it "renders a viewer link and thumbnail image when document has uuid and thumbnail_display" do
-    document = instance_double(SolrDocument)
-    allow(document).to receive(:uuid?).and_return(true)
-    allow(document).to receive(:[]).with("thumbnail_display").and_return("/thumb.jpg")
-    allow(document).to receive(:[]).with("id").and_return("123")
-    allow(document).to receive(:in_a_special_collection?).and_return(false)
-    allow(document).to receive(:identifier_data).and_return({ oclc: ["40810988"], 'bib-id': "123" })
-
-    rendered = render_inline(described_class.new(document:))
-    expect(rendered.css('a[href="#viewer-container"]')).not_to be_empty
-    expect(rendered.css('.document-thumbnail.has-viewer-link').attribute('data-bib-id').to_s).to eq('123')
-    expect(rendered.css('img').attribute('src').to_s).to eq('/thumb.jpg')
-    expect(rendered.css('span.visually-hidden').text).to eq('Go to viewer')
-  end
-
   it "includes only the bib-id identifier for figgy retrieval if the document is in special collections" do
-    document = instance_double(SolrDocument)
     allow(document).to receive_messages(
       uuid?: false,
       in_a_special_collection?: true,
       identifier_data: { oclc: ["40810988"], 'bib-id': "9969113523506421" }
     )
-
-    rendered = render_inline(described_class.new(document:))
+    allow(document).to receive(:[]).with("electronic_access_1display").and_return(nil)
+    allow(component).to receive(:action_name).and_return(action)
+    rendered = render_inline(component)
     expect(rendered.css('.document-thumbnail').attribute('data-oclc')).to be_nil
     expect(rendered.css('.document-thumbnail').attribute('data-bib-id').to_s).to eq('9969113523506421')
   end
 
   it 'includes a div.default within a div.document-thumbnail' do
-    document = instance_double(SolrDocument)
     allow(document).to receive_messages(
       uuid?: false,
       in_a_special_collection?: true,
       identifier_data: { oclc: ["40810988"], 'bib-id': "9969113523506421" }
     )
-
-    rendered = render_inline(described_class.new(document:))
-
+    allow(document).to receive(:[]).with("electronic_access_1display").and_return(nil)
+    allow(component).to receive(:action_name).and_return(action)
+    rendered = render_inline(component)
     expect(rendered.css('div.document-thumbnail > div.default')).not_to be_empty
+  end
+end
+
+RSpec.describe ThumbnailComponent, type: :component, thumbnails: true do
+  let(:document) { instance_double(SolrDocument) }
+  let(:component) { described_class.new(document:) }
+
+  context "when rendering a thumbnail in the search results page" do
+    before do
+      allow(component).to receive(:action_name).and_return('index')
+    end
+
+    it "an ephemera document thumbnail does not have a viewer link or a tag viewer-container" do
+      allow(document).to receive(:uuid?).and_return(true)
+      allow(document).to receive(:[]).with("thumbnail_display").and_return("/thumb.jpg")
+      allow(document).to receive(:[]).with("id").and_return("123")
+      allow(document).to receive(:in_a_special_collection?).and_return(false)
+      allow(document).to receive(:identifier_data).and_return({ oclc: ["40810988"], 'bib-id': "123" })
+
+      rendered = render_inline(component)
+      expect(rendered.css('img').attribute('src').to_s).to eq('/thumb.jpg')
+      expect(rendered.css('a').length).to eq 0
+      expect(rendered.css('span.visually-hidden').length).to eq 0
+      expect(rendered.css('.has-viewer-link').length).to eq 0
+    end
+  end
+  context "when rendering a thumbnail in the record page" do
+    before do
+      allow(component).to receive(:action_name).and_return('show')
+    end
+    it "an ephemera document thumbnail has a viewer link and a tag viewer-container" do
+      allow(document).to receive(:uuid?).and_return(true)
+      allow(document).to receive(:[]).with("thumbnail_display").and_return("/thumb.jpg")
+      allow(document).to receive(:[]).with("id").and_return("123")
+      allow(document).to receive(:in_a_special_collection?).and_return(false)
+      allow(document).to receive(:identifier_data).and_return({ oclc: ["40810988"], 'bib-id': "123" })
+
+      rendered = render_inline(component)
+      expect(rendered.css('.document-thumbnail.has-viewer-link').attribute('data-bib-id').to_s).to eq('123')
+      expect(rendered.css('img').attribute('src').to_s).to eq('/thumb.jpg')
+      expect(rendered.css('span.visually-hidden').text).to eq('Go to viewer')
+      expect(rendered.css('a').attribute('href').to_s).to eq('#viewer-container')
+    end
+  end
+
+  context "other cases when rendering a thumbnail in the search results page" do
+    it_behaves_like "thumbnail identifier checks", 'index'
+  end
+  context "other cases when rendering a thumbnail in the record page" do
+    it_behaves_like "thumbnail identifier checks", 'show'
   end
 end

--- a/spec/javascript/orangelight/figgy_manifest_manager.spec.js
+++ b/spec/javascript/orangelight/figgy_manifest_manager.spec.js
@@ -1,7 +1,38 @@
 import {
   FiggyViewer,
   FiggyViewerSet,
+  isRecordPagePath,
+  wrapWithViewerLink,
 } from '../../../app/javascript/orangelight/figgy_manifest_manager';
+describe('isRecordPagePath', () => {
+  it('returns true when on record page', () => {
+    const origin = 'http://localhost';
+    delete window.location;
+    window.location = { origin, pathname: '/catalog/998873506421' };
+    expect(isRecordPagePath()).toBe(true);
+  });
+
+  it('returns false on search results page', () => {
+    const origin = 'http://localhost';
+    delete window.location;
+    window.location = {
+      origin,
+      pathname: '/catalog?search_field=all_fields&q=test',
+    };
+    expect(isRecordPagePath()).toBe(false);
+  });
+});
+
+describe('wrapWithViewerLink', () => {
+  it('wraps element with viewer link and adds accessibility span', () => {
+    const $element = window.jQuery('<div></div>');
+    wrapWithViewerLink($element);
+    expect($element.hasClass('has-viewer-link')).toBe(true);
+    expect($element.parent('a').attr('href')).toBe('#viewer-container');
+    expect($element.find('span.visually-hidden').length).toBe(1);
+    expect($element.find('span.visually-hidden').text()).toBe('Go to viewer');
+  });
+});
 
 describe('RelatedRecords', function () {
   afterEach(vi.clearAllMocks);


### PR DESCRIPTION
1. Don't create a pointer on a search results thumbnail
2. Render one partial for the search results thumbnail and one partial for the record page.
3. Address different dom structure in the show and index page
4. Address different dom structure if it's a default-thumbnail,
5. if it's a thumbnail from an ephemera resource - it has digital content
6. if it's a thumbnail from a figgy resource - it has digital content

related to #5217