### PR TITLE
Improve performance of online_holding_note?

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -722,7 +722,7 @@ detectors:
     - Orangelight::ProcessVocabularyComponent#build_search_subject_links
     - BookmarksController#csv_bom
     - BookmarksController#two_values
-    - Orangelight::Catalog#online_holding_note?
+    - Orangelight::Catalog#show_location_has?
     - ApplicationHelper#action_notes_display
     - ApplicationHelper#html_safe
     - ApplicationHelper#location_has
@@ -768,7 +768,7 @@ detectors:
     - ApplicationController#referrer_from_url
     - BookmarksController#csv_bom
     - BookmarksController#two_values
-    - Orangelight::Catalog#online_holding_note?
+    - Orangelight::Catalog#show_location_has?
     - Orangelight::BrowsablesController#validate_rpp
     - Requests::FormController#sanitize
     - FeedbackForm#error_message

--- a/Gemfile
+++ b/Gemfile
@@ -91,6 +91,7 @@ gem 'yajl-ruby', '>= 1.3.1', require: 'yajl'
 gem 'yard'
 
 group :development do
+  gem 'benchmark-ips'
   gem 'capistrano', '~> 3.4', require: false
   gem 'capistrano-passenger'
   gem 'capistrano-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
     benchmark (0.4.1)
+    benchmark-ips (2.14.0)
     better_html (2.1.1)
       actionview (>= 6.0)
       activesupport (>= 6.0)
@@ -361,7 +362,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.12.2)
+    json (2.15.2)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -786,6 +787,7 @@ DEPENDENCIES
   axe-core-rspec
   babel-transpiler
   bcrypt_pbkdf
+  benchmark-ips
   blacklight (~> 8.8)
   blacklight-hierarchy
   blacklight-marc (~> 8.1)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -367,7 +367,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'summary_note_display', label: 'Summary note'
     config.add_show_field 'content_advice_display', label: 'Content advice'
     config.add_show_field 'notes_display', label: 'Notes'
-    config.add_show_field 'holdings_1display', label: 'Location has', if: :online_holding_note?, helper_method: :location_has
+    config.add_show_field 'holdings_1display', label: 'Location has', if: :show_location_has?, helper_method: :location_has
     config.add_show_field 'with_notes_display', label: 'With'
     config.add_show_field 'bibliographic_notes_display', label: 'Bibliographic history'
     config.add_show_field 'dissertation_notes_display', label: 'Dissertation note'

--- a/app/controllers/concerns/orangelight/catalog.rb
+++ b/app/controllers/concerns/orangelight/catalog.rb
@@ -67,9 +67,9 @@ module Orangelight
       return current_user.email if current_or_guest_user.cas_provider?
     end
 
-    def online_holding_note?(_field_config, document)
-      location_notes = JSON.parse(document[:holdings_1display] || '{}').collect { |_k, v| v['location_has'] }
-      document[:electronic_access_1display].present? && location_notes.any? && document[:location].blank?
+    def show_location_has?(_field_config, document)
+      any_location_notes = document.holdings_1display.any? { |_key, value| value[:location_has] }
+      document[:electronic_access_1display].present? && any_location_notes && document[:location].blank?
     end
 
     def linked_records

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -244,6 +244,10 @@ class SolrDocument
     (doc_electronic_access.length + electronic_portfolios.length).positive?
   end
 
+  def holdings_1display
+    @holdings_1display ||= JSON.parse(self[:holdings_1display] || '{}', symbolize_names: true)
+  end
+
   private
 
     def electronic_access_uris

--- a/benchmarks/app/controllers/concerns/orangelight/catalog.rb
+++ b/benchmarks/app/controllers/concerns/orangelight/catalog.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'benchmark/ips'
+require 'objspace'
+require_relative '../../../../../config/environment'
+
+fixture = JSON.parse(Rails.root.join('spec/fixtures/raw/9933643713506421_raw.json').read)
+document = SolrDocument.new(fixture)
+
+def print_allocations
+  GC.disable
+  objects_before = ObjectSpace.each_object.count
+  yield
+  objects_after = ObjectSpace.each_object.count
+  GC.enable
+  # rubocop:disable Rails/Output
+  puts "#{objects_after - objects_before} objects allocated"
+  # rubocop:enable Rails/Output
+end
+
+# rubocop:disable Style/MixinUsage
+include Orangelight::Catalog
+# rubocop:enable Style/MixinUsage
+
+Benchmark.ips do |benchmark|
+  benchmark.report { show_location_has?(nil, document) }
+end
+
+print_allocations { show_location_has?(nil, document) }

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -39,8 +39,8 @@ RSpec.describe CatalogController do
       expect(email).to be_nil
     end
   end
-  describe '#online_holding_note?' do
-    subject(:note) { described_class.new.online_holding_note?(nil, document) }
+  describe '#show_location_has?' do
+    subject(:note) { described_class.new.show_location_has?(nil, document) }
 
     let(:link) { 'field not blank' }
     let(:holdings) do
@@ -48,21 +48,21 @@ RSpec.describe CatalogController do
     end
 
     describe 'for document with link and holding note' do
-      let(:document) { { electronic_access_1display: link, holdings_1display: holdings } }
+      let(:document) { SolrDocument.new({ electronic_access_1display: link, holdings_1display: holdings }) }
 
       it 'returns true' do
         expect(note).to be true
       end
     end
     describe 'document with link missing holding note' do
-      let(:document) { { electronic_access_1display: link } }
+      let(:document) { SolrDocument.new({ electronic_access_1display: link }) }
 
       it 'returns false' do
         expect(note).to be false
       end
     end
     describe 'document missing link with holding note' do
-      let(:document) { { holdings_1display: holdings } }
+      let(:document) { SolrDocument.new({ holdings_1display: holdings }) }
 
       it 'returns false' do
         expect(note).to be false


### PR DESCRIPTION
* Rename method for clarity
* Memoize the parsed JSON so that it does not need to be parsed again for every field in the catalog controller (this is the main performance gain)
* Symbolize names to reduce memory allocations
* Use `any?` with a block, rather than `collect` then `any`, so we don't need to iterate through every holding if we get a match before that
* Check in a microbenchmark
* Upgrade the json gem to a newer version that has some performance optimizations

Microbenchmark before:
```
$ bundle exec ruby benchmarks/app/controllers/concerns/orangelight/catalog.rb
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
                        36.000 i/100ms
Calculating -------------------------------------
                        363.356 (± 1.4%) i/s    (2.75 ms/i) -      1.836k in   5.053892s
23428 objects allocated
```

Microbenchmark after:
```
Warming up --------------------------------------
                       374.839k i/100ms
Calculating -------------------------------------
                          3.749M (± 0.7%) i/s  (266.76 ns/i) -     18.742M in   4.999956s
2 objects allocated
```

* More iterations/second is good!
* Fewer allocations is good!

The user-visible effect is a slight increase in speed on the show page for titles with many holdings.  In my local dev setup, this method used to take ~10% of all time spent displaying the show page for the journal "Science".  With this commit, it takes ~1% of all time.