### PR TITLE
Remove CSS for non-existant selector

### DIFF
--- a/app/assets/stylesheets/components/search.scss
+++ b/app/assets/stylesheets/components/search.scss
@@ -46,34 +46,6 @@ header .search-navbar .input-group .search-btn {
   }
 }
 
-#search-navbar .search_field {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  border-radius: 0;
-  background: $white;
-  padding: 7px 20px 7px 15px;
-  width: 100%;
-  cursor: pointer;
-  border: 1px solid #ccc;
-  outline: none;
-  font-size: 14px;
-  height: 34px;
-  -webkit-border-top-left-radius: 3px;
-  -webkit-border-bottom-left-radius: 3px;
-  -moz-border-radius-topleft: 3px;
-  -moz-border-radius-bottomleft: 3px;
-  border-top-left-radius: 3px;
-  border-bottom-left-radius: 3px;
-  height: 42px;
-  border-right: 0;
-
-  @media (max-width: $bp-small) {
-    border-radius: 3px;
-    border: 1px solid #ccc;
-  }
-}
-
 .search-widgets select {
   -webkit-appearance: none;
   -moz-appearance: none;


### PR DESCRIPTION
`#search_field` exists as an id, and `.search-field` (with a hyphen) exists as a class, but `.search_field` does not exist as a class.  We seem to be doing fine without this CSS matching anything, so let's remove it.