### PR TITLE
Make announcement selector more specific so that the announcement doesn't get margins on the top and bottom

### DIFF
--- a/app/assets/stylesheets/shame.scss
+++ b/app/assets/stylesheets/shame.scss
@@ -2,7 +2,7 @@
 
 @import "variables/colors";
 
-.announcement {
+.alert.announcement {
   border-left: 4px solid #E0CB52;
   z-index: 1;
   margin: 0;


### PR DESCRIPTION
Fixes a regression introduced by #5289