### PR TITLE
Alma users - patrons with provider='alma' should be able to use the fill in option in the request form

### DIFF
--- a/app/models/requests/form_decorator.rb
+++ b/app/models/requests/form_decorator.rb
@@ -49,7 +49,6 @@ module Requests
 
     def any_fill_in_eligible?
       return false unless eligible_for_library_services?
-      return false if patron.alma_provider?
 
       fill_in = false
       unless requestable.one? && (requestable.first.services & ["on_order", "online"]).present?


### PR DESCRIPTION
Alma users - patrons with provider='alma' should be able to use the fill in option in the request form

related to #5237