### PR TITLE
Simplify Requestable constructor a little

### DIFF
--- a/app/models/requests/requestable.rb
+++ b/app/models/requests/requestable.rb
@@ -5,7 +5,7 @@ module Requests
   class Requestable
     attr_reader :bib, :holding, :item, :location, :call_number, :title, :patron, :services
 
-    delegate :illiad_request_url, :illiad_request_parameters, to: :@illiad
+    delegate :illiad_request_url, :illiad_request_parameters, to: :illiad
     delegate :eligible_for_library_services?, to: :@patron
 
     include Requests::Aeon
@@ -24,7 +24,6 @@ module Requests
       @patron = patron
       @call_number = @holding.holding_data['call_number_browse']
       @title = bib[:title_citation_display]&.first
-      @illiad = Requests::Illiad.new(enum: item&.fetch(:enum, nil), chron: item&.fetch(:chron, nil), call_number:)
     end
 
     delegate :pick_up_location_code, :item_type, :enum_value, :cron_value, :item_data?,
@@ -171,6 +170,10 @@ module Requests
     end
 
     private
+
+      def illiad
+        @illiad ||= Requests::Illiad.new(enum: item&.fetch(:enum, nil), chron: item&.fetch(:chron, nil), call_number:)
+      end
 
       # Location data presented as an object, rather than a hash.
       # The goal is to gradually replace all uses of the hash with

--- a/benchmarks/app/models/requests/requestable.rb
+++ b/benchmarks/app/models/requests/requestable.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'benchmark/ips'
+require_relative '../../../../config/environment'
+
+fixture = JSON.parse(Rails.root.join('spec/fixtures/raw/993569343506421.json').read)
+bib = SolrDocument.new(fixture)
+
+holding_data = {
+  'location_code': "lewis$stacks", 'location': "Stacks", 'library': "Lewis Library", 'call_number': "QL737.U58C85", 'call_number_browse': "QL737.U58C85", 'items': [{ 'holding_id': "22699859840006421", 'id': "23699859830006421", 'status_at_load': "1", 'barcode': "32101015665811", 'copy_number': "1" }]
+}
+holding = Requests::Holding.new(mfhd_id: '22699859840006421', holding_data:)
+item = Requests::Item.new(holding.items.first)
+
+location = JSON.parse(Rails.root.join('spec/fixtures/holding_locations/rare_xr.json').read).with_indifferent_access
+
+patron_hash = { "netid" => "foo", "first_name" => "Foo", "last_name" => "Request", "barcode" => "2
+2101007797777",
+                "university_id" => "9999999", "patron_group" => "REG", "patron_id" => "99999", "active_email" => "foo
+@princeton.edu" }.with_indifferent_access
+patron = Requests::Patron.new(user: User.new, patron_hash:)
+
+Benchmark.ips do |benchmark|
+  benchmark.report 'Requestable#initialize' do
+    Requests::Requestable.new(bib:, location:, item:, holding:, patron:)
+  end
+end


### PR DESCRIPTION
This way, we don't have to create an instance of the Illiad class until it's needed.