### PR TITLE
[#5266] Address empty author and unusual pub date in requests form metadata display

### DIFF
--- a/app/components/requests/metadata_field_component.rb
+++ b/app/components/requests/metadata_field_component.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# This component is responsible for displaying metadata fields and values that are appropriate for
+# the Requests form
+class Requests::MetadataFieldComponent < Blacklight::MetadataFieldComponent
+  def render?
+    field.values.present? && !ridiculous_date?
+  end
+
+  private
+
+    attr_reader :field
+
+    def ridiculous_date?
+      field.key == 'pub_date_display' && field.values.any? { it.to_i > 5000 }
+    end
+end

--- a/app/views/requests/form/_show_basic_metadata.html.erb
+++ b/app/views/requests/form/_show_basic_metadata.html.erb
@@ -1,9 +1,10 @@
-
-<% doc_presenter = document_presenter(document) %>
 <dl class="dl-horizontal  dl-invert top-fields">
-  <% Requests.config["short_record_display"].each do |field_key, field_label| %>
-    <%# https://github.com/projectblacklight/blacklight/blob/main/lib/blacklight/configuration/field.rb %>
-    <% field_presenter = Blacklight::FieldPresenter.new(doc_presenter.view_context, document, Blacklight::Configuration::Field.new(field: field_key, label: field_label).normalize!) %>
-    <%= render(AlwaysShowMetadataFieldComponent.new(field: field_presenter, show: true)) %>
+  <% field_presenters = Requests.config["short_record_display"].map do |field_key, field_label|
+    # https://github.com/projectblacklight/blacklight/blob/main/lib/blacklight/configuration/field.rb
+     field_config = Blacklight::Configuration::Field.new(field: field_key, key: field_key, label: field_label, if: true, unless: false)
+     field_presenter = Blacklight::FieldPresenter.new(controller.view_context, document, field_config)
+  end %>
+  <% field_presenters.each do |field_presenter| %>
+    <%= render(Requests::MetadataFieldComponent.new(field: field_presenter, show: true)) %>
   <% end %>
 </dl>

--- a/benchmarks/app/views/requests/form/_show_basic_metadata.rb
+++ b/benchmarks/app/views/requests/form/_show_basic_metadata.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'benchmark/ips'
+require_relative '../../../../../config/environment'
+
+fixture = JSON.parse(Rails.root.join('spec/fixtures/raw/993569343506421.json').read)
+document = SolrDocument.new(fixture)
+
+controller = Requests::FormController.new
+controller.action_name = 'form'
+controller.request = ActionDispatch::Request.empty
+view_context = controller.view_context
+
+Benchmark.ips do |benchmark|
+  benchmark.report do
+    view_context.render partial: 'show_basic_metadata', locals: { document: }
+  end
+end

--- a/spec/views/requests/request/_show_basic_metadata.html.erb_spec.rb
+++ b/spec/views/requests/request/_show_basic_metadata.html.erb_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'rails_helper'
+RSpec.describe '_show_basic_metadata partial', :requests do
+  let(:view_context) do
+    controller = Requests::FormController.new
+    controller.action_name = 'form'
+    controller.request = ActionDispatch::Request.empty
+    controller.view_context
+  end
+  it 'displays the date' do
+    document = SolrDocument.new pub_date_display: '1985'
+    rendered = view_context.render partial: 'show_basic_metadata', locals: { document: }
+    expect(rendered).to include '1985'
+  end
+  it 'does not display the date if it is 9999' do
+    document = SolrDocument.new pub_date_display: '9999'
+    rendered = view_context.render partial: 'show_basic_metadata', locals: { document: }
+    expect(rendered).not_to include '9999'
+  end
+  it 'displays the author' do
+    document = SolrDocument.new author_citation_display: ['Shoberg, Lore']
+    rendered = view_context.render partial: 'show_basic_metadata', locals: { document: }
+    expect(rendered).to include 'Author/Artist'
+    expect(rendered).to include 'Shoberg, Lore'
+  end
+  it 'does not display the author if no author is present' do
+    document = SolrDocument.new author_citation_display: []
+    rendered = view_context.render partial: 'show_basic_metadata', locals: { document: }
+    expect(rendered).not_to include 'Author/Artist'
+  end
+end


### PR DESCRIPTION
Closes #5266

Includes a modest performance improvement per the included benchmark:

Before:
```
$ be ruby benchmarks/app/views/requests/form/_show_basic_metadata.rb
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
                       420.000 i/100ms
Calculating -------------------------------------
                          4.554k (± 2.3%) i/s  (219.58 μs/i) -     23.100k in   5.075193s
```

After:
```
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
                       494.000 i/100ms
Calculating -------------------------------------
                          4.999k (± 4.1%) i/s  (200.02 μs/i) -     25.194k in   5.048394s
```