### PR TITLE
Update logic of building pickup locations

### DIFF
--- a/app/models/concerns/requests/bibdata.rb
+++ b/app/models/concerns/requests/bibdata.rb
@@ -49,7 +49,11 @@ module Requests
       Requests::BibdataService.delivery_locations.each_value do |pick_up|
         pick_up_locations << { label: pick_up["label"], gfa_pickup: pick_up["gfa_pickup"], pick_up_location_code: pick_up["library"]["code"] || 'firestone', staff_only: pick_up["staff_only"] } if pick_up["pickup_location"] == true
       end
-      Requests::Location.sort_pick_up_locations(pick_up_locations)
+      # Filter pickup locations based on this location's code:
+      # - When code is 'firestone$pf', only include PF locations
+      # - All other locations, exclude PF locations
+      filtered_locations = Requests::Location.filter_pick_up_locations_by_code(pick_up_locations, location_code)
+      Requests::Location.sort_pick_up_locations(filtered_locations)
     end
 
     # get the location contact email from thr delivery locations via the library code

--- a/app/views/requests/request_mailer/_item_info.html.erb
+++ b/app/views/requests/request_mailer/_item_info.html.erb
@@ -11,9 +11,13 @@
           <td valign="top" class="responsive-column-container-all">
             <div style="font-weight:normal;font-size:12px;">
               <% if key == "pick_up" %>Pick-up<% else %><%= format_label(key) %><% end %></div>
-            <span style="margin-bottom:0;"
-              class="large-print"><% if key == "pick_up" %><%= Requests::BibdataService.delivery_locations[value]['label'].html_safe %>,<% end %>
-              <%= value.html_safe %></span>
+            <span style="margin-bottom:0;" class="large-print">
+              <% if key == "pick_up" %>
+                <%= Requests::BibdataService.delivery_locations[value]['label'].html_safe %>
+              <% else %>
+                <%= value %>
+              <% end %>
+            </span>
           </td>
           <% end %>
           <% end %>


### PR DESCRIPTION
Illiad eligible items should be picked up from Firestone Library with gfa_pickup of PA
Before soring default_pick_ups filter them based on the location code: If it's firestone$pf use delivery location gfa_pickup for any other location including firestone (not$pf) reject delivery location with gfa_pickup PF

related to #5234