### PR TITLE
Retrieve patron data in its own Thread

### DIFF
--- a/app/models/requests/form.rb
+++ b/app/models/requests/form.rb
@@ -3,7 +3,7 @@
 module Requests
   # This class is responsible for assembling the data to display the Requests form
   class Form
-    attr_reader :system_id, :mfhd, :patron, :requestable, :requestable_unrouted, :holdings, :location, :location_code, :pick_ups
+    attr_reader :system_id, :mfhd, :requestable, :requestable_unrouted, :holdings, :location, :location_code, :pick_ups
     alias default_pick_ups pick_ups
     delegate :eligible_for_library_services?, to: :patron
     delegate :items, :too_many_items?, to: :requestables_list
@@ -13,14 +13,14 @@ module Requests
 
     # @option opts [String] :system_id A bib record id or a special collection ID value
     # @option opts [Fixnum] :mfhd alma holding id
-    # @option opts [Patron] :patron current Patron object
-    def initialize(system_id:, mfhd:, patron: nil)
+    # @option opts [Thread] :patron_request a Thread that will resolve to a Patron object when #value is called
+    def initialize(system_id:, mfhd:, patron_request: nil)
       @system_id = system_id
       @holdings = JSON.parse(doc[:holdings_1display] || '{}')
       # scsb items are the only ones that come in without a MFHD parameter from the catalog now
       # set it for them, because they only ever have one location
       @mfhd = mfhd || @holdings.keys.first
-      @patron = patron
+      @patron_request = patron_request
       @location_code = @holdings[@mfhd]["location_code"] if @holdings[@mfhd].present?
       @location = load_bibdata_location
       @pick_ups = build_pick_ups
@@ -76,7 +76,13 @@ module Requests
       @doc ||= SolrDocument.new(solr_doc(system_id))
     end
 
+    def patron
+      @patron ||= patron_request.value
+    end
+
     private
+
+      attr_reader :patron_request
 
       def load_bibdata_location
         return if location_code.blank?

--- a/spec/factories/requests/request.rb
+++ b/spec/factories/requests/request.rb
@@ -5,241 +5,241 @@ FactoryBot.define do
   factory :request_no_items, class: 'Requests::Form' do
     system_id { '9944928463506421' }
     mfhd { '22490610730006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   #  I think this is a problem record
   factory :request_on_order, class: 'Requests::Form' do
     system_id { '9939075533506421' }
     mfhd { '22675089420006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   factory :request_thesis, class: 'Requests::Form' do
     system_id { "dsp019c67wp402" }
     mfhd { 'thesis' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   factory :request_numismatics, class: 'Requests::Form' do
     system_id { "coin-1167" }
     mfhd { 'numismatics' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   factory :request_paging_available, class: 'Requests::Form' do
     system_id { '9960093633506421' }
     mfhd { '2272418840006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   factory :request_paging_available_barcode_patron, class: 'Requests::Form' do
     system_id { '9960093633506421' }
     mfhd { '2272418840006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   factory :request_paging_available_unauthenticated_patron, class: 'Requests::Form' do
     system_id { '9960093633506421' }
     mfhd { '2272418840006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   # missing item
   factory :request_missing_item, class: 'Requests::Form' do
     system_id { '9915486663506421' }
     mfhd { '22495908770006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   factory :request_on_shelf, class: 'Requests::Form' do
     system_id { '9912140633506421' }
     mfhd { '22722595360006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   factory :aeon_eal_alma_item, class: 'Requests::Form' do
     system_id { '9977213233506421' }
     mfhd { '22707739710006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   factory :aeon_w_barcode, class: 'Requests::Form' do
     system_id { '9995944353506421' }
     mfhd { '22500750240006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   factory :aeon_w_long_title, class: 'Requests::Form' do
     system_id { '9929908463506421' }
     mfhd { '22656754050006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   factory :aeon_no_item_record, class: 'Requests::Form' do
     system_id { '9925358453506421' }
     mfhd { '22615926030006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   factory :aeon_rbsc_alma_enumerated, class: 'Requests::Form' do
     system_id { '996160863506421' }
     mfhd_id { '22563389780006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, patron:, mfhd: mfhd_id) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, patron_request:, mfhd: mfhd_id) }
   end
 
   factory :aeon_rbsc_enumerated, class: 'Requests::Form' do
     system_id { '9967949663506421' }
     mfhd_id { '22677203260006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, patron:, mfhd: mfhd_id) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, patron_request:, mfhd: mfhd_id) }
   end
 
   factory :aeon_marquand, class: 'Requests::Form' do
     system_id { '9979153343506421' }
     mfhd_id { '22742463930006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, patron:, mfhd: mfhd_id) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, patron_request:, mfhd: mfhd_id) }
   end
 
   factory :aeon_mudd, class: 'Requests::Form' do
     system_id { '9960234393506421' }
     mfhd_id { '22524308350006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, patron:, mfhd: mfhd_id) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, patron_request:, mfhd: mfhd_id) }
   end
 
   factory :aeon_mudd_barcode_patron, class: 'Requests::Form' do
     system_id { '9960234393506421' }
     mfhd_id { '22524308350006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, patron:, mfhd: mfhd_id) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, patron_request:, mfhd: mfhd_id) }
   end
 
   factory :aeon_mudd_unauthenticated_patron, class: 'Requests::Form' do
     system_id { '9960234393506421' }
     mfhd_id { '22524308350006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, patron:, mfhd: mfhd_id) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, patron_request:, mfhd: mfhd_id) }
   end
 
   factory :missing_item, class: 'Requests::Form' do
     system_id { '9915486663506421' }
     mfhd_id { '22495908770006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, patron:, mfhd: mfhd_id) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, patron_request:, mfhd: mfhd_id) }
   end
 
   factory :request_with_items_charged, class: 'Requests::Form' do
     system_id { '9913891213506421' }
     mfhd_id { '22739043950006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, patron:, mfhd: mfhd_id) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, patron_request:, mfhd: mfhd_id) }
   end
 
   factory :request_with_items_charged_barcode_patron, class: 'Requests::Form' do
     system_id { '9913891213506421' }
     mfhd_id { '22739043950006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, patron:, mfhd: mfhd_id) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, patron_request:, mfhd: mfhd_id) }
   end
 
   factory :request_with_items_charged_unauthenticated_patron, class: 'Requests::Form' do
     system_id { '9913891213506421' }
     mfhd_id { '22739043950006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, patron:, mfhd: mfhd_id) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, patron_request:, mfhd: mfhd_id) }
   end
 
   factory :request_serial_with_item_on_hold, class: 'Requests::Form' do
     system_id { '9988406853506421' }
     mfhd_id { '22743233800006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, patron:, mfhd: mfhd_id) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, patron_request:, mfhd: mfhd_id) }
   end
 
   factory :request_aeon_holding_volume_note, class: 'Requests::Form' do
     system_id { '996160863506421' }
     mfhd { '22563389780006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   factory :request_scsb_cu, class: 'Requests::Form' do
     system_id { 'SCSB-5235419' }
     mfhd { nil }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   # use_statement: "In Library Use"
   factory :request_scsb_ar, class: 'Requests::Form' do
     system_id { 'SCSB-2650865' }
     mfhd { nil }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   factory :request_scsb_mr, class: 'Requests::Form' do
     system_id { 'SCSB-2901229' }
     mfhd { nil }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   factory :request_scsb_no_oclc, class: 'Requests::Form' do
     system_id { 'SCSB-5396104' }
     mfhd { nil }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   factory :mfhd_with_no_circ_and_circ_item, class: 'Requests::Form' do
     system_id { '992577173506421' }
     mfhd_id { '22591178060006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, patron:, mfhd: mfhd_id) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, patron_request:, mfhd: mfhd_id) }
   end
 
   factory :request_col_dev_office, class: 'Requests::Form' do
     system_id { '9911629773506421' }
     mfhd_id { '22608294270006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, patron:, mfhd: mfhd_id) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, patron_request:, mfhd: mfhd_id) }
   end
 
   factory :request_holdings_management, class: 'Requests::Form' do
     system_id { '9925798443506421' }
     mfhd_id { '22733278430006421' }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, patron:, mfhd: mfhd_id) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, patron_request:, mfhd: mfhd_id) }
   end
 
   factory :request_scsb_hl, class: 'Requests::Form' do
     system_id { 'SCSB-10966202' }
     mfhd { nil }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 
   factory :scsb_manuscript_multi_volume, class: 'Requests::Form' do
     system_id { 'SCSB-7874204' }
     mfhd { nil }
-    patron { FactoryBot.build(:patron) }
-    initialize_with { new(system_id:, mfhd:, patron:) }
+    patron_request { Thread.new { FactoryBot.build(:patron) } }
+    initialize_with { new(system_id:, mfhd:, patron_request:) }
   end
 end

--- a/spec/helpers/requests/application_helper_spec.rb
+++ b/spec/helpers/requests/application_helper_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
   let(:patron) do
     Requests::Patron.new(user:, patron_hash: valid_patron)
   end
+  let(:patron_request) { instance_double(Thread, value: patron) }
 
   describe '#submit_disabled' do
     let(:user) { FactoryBot.build(:user) }
@@ -20,7 +21,7 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
       {
         system_id: '9981794023506421',
         mfhd: '22591269990006421',
-        patron:
+        patron_request:
       }
     end
     let(:request_with_items_on_reserve) { Requests::Form.new(**params) }
@@ -37,7 +38,7 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
         {
           system_id: '9992220243506421',
           mfhd: '22558467250006421',
-          patron:
+          patron_request:
         }
       end
       it 'returns a boolean to enable submit for logged in user' do
@@ -56,7 +57,7 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
         {
           system_id: '9938488723506421',
           mfhd: '22522147400006421',
-          patron:
+          patron_request:
         }
       end
       it 'lewis is a submitable request' do
@@ -71,7 +72,7 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
       {
         system_id: '994916543506421',
         mfhd: '22724990930006421',
-        patron:
+        patron_request:
       }
     end
     let(:default_pick_ups) do
@@ -91,7 +92,7 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
       {
         system_id: '994264203506421',
         mfhd: '22697858020006421',
-        patron:
+        patron_request:
       }
     end
     let(:default_pick_ups) do
@@ -129,7 +130,7 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
       {
         system_id: '9973529363506421',
         mfhd: '22667098870006421',
-        patron:
+        patron_request:
       }
     end
     let(:aeon_only_request) { Requests::FormDecorator.new(Requests::Form.new(**params), nil, '/catalog/12345') }

--- a/spec/models/requests/form_no_vcr_spec.rb
+++ b/spec/models/requests/form_no_vcr_spec.rb
@@ -11,13 +11,14 @@ RSpec.describe Requests::Form, type: :model, requests: true do
   let(:patron) do
     Requests::Patron.new(user:, patron_hash: valid_patron)
   end
+  let(:patron_request) { Thread.new { patron } }
   context "with an object with a LOT of items" do
     let(:document_id) { '9933643713506421' }
     let(:params) do
       {
         system_id: document_id,
         mfhd: '22727480400006421',
-        patron:
+        patron_request:
       }
     end
     let(:request) { described_class.new(**params) }

--- a/spec/models/requests/form_spec.rb
+++ b/spec/models/requests/form_spec.rb
@@ -11,6 +11,10 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
   let(:patron) do
     Requests::Patron.new(user:, patron_hash: valid_patron)
   end
+  let(:patron_request) do
+    # Mocking Thread, because these tests deadlock if it is a real Thread
+    instance_double(Thread, value: patron)
+  end
 
   context "with a bad system_id" do
     let(:bad_system_id) { 'foo' }
@@ -18,7 +22,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: bad_system_id,
         mfhd: nil,
-        patron:
+        patron_request:
       }
     end
     let(:bad_request) { described_class.new(**params) }
@@ -42,7 +46,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9960102253506421',
         mfhd: '22548491940006421',
-        patron:
+        patron_request:
       }
     end
     let(:request_with_reserve_items) { described_class.new(**params) }
@@ -59,7 +63,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9988805493506421',
         mfhd: '22705318390006421',
-        patron:
+        patron_request:
       }
     end
     let(:request_with_holding_item) { described_class.new(**params) }
@@ -160,7 +164,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9917917633506421',
         mfhd: '22720740220006421',
-        patron:
+        patron_request:
       }
     end
     let(:request_with_only_holding) { described_class.new(**params) }
@@ -188,7 +192,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '994909303506421',
         mfhd: '22584686190006421',
-        patron:
+        patron_request:
       }
     end
 
@@ -216,7 +220,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9947589763506421',
         mfhd: '22656885190006421',
-        patron:
+        patron_request:
       }
     end
     let(:request_system_id_only_with_holdings) { described_class.new(**params) }
@@ -243,7 +247,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9924784993506421',
         mfhd: '22708132010006421',
-        patron:
+        patron_request:
       }
     end
     let(:request_system_id_only_with_holdings_with_some_items) { described_class.new(**params) }
@@ -270,7 +274,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9931805453506421',
         mfhd: '22705623210006421',
-        patron:
+        patron_request:
       }
     end
     let(:request_with_items_at_temp_locations) { described_class.new(**params) }
@@ -288,7 +292,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9961959423506421',
         mfhd: '22525427880006421',
-        patron:
+        patron_request:
       }
     end
     let(:request_with_items_at_temp_locations) { described_class.new(**params) }
@@ -308,7 +312,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9923858683506421',
         mfhd: nil,
-        patron:
+        patron_request:
       }
     end
     let(:request_with_only_system_id) { described_class.new(**params) }
@@ -325,7 +329,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9947595913506421',
         mfhd: '22489764810006421',
-        patron:
+        patron_request:
       }
     end
     let(:request_with_only_system_id) { described_class.new(**params) }
@@ -344,7 +348,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '99103251433506421',
         mfhd: '22480270140006421',
-        patron:
+        patron_request:
       }
     end
     let(:request_with_on_order) { described_class.new(**params) }
@@ -390,7 +394,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9920022063506421',
         mfhd: '22560993150006421',
-        patron:
+        patron_request:
       }
     end
     let(:request_with_missing) { described_class.new(**params) }
@@ -415,7 +419,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9996272613506421',
         mfhd: '22529639530006421',
-        patron:
+        patron_request:
       }
     end
     let(:request) { described_class.new(**params) }
@@ -436,7 +440,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9942430233506421',
         mfhd: '22600149340006421',
-        patron:
+        patron_request:
       }
     end
     let(:request_preservation) { described_class.new(**params) }
@@ -452,7 +456,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9917917633506421',
         mfhd: '22720740220006421',
-        patron:
+        patron_request:
       }
     end
     let(:request) { described_class.new(**params) }
@@ -476,7 +480,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
     let(:params) do
       {
         system_id: '996160863506421',
-        patron:,
+        patron_request:,
         mfhd: '22563389780006421'
       }
     end
@@ -502,7 +506,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9996764833506421',
         mfhd: '22680107620006421',
-        patron:
+        patron_request:
       }
     end
     let(:request) { described_class.new(**params) }
@@ -532,7 +536,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '994264203506421',
         mfhd: '22697842050006421',
-        patron:
+        patron_request:
       }
     end
     let(:request) { described_class.new(**params) }
@@ -559,7 +563,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9999074333506421',
         mfhd: '22578723910006421',
-        patron:
+        patron_request:
       }
     end
     let(:request) { described_class.new(**params) }
@@ -584,7 +588,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '994955013506421',
         mfhd: '22644665360006421',
-        patron:
+        patron_request:
       }
     end
     let(:request) { described_class.new(**params) }
@@ -600,7 +604,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9948152393506421',
         mfhd: '22717671090006421',
-        patron:
+        patron_request:
       }
     end
     let(:request) { described_class.new(**params) }
@@ -616,7 +620,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '994952203506421',
         mfhd: '22644769680006421',
-        patron:
+        patron_request:
       }
     end
     let(:request) { described_class.new(**params) }
@@ -632,7 +636,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9974943583506421',
         mfhd: '22711798720006421',
-        patron:
+        patron_request:
       }
     end
     let(:request) { described_class.new(**params) }
@@ -678,7 +682,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9925693243506421',
         mfhd: '22554332290006421',
-        patron:
+        patron_request:
       }
     end
     let(:request) { described_class.new(**params) }
@@ -694,7 +698,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '994955013506421',
         mfhd: '22644665360006421',
-        patron:
+        patron_request:
       }
     end
     let(:request) { described_class.new(**params) }
@@ -710,7 +714,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9919698813506421',
         mfhd: '22589919750006421',
-        patron:
+        patron_request:
       }
     end
     let(:request_with_optional_params) { described_class.new(**params) }
@@ -727,7 +731,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9997123553506421',
         mfhd: '22586693240006421',
-        patron:
+        patron_request:
       }
     end
     let(:request_for_preservation) { described_class.new(**params) }
@@ -743,7 +747,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: '9946931463506421',
         mfhd: '22715350280006421',
-        patron:
+        patron_request:
       }
     end
     let(:request_with_single_aeon_holding) { described_class.new(**params) }
@@ -755,7 +759,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: 'SCSB-5290772',
         mfhd: nil,
-        patron:
+        patron_request:
       }
     end
     let(:request_scsb) { described_class.new(**params) }
@@ -791,7 +795,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: 'SCSB-5640725',
         mfhd: nil,
-        patron:
+        patron_request:
       }
     end
     let(:request_scsb) { described_class.new(**params) }
@@ -822,7 +826,7 @@ describe Requests::Form, vcr: { cassette_name: 'form_models', record: :none }, r
       {
         system_id: 'SCSB-7935196',
         mfhd: nil,
-        patron:
+        patron_request:
       }
     end
     let(:request_scsb) { described_class.new(**params) }

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -11,9 +11,10 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
               email: "foo@princeton.edu", status: "staff", pustatus: "stf", universityid: "9999999", title: nil } }.with_indifferent_access
   end
   let(:patron) { Requests::Patron.new(user:, patron_hash: valid_patron) }
+  let(:patron_request) { instance_double(Thread, value: patron) }
 
   context "Is a bibliographic record on the shelf" do
-    let(:request) { FactoryBot.build(:request_on_shelf, patron:) }
+    let(:request) { FactoryBot.build(:request_on_shelf, patron_request:) }
     let(:requestable) { request.requestable.last }
     let(:mfhd_id) { requestable.holding.mfhd_id }
     let(:call_number) { CGI.escape(requestable.holding.holding_data['call_number']) }
@@ -61,7 +62,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
   end
 
   context 'A requestable item with a missing status' do
-    let(:request) { FactoryBot.build(:request_missing_item, patron:) }
+    let(:request) { FactoryBot.build(:request_missing_item, patron_request:) }
     let(:requestable) { request.requestable }
     describe "#services" do
       it "returns an item status of missing" do
@@ -100,7 +101,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
   end
 
   context 'A requestable item with hold_request status' do
-    let(:request) { FactoryBot.build(:request_serial_with_item_on_hold, patron:) }
+    let(:request) { FactoryBot.build(:request_serial_with_item_on_hold, patron_request:) }
     let(:requestable_on_hold) { request.requestable[0] }
 
     describe '#services' do
@@ -135,7 +136,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
   end
 
   context 'A non circulating item' do
-    let(:request) { FactoryBot.build(:mfhd_with_no_circ_and_circ_item, patron:) }
+    let(:request) { FactoryBot.build(:mfhd_with_no_circ_and_circ_item, patron_request:) }
     let(:requestable) { request.requestable[12] }
     let(:no_circ_item_id) { requestable.item['id'] }
     let(:no_circ_item_type) { requestable.item['item_type'] }
@@ -153,7 +154,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
     end
   end
   context 'A circulating item' do
-    let(:request) { FactoryBot.build(:mfhd_with_no_circ_and_circ_item, patron:) }
+    let(:request) { FactoryBot.build(:mfhd_with_no_circ_and_circ_item, patron_request:) }
     let(:requestable) { request.requestable[0] }
     let(:no_circ_item_id) { requestable.item['id'] }
     let(:no_circ_item_type) { requestable.item['item_type'] }
@@ -192,7 +193,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
   end
 
   context 'A requestable item from an Aeon EAL Holding with a nil barcode' do
-    let(:request) { FactoryBot.build(:aeon_eal_alma_item, patron:) }
+    let(:request) { FactoryBot.build(:aeon_eal_alma_item, patron_request:) }
     let(:requestable) { request.requestable.first } # assume only one requestable
 
     describe '#services' do
@@ -233,7 +234,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
   end
 
   context 'A requestable serial item that has volume and item data in its openurl' do
-    let(:request) { FactoryBot.build(:aeon_rbsc_enumerated, patron:) }
+    let(:request) { FactoryBot.build(:aeon_rbsc_enumerated, patron_request:) }
     let(:requestable_holding) { request.requestable.select { |r| r.holding.mfhd_id == '22677203260006421' } }
     let(:requestable) { requestable_holding.first } # assume only one requestable
 
@@ -263,7 +264,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
   end
 
   context 'A requestable item from an Aeon EAL Holding with a nil barcode' do
-    let(:request) { FactoryBot.build(:aeon_rbsc_alma_enumerated, patron:) }
+    let(:request) { FactoryBot.build(:aeon_rbsc_alma_enumerated, patron_request:) }
     let(:requestable_holding) { request.requestable.select { |r| r.holding.mfhd_id == '22563389780006421' } }
     let(:holding_id) { '22256352610006421' }
     let(:requestable) { requestable_holding.first } # assume only one requestable
@@ -295,7 +296,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
   end
 
   context 'A requestable item from a RBSC holding without an item record' do
-    let(:request) { FactoryBot.build(:aeon_no_item_record, patron:) }
+    let(:request) { FactoryBot.build(:aeon_no_item_record, patron_request:) }
     let(:requestable) { request.requestable.first } # assume only one requestable
     describe '#barcode?' do
       it 'does not have a barcode' do
@@ -347,7 +348,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
   end
 
   context 'A Recap Marquand holding' do
-    let(:request) { FactoryBot.build(:aeon_marquand, patron:) }
+    let(:request) { FactoryBot.build(:aeon_marquand, patron_request:) }
     let(:requestable) { request.requestable.first } # assume only one requestable
 
     describe '#site' do
@@ -456,7 +457,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
   end
 
   context 'A requestable item from a RBSC holding with an item record including a barcode' do
-    let(:request) { FactoryBot.build(:aeon_w_barcode, patron:) }
+    let(:request) { FactoryBot.build(:aeon_w_barcode, patron_request:) }
     let(:requestable) { request.requestable.first } # assume only one requestable
     describe '#barcode?' do
       it 'has a barcode' do
@@ -515,7 +516,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
   end
 
   context 'A requestable item from Forrestal Annex with no item data' do
-    let(:request) { FactoryBot.build(:request_no_items, patron:) }
+    let(:request) { FactoryBot.build(:request_no_items, patron_request:) }
     let(:requestable) { request.requestable.first }
 
     describe 'requestable with no items ' do
@@ -556,7 +557,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
   end
 
   context 'On Order materials' do
-    let(:request) { FactoryBot.build(:request_on_order, patron:) }
+    let(:request) { FactoryBot.build(:request_on_order, patron_request:) }
     let(:requestable) { request.requestable.last } # serial records on order at the end
 
     describe 'with a status of on_order ' do
@@ -603,7 +604,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
       {
         system_id: '9999998003506421',
         mfhd: '22480198860006421',
-        patron:
+        patron_request:
       }
     end
     let(:request) { Requests::Form.new(**params) }
@@ -669,7 +670,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
       {
         system_id: '9999998003506421',
         mfhd: '22480198860006421',
-        patron:
+        patron_request:
       }
     end
     let(:request) { Requests::Form.new(**params) }
@@ -730,7 +731,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
       {
         system_id: '9999998003506421',
         mfhd: '22480198860006421',
-        patron:
+        patron_request:
       }
     end
     let(:request) { Requests::Form.new(**params) }
@@ -868,7 +869,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
   end
 
   context 'An Item being shared with another institution' do
-    let(:request) { Requests::Form.new(system_id: '9977664533506421', mfhd: '22109013720006421', patron:) }
+    let(:request) { Requests::Form.new(system_id: '9977664533506421', mfhd: '22109013720006421', patron_request:) }
     let(:requestable) { request.requestable.first }
 
     before do
@@ -914,7 +915,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
   end
 
   context 'A Record in the Collection Development Office process type' do
-    let(:request) { FactoryBot.build(:request_col_dev_office, patron:) }
+    let(:request) { FactoryBot.build(:request_col_dev_office, patron_request:) }
     let(:requestable) { request.requestable.first }
     before do
       stub_catalog_raw(bib_id: '9911629773506421', type: 'alma')
@@ -933,7 +934,7 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
   end
 
   context 'A Record in the Holdings Managment process type' do
-    let(:request) { FactoryBot.build(:request_holdings_management, patron:) }
+    let(:request) { FactoryBot.build(:request_holdings_management, patron_request:) }
     let(:requestable) { request.requestable.first }
     before do
       stub_catalog_raw(bib_id: '9925798443506421', type: 'alma')

--- a/spec/models/requests/router_spec.rb
+++ b/spec/models/requests/router_spec.rb
@@ -8,6 +8,7 @@ describe Requests::Router, vcr: { cassette_name: 'requests_router', record: :non
     let(:patron) do
       Requests::Patron.new(user:, patron_hash: valid_patron)
     end
+    let(:patron_request) { Thread.new { patron } }
 
     let(:scsb_single_holding_item) { file_fixture('../SCSB-2635660.json') }
     let(:location_code) { 'scsbcul' }
@@ -15,7 +16,7 @@ describe Requests::Router, vcr: { cassette_name: 'requests_router', record: :non
       {
         system_id: 'SCSB-2635660',
         mfhd: nil,
-        patron:
+        patron_request:
       }
     end
     let(:scsb_availability_params) do


### PR DESCRIPTION
For request forms with a single item, the performance bottleneck is waiting for the patron information from Bibdata (typically 500-1500ms).

This commit places the Bibdata patron request into its own Thread, so that we can do other work to construct the form while we wait for the patron data.

In my local dev setup, the median amount of time taken to load the Requests form is 300 ms faster on this branch than main.