### PR TITLE
[#5224] handle ILLiad empty responses

### DIFF
--- a/app/models/requests/illiad_patron.rb
+++ b/app/models/requests/illiad_patron.rb
@@ -23,7 +23,7 @@ module Requests
       return nil if patron.blank?
 
       patron_response = post_json_response(url: 'ILLiadWebPlatform/Users', body: attributes.to_json)
-      patron_response = illiad_patron if patron_response.blank? && error.dig("ModelState", "UserName") == ["Username #{netid} already exists."]
+      patron_response = illiad_patron if patron_response.blank? && error&.dig("ModelState", "UserName") == ["Username #{netid} already exists."]
       patron_response
     end
 

--- a/spec/models/requests/illiad_patron_spec.rb
+++ b/spec/models/requests/illiad_patron_spec.rb
@@ -136,4 +136,13 @@ describe Requests::IlliadPatron, type: :controller, requests: true, patrons: tru
       expect(illiad_patron.attributes).to eq({})
     end
   end
+
+  context 'ILLiad is down' do
+    it 'create_illiad_patron is empty' do
+      stub_request(:post, "#{illiad_patron.illiad_api_base}/ILLiadWebPlatform/Users")
+        .to_timeout
+      patron = illiad_patron.create_illiad_patron
+      expect(patron).to be_blank
+    end
+  end
 end


### PR DESCRIPTION
When a patron submits an ILL request and ILLiad is down, the following behavior happens on this branch:

- The user gets a message near the "Request this item" button: "There was a problem with this request which Library staff need to investigate. You’ll be notified once it’s resolved and requested for you."
- An email is sent to recap problems

closes #5224 