### PR TITLE
Memoize Bibdata.holding_locations in some helpers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -73,7 +73,7 @@ module ApplicationHelper
   # @param [Hash] holding values
   def holding_location(holding)
     location_code = holding.fetch('location_code', '').to_sym
-    resolved_location = Bibdata.holding_locations[location_code]
+    resolved_location = holding_locations[location_code]
     resolved_location ? resolved_location : {}
   end
 
@@ -167,12 +167,17 @@ module ApplicationHelper
   end
 
   def bibdata_location_code_to_sym(value)
-    Bibdata.holding_locations[value.to_sym]
+    holding_locations[value.to_sym]
+  end
+
+  def holding_locations
+    # Memoize, because it takes quite a while to read/parse all the locations from the disk cache
+    @holding_locations ||= Bibdata.holding_locations
   end
 
   def render_location_code(value)
     values = normalize_location_code(value).map do |loc|
-      location = Bibdata.holding_locations[loc.to_sym]
+      location = holding_locations[loc.to_sym]
       location.nil? ? loc : "#{loc}: #{location_full_display(location)}"
     end
     values.one? ? values.first : values
@@ -241,7 +246,7 @@ module ApplicationHelper
   # Returns true for locations with remote storage.
   # Remote storage locations have a value of 'recap_rmt' in Alma.
   def remote_storage?(location_code)
-    Bibdata.holding_locations[location_code]["remote_storage"] == 'recap_rmt'
+    holding_locations[location_code]["remote_storage"] == 'recap_rmt'
   end
 
   # Returns true for locations where the user can walk and fetch an item.

--- a/benchmarks/app/helpers/application_helper.rb
+++ b/benchmarks/app/helpers/application_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require 'benchmark/ips'
+require_relative '../../../config/environment'
+
+view_context = CatalogController.new.view_context
+
+Benchmark.ips do |benchmark|
+  benchmark.report 'ApplicationHelper#render_location_code' do
+    view_context.render_location_code 'rare$ctsn'
+  end
+end


### PR DESCRIPTION
It can take quite some time to read and parse the holding locations from the disk cache. This can be seen as a bottleneck on both the advanced search form and the search results page.  Therefore, we should strive not to do this expensive process more than once per request.

On the advanced form, where the #render_location_code helper method is called once for every location in the solr index, memoizing Bibdata.holding_locations has a significant performance gain.  Just running this locally, the server responds with the advanced search form in half the time!

Microbenchmark before:
```
$ be ruby benchmarks/app/helpers/application_helper.rb
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
ApplicationHelper#render_location_code
                        87.000 i/100ms
Calculating -------------------------------------
ApplicationHelper#render_location_code
                        882.392 (± 1.6%) i/s    (1.13 ms/i) -      4.437k in   5.029587s
```

After:
```
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
ApplicationHelper#render_location_code
                       127.558k i/100ms
Calculating -------------------------------------
ApplicationHelper#render_location_code
                          1.280M (± 1.0%) i/s  (781.40 ns/i) -      6.505M in   5.083919s
```