### PR TITLE
Improve performance of in_a_special_collection? method

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -193,15 +193,12 @@ class SolrDocument
   end
 
   def in_a_special_collection?
-    holdings_1display = self['holdings_1display']
-    return true unless holdings_1display
+    return true if holdings_1display.blank?
 
-    JSON.parse(holdings_1display)
-        &.values
-        &.any? do |holding|
-          location_code = holding['location_code']
-          Bibdata.holding_locations.dig(location_code, 'aeon_location') if location_code
-        end
+    holdings_1display&.any? do |_holding_id, holding|
+      location_code = holding[:location_code]
+      holding_locations.dig(location_code, :aeon_location) if location_code
+    end
   end
 
   # host_id an Array of host id(s)
@@ -295,5 +292,9 @@ class SolrDocument
       params = { q: "id:#{RSolr.solr_escape(id)}" }
       solr_response = Blacklight.default_index.connection.get('select', params:)
       solr_response["response"]["docs"].first
+    end
+
+    def holding_locations
+      @holding_locations ||= Bibdata.holding_locations
     end
 end

--- a/benchmarks/app/models/solr_document.rb
+++ b/benchmarks/app/models/solr_document.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'benchmark/ips'
+require_relative '../../../config/environment'
+
+locations_hash = JSON.parse(Rails.root.join('spec/fixtures/bibdata/holding_locations.json').read).to_h do |location|
+  [location['code'], location.with_indifferent_access]
+end.with_indifferent_access
+Rails.cache.write('holding_locations', locations_hash)
+
+# This document represents the worst case: none of the holdings are at an aeon location
+fixture = JSON.parse(Rails.root.join('spec/fixtures/raw/993569343506421.json').read)
+document = SolrDocument.new(fixture)
+
+Benchmark.ips do |benchmark|
+  benchmark.report { document.in_a_special_collection? }
+end


### PR DESCRIPTION
* Use memoized holdings_1display, rather than reparsing it
* Memoize Bibdata.holding_locations, since it can be slow to read and parse it from the cache

Before:

```
$ bundle exec ruby benchmarks/app/models/solr_document.rb
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
                        14.000 i/100ms
Calculating -------------------------------------
                        140.216 (± 3.6%) i/s    (7.13 ms/i) -    714.000 in   5.097520s
```

After:

```
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
                        82.533k i/100ms
Calculating -------------------------------------
                        823.700k (± 0.9%) i/s    (1.21 μs/i) -      4.127M in   5.010307s
```