### PR TITLE
Remove unused method digitize_email 

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -755,7 +755,6 @@ detectors:
   UnusedParameters:
     exclude:
     - Requests::RequestMailer#annex_edd_email
-    - Requests::RequestMailer#digitize_email
     - Requests::RequestMailer#recap_marquand_edd_email
     - Requests::RequestMailer#recap_marquand_in_library_email
   UtilityFunction:

--- a/app/mailers/requests/request_mailer.rb
+++ b/app/mailers/requests/request_mailer.rb
@@ -125,10 +125,6 @@ module Requests
            subject:)
     end
 
-    def digitize_email(submission)
-      # TODO: what should we do here
-    end
-
     def digitize_confirmation(submission)
       confirmation_email(submission:, subject_key: 'requests.digitize.email_subject', from_key: 'requests.digitize.email_from')
     end


### PR DESCRIPTION
Remove unused method digitize_email  from app/mailers/requests/request_mailer.rb

Remove it from .reek.yml