### PR TITLE
Don't send the "does not support file uploads" error to honeybadger

### DIFF
--- a/config/honeybadger.yml
+++ b/config/honeybadger.yml
@@ -10,3 +10,4 @@ exceptions:
     - 'RedisClient::ReadTimeoutError'
     - 'RSolr::Error::ConnectionRefused'
     - 'SignalException'
+    - !ruby/regexp '/Sorry, the catalog does not support file uploads/i'


### PR DESCRIPTION
This is expected behavior as of https://github.com/pulibrary/orangelight/pull/5128, so there is no need to add it to honeybadger.