### PR TITLE
Remove unused CSS

### DIFF
--- a/app/assets/stylesheets/components/search-results.scss
+++ b/app/assets/stylesheets/components/search-results.scss
@@ -105,14 +105,6 @@ dd.blacklight-electronic_access_display {
   padding-left: 10px;
 }
 
-#spell {
-  padding: 0 15px;
-
-  h4 {
-    margin: 1em 0 0.5em 0;
-  }
-}
-
 em.highlight-query {
   background-color: #FFFDD0;
 }


### PR DESCRIPTION
We don't have Blacklight's spellcheck feature enabled, so we don't have an element with id `spell`.