### PR TITLE
Remove duplicate method calls

### DIFF
--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -7,8 +7,8 @@
     <% physical_block = holding_block_search(document) -%>
     <% online_block = online_content_block(document) -%>
     <% if physical_block.present? || online_block.present? -%>
-      <%= holding_block_search(document) -%>
-      <%= online_content_block(document) -%>
+      <%= physical_block -%>
+      <%= online_block -%>
     <% else -%>
       <div><%= t('blacklight.holdings.search_missing') %></div>
     <% end -%>


### PR DESCRIPTION
The holding_block_search method is quite expensive.  There is no need to call it more than once.