### PR TITLE
Use Webmock, rather than VCR, for one context of requestables test

### DIFF
--- a/spec/cassettes/requestable.yml
+++ b/spec/cassettes/requestable.yml
@@ -2181,59 +2181,6 @@ http_interactions:
   recorded_at: Fri, 06 Aug 2021 12:12:00 GMT
 - request:
     method: get
-    uri: https://bibdata-staging.lib.princeton.edu/bibliographic/9995944353506421/holdings/22500750240006421/availability.json
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - Faraday v1.5.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Server:
-      - nginx/1.19.10
-      Date:
-      - Fri, 06 Aug 2021 12:12:06 GMT
-      Content-Type:
-      - application/json; charset=utf-8
-      Transfer-Encoding:
-      - chunked
-      Connection:
-      - keep-alive
-      Status:
-      - 200 OK
-      Access-Control-Allow-Headers:
-      - Origin, Content-Type, Accept, Authorization, Token
-      Cache-Control:
-      - max-age=0, private, must-revalidate
-      Access-Control-Allow-Origin:
-      - "*"
-      Etag:
-      - W/"4e4b67b902eaa78eeb8ee68d316f1fab"
-      X-Runtime:
-      - '6.148800'
-      Access-Control-Request-Method:
-      - GET
-      X-Request-Id:
-      - fc74dcc7-3bc7-4a87-b2b4-65dad3c14525
-      X-Powered-By:
-      - Phusion Passenger(R) 6.0.9
-    body:
-      encoding: UTF-8
-      string: '[{"barcode":"32101033923176","id":"23500750230006421","holding_id":"22500750240006421","copy_number":"1","status":"Available","status_label":"Item
-        in place","status_source":"base_status","process_type":null,"on_reserve":"N","item_type":"Closed","pickup_location_id":"rare","pickup_location_code":"rare","location":"rare$xr","label":"Special
-        Collections - Remote Storage (ReCAP): Rare Books. Special Collections Use
-        Only","description":"","enum_display":"","chron_display":"","in_temp_library":false}]'
-  recorded_at: Fri, 06 Aug 2021 12:12:06 GMT
-- request:
-    method: get
     uri: https://catalog.princeton.edu/catalog/9944928463506421/raw
     body:
       encoding: US-ASCII

--- a/spec/fixtures/availability/by_holding_id/9995944353506421_22500750240006421.json
+++ b/spec/fixtures/availability/by_holding_id/9995944353506421_22500750240006421.json
@@ -1,0 +1,22 @@
+[
+    {
+        "barcode": "32101033923176",
+        "id": "23500750230006421",
+        "holding_id": "22500750240006421",
+        "copy_number": "1",
+        "status": "Available",
+        "status_label": "Item in place",
+        "status_source": "base_status",
+        "process_type": null,
+        "on_reserve": "N",
+        "item_type": "Closed",
+        "pickup_location_id": "rare",
+        "pickup_location_code": "rare",
+        "location": "rare$xr",
+        "label": "Special Collections - Remote Storage (ReCAP): Rare Books. Special Collections Use Only",
+        "description": "",
+        "enum_display": "",
+        "chron_display": "",
+        "in_temp_library": false
+    }
+]

--- a/spec/fixtures/holding_locations/rare_xr.json
+++ b/spec/fixtures/holding_locations/rare_xr.json
@@ -1,0 +1,39 @@
+{
+    "label": "Remote Storage (ReCAP): Rare Books. Special Collections Use Only",
+    "code": "rare$xr",
+    "aeon_location": true,
+    "recap_electronic_delivery_location": false,
+    "open": false,
+    "requestable": true,
+    "always_requestable": true,
+    "circulates": false,
+    "remote_storage": "recap_rmt",
+    "fulfillment_unit": "Closed",
+    "library": {
+        "label": "Special Collections",
+        "code": "rare",
+        "order": 0
+    },
+    "holding_library": {
+        "label": "Special Collections",
+        "code": "rare",
+        "order": 0
+    },
+    "delivery_locations": [
+        {
+            "label": "Special Collections",
+            "address": "One Washington Rd. Princeton, NJ 08544",
+            "phone_number": "609-258-1470",
+            "contact_email": "rbsc@princeton.edu",
+            "gfa_pickup": "PG",
+            "staff_only": false,
+            "pickup_location": false,
+            "digital_location": true,
+            "library": {
+                "label": "Firestone Library",
+                "code": "firestone",
+                "order": 0
+            }
+        }
+    ]
+}

--- a/spec/fixtures/raw/9995944353506421.json
+++ b/spec/fixtures/raw/9995944353506421.json
@@ -1,0 +1,152 @@
+{
+    "id": "9995944353506421",
+    "numeric_id_b": true,
+    "author_display": [
+        "Mayer, Bernadette"
+    ],
+    "author_citation_display": [
+        "Mayer, Bernadette",
+        "Station Hill Press",
+        "Granary Books Language Writing Collection (Princeton University)"
+    ],
+    "author_roles_1display": "{\"secondary_authors\":[\"Station Hill Press\",\"Granary Books Language Writing Collection (Princeton University)\"],\"translators\":[],\"editors\":[],\"compilers\":[],\"primary_author\":\"Mayer, Bernadette\"}",
+    "author_s": [
+        "Mayer, Bernadette",
+        "Station Hill Press",
+        "Granary Books Language Writing Collection (Princeton University)"
+    ],
+    "marc_relator_display": [
+        "Author"
+    ],
+    "uniform_title_s": [
+        "Poems. Selections"
+    ],
+    "title_display": "Eating the colors of a lineup of words : the early books of Bernadette Mayer / Bernadette Mayer.",
+    "title_t": [
+        "Eating the colors of a lineup of words : the early books of Bernadette Mayer / Bernadette Mayer."
+    ],
+    "title_citation_display": [
+        "Eating the colors of a lineup of words : the early books of Bernadette Mayer"
+    ],
+    "compiled_created_t": [
+        "Eating the colors of a lineup of words : the early books of Bernadette Mayer / Bernadette Mayer."
+    ],
+    "pub_created_display": [
+        "Barrytown, NY : Station Hill Press, [2015]",
+        "©2015."
+    ],
+    "pub_created_s": [
+        "Barrytown, NY : Station Hill Press, [2015]",
+        "©2015."
+    ],
+    "pub_citation_display": [
+        "Barrytown, NY: Station Hill Press"
+    ],
+    "publication_location_citation_display": [
+        "Barrytown, NY"
+    ],
+    "publisher_citation_display": [
+        "Station Hill Press"
+    ],
+    "pub_date_display": [
+        "2015"
+    ],
+    "pub_date_start_sort": 2015,
+    "pub_date_end_sort": 2015,
+    "publication_date_citation_display": [
+        "2015"
+    ],
+    "cataloged_tdt": "2016-03-31T00:00:00Z",
+    "format": [
+        "Book"
+    ],
+    "description_display": [
+        "450 pages : illustrations ; 26 cm."
+    ],
+    "description_t": [
+        "450 pages : illustrations ; 26 cm."
+    ],
+    "number_of_pages_citation_display": [
+        "450 pages"
+    ],
+    "series_display": [
+        "SHP archive editions."
+    ],
+    "notes_display": [
+        "Princeton copy 1 Mayer's thumbprint on title page.",
+        "Princeton copy 1 TLS from Sam Truitt to Steve [Clay] laid in."
+    ],
+    "language_name_display": [
+        "English"
+    ],
+    "language_facet": [
+        "English"
+    ],
+    "language_iana_s": [
+        "en"
+    ],
+    "mult_languages_iana_s": [
+        "en"
+    ],
+    "source_acquisition_display": [
+        "Princeton copy 1 Purchased 2014; Granary Books, Inc. 168 Mercer Street, New York, NY 10012 USA."
+    ],
+    "subject_facet": [
+        "Poetry"
+    ],
+    "lcgft_s": [
+        "Poetry"
+    ],
+    "lcgft_genre_facet": [
+        "Poetry"
+    ],
+    "related_name_json_1display": "{\"Related name\":[\"Station Hill Press\",\"Granary Books Language Writing Collection (Princeton University)\"]}",
+    "isbn_display": [
+        "9781581771350",
+        "1581771355"
+    ],
+    "lccn_display": [
+        "  2014017761"
+    ],
+    "lccn_s": [
+        "2014017761"
+    ],
+    "isbn_s": [
+        "9781581771350"
+    ],
+    "oclc_s": [
+        "876671268"
+    ],
+    "other_version_s": [
+        "9781581771350",
+        "ocn876671268"
+    ],
+    "holdings_1display": "{\"22500750240006421\":{\"location_code\":\"rare$xr\",\"location\":\"Remote Storage (ReCAP): Rare Books. Special Collections Use Only\",\"library\":\"Special Collections\",\"call_number\":\"RECAP-33923176\",\"call_number_browse\":\"RECAP-33923176\",\"items\":[{\"holding_id\":\"22500750240006421\",\"id\":\"23500750230006421\",\"status_at_load\":\"1\",\"barcode\":\"32101033923176\",\"copy_number\":\"1\"}]}}",
+    "location_code_s": [
+        "rare$xr"
+    ],
+    "location": [
+        "Special Collections"
+    ],
+    "location_display": [
+        "Remote Storage (ReCAP): Rare Books. Special Collections Use Only"
+    ],
+    "advanced_location_s": [
+        "rare$xr",
+        "Special Collections"
+    ],
+    "name_uniform_title_1display": "[[\"Mayer, Bernadette.\",\"Poems.\",\"Selections.\"]]",
+    "name_title_browse_s": [
+        "Mayer, Bernadette. Poems",
+        "Mayer, Bernadette. Poems. Selections"
+    ],
+    "call_number_display": [
+        "RECAP-33923176"
+    ],
+    "call_number_browse_s": [
+        "RECAP-33923176"
+    ],
+    "call_number_locator_display": [
+        "RECAP-33923176"
+    ]
+}

--- a/spec/models/requests/requestable_spec.rb
+++ b/spec/models/requests/requestable_spec.rb
@@ -459,6 +459,13 @@ describe Requests::Requestable, vcr: { cassette_name: 'requestable', record: :no
   context 'A requestable item from a RBSC holding with an item record including a barcode' do
     let(:request) { FactoryBot.build(:aeon_w_barcode, patron_request:) }
     let(:requestable) { request.requestable.first } # assume only one requestable
+    before do
+      stub_catalog_raw bib_id: '9995944353506421'
+      stub_single_holding_location 'rare$xr'
+      stub_delivery_locations
+      stub_availability_by_holding_id bib_id: '9995944353506421', holding_id: '22500750240006421'
+      stub_scsb_availability bib_id: '9995944353506421', institution_id: 'PUL', barcode: '32101033923176'
+    end
     describe '#barcode?' do
       it 'has a barcode' do
         expect(requestable.barcode?).to be true


### PR DESCRIPTION
With VCR's requestable cassette_name enabled, these tests were making real, unmocked calls to SCSB.  To confirm:
1. Without this commit, open sniffnet or wireshark
2. Set up your filters to watch for outgoing traffic on port 9093
3. Run `bundle exec rspec spec/models/requests/requestable_spec.rb`
4. Note that we made 22 outgoing requests!

With this commit, it only makes 13 outgoing requests on port 9093.