### PR TITLE
Refactor hidden_fields_item helper into its own view component

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -113,9 +113,6 @@ detectors:
     - Requests::ApplicationHelper#current_location_label
     - Requests::ApplicationHelper#display_requestable_list
     - Requests::ApplicationHelper#display_status
-    - Requests::ApplicationHelper#hidden_fields_for_item
-    - Requests::ApplicationHelper#hidden_fields_for_scsb
-    - Requests::ApplicationHelper#hidden_fields_item
     - Requests::ApplicationHelper#hidden_fields_mfhd
     - Requests::ApplicationHelper#hidden_service_options
     - Requests::ApplicationHelper#item_checkbox
@@ -230,9 +227,6 @@ detectors:
     - BlacklightHelper#oclc_resolve
     - CatalogHelper#render_search_to_page_title
     - Requests::ApplicationHelper#display_status
-    - Requests::ApplicationHelper#hidden_fields_for_item
-    - Requests::ApplicationHelper#hidden_fields_for_scsb
-    - Requests::ApplicationHelper#hidden_fields_item
     - Requests::ApplicationHelper#hidden_fields_mfhd
     - Requests::ApplicationHelper#item_checkbox
     - Requests::ApplicationHelper#pick_up_locations
@@ -522,8 +516,6 @@ detectors:
     - BlacklightHelper#oclc_resolve
     - HoldingsHelper#holdings_block
     - Requests::ApplicationHelper#display_status
-    - Requests::ApplicationHelper#hidden_fields_for_item
-    - Requests::ApplicationHelper#hidden_fields_item
     - Requests::ApplicationHelper#hidden_fields_mfhd
     - Requests::RequestHelper#login_url
     - Blacklight::Document::Ris#ris_authors
@@ -638,7 +630,6 @@ detectors:
     - Requests::ApplicationHelper#available_pick_ups
     - Requests::ApplicationHelper#current_location_label
     - Requests::ApplicationHelper#display_requestable_list
-    - Requests::ApplicationHelper#hidden_fields_item
     - Requests::ApplicationHelper#hidden_fields_mfhd
     - Requests::ApplicationHelper#output_request_input
     - Requests::ApplicationHelper#preferred_request_content_tag

--- a/app/components/requests/item_hidden_fields_component.html.erb
+++ b/app/components/requests/item_hidden_fields_component.html.erb
@@ -1,0 +1,25 @@
+
+<input type="hidden" name="requestable[][bibid]" value="<%= requestable.bib[:id].to_s %>" id="requestable_bibid_<%= request_id %>" />
+<input type="hidden" name="requestable[][mfhd]" value="<%= requestable.holding.mfhd_id %>" id="requestable_mfhd_<%= request_id %>" />
+<% unless requestable.holding.holding_data["call_number"].nil? -%>
+  <input type="hidden" name="requestable[][call_number]" value="<%= requestable.holding.holding_data['call_number'].to_s %>" id="requestable_call_number_<%= request_id %>" />
+<% end -%>
+<input type="hidden" name="requestable[][location_code]" value="<%= requestable.item_location_code.to_s %>" id="requestable_location_<%= request_id %>" />
+<% if requestable.item? -%>
+  <input type="hidden" name="requestable[][item_id]" value="<%= request_id.to_s %>" id="requestable_item_id_<%= request_id %>" />
+  <% unless barcode.nil? -%>
+    <input type="hidden" name="requestable[][barcode]" value="<%= barcode.to_s %>" id="requestable_barcode_<%= request_id %>" />
+  <% end %>
+  <% if enum_value.present? -%>
+    <input type="hidden" name="requestable[][enum]" value="<%= enum_value %>" id="requestable_enum_<%= request_id %>" />
+  <% end -%>
+  <input type="hidden" name="requestable[][copy_number]" value="<%= item.copy_number.to_s %>" id="requestable_copy_number_<%= request_id %>" />
+  <input type="hidden" name="requestable[][status]" value="<%= item['status'].to_s %>" id="requestable_status_<%= request_id %>" />
+<% else %>
+  <input type="hidden" name="requestable[][item_id]" value="<%= requestable.preferred_request_id %>" id="requestable_item_id_<%= requestable.preferred_request_id %>"
+<% end -%>
+<% if partner_holding? -%>
+  <input type="hidden" name="requestable[][cgd]" value="<%= item['cgd'].to_s %>" id="requestable_cgd_<%= item_id %>" />
+  <input type="hidden" name="requestable[][cc]" value="<%= item['collection_code'].to_s %>" id="requestable_collection_code_<%= item_id %>" />
+  <input type="hidden" name="requestable[][use_statement]" value="<%= item['use_statement'].to_s %>" id="requestable_use_statement_<%= item_id %>" />
+<% end -%>

--- a/app/components/requests/item_hidden_fields_component.rb
+++ b/app/components/requests/item_hidden_fields_component.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+module Requests
+  class ItemHiddenFieldsComponent < ViewComponent::Base
+    def initialize(requestable)
+      @requestable = requestable
+    end
+
+      private
+
+        attr_reader :requestable
+
+        delegate :item, :partner_holding?, to: :requestable
+        delegate :barcode, :enum_value, to: :item
+
+        def request_id
+          requestable.preferred_request_id
+        end
+
+        def item_id
+          item['id']
+        end
+  end
+end

--- a/app/helpers/requests/application_helper.rb
+++ b/app/helpers/requests/application_helper.rb
@@ -143,21 +143,6 @@ module Requests
     end
     # rubocop:enable Rails/OutputSafety
 
-    def hidden_fields_item(requestable)
-      request_id = requestable.preferred_request_id
-      hidden = hidden_field_tag "requestable[][bibid]", "", value: requestable.bib[:id].to_s, id: "requestable_bibid_#{request_id}"
-      hidden += hidden_field_tag "requestable[][mfhd]", "", value: requestable.holding.mfhd_id, id: "requestable_mfhd_#{request_id}"
-      hidden += hidden_field_tag "requestable[][call_number]", "", value: requestable.holding.holding_data['call_number'].to_s, id: "requestable_call_number_#{request_id}" unless requestable.holding.holding_data["call_number"].nil?
-      hidden += hidden_field_tag "requestable[][location_code]", "", value: requestable.item_location_code.to_s, id: "requestable_location_#{request_id}"
-      hidden += if requestable.item?
-                  hidden_fields_for_item(item: requestable.item, preferred_request_id: requestable.preferred_request_id)
-                else
-                  hidden_field_tag("requestable[][item_id]", "", value: requestable.preferred_request_id, id: "requestable_item_id_#{requestable.preferred_request_id}")
-                end
-      hidden += hidden_fields_for_scsb(item: requestable.item) if requestable.partner_holding?
-      hidden
-    end
-
     def suppress_login?(request)
       request.only_aeon?
     end
@@ -401,20 +386,6 @@ module Requests
         # currently for resource sharing items through Illiad we use firestone Library with gfa_pickup of PA
         location = default_pick_ups.find { |location| location[:gfa_pickup] == "PA" }
         [location].compact
-      end
-
-      def hidden_fields_for_item(item:, preferred_request_id:)
-        hidden = hidden_field_tag("requestable[][item_id]", "", value: preferred_request_id.to_s, id: "requestable_item_id_#{preferred_request_id}")
-        hidden += hidden_field_tag("requestable[][barcode]", "", value: item['barcode'].to_s, id: "requestable_barcode_#{preferred_request_id}") unless item["barcode"].nil?
-        hidden += hidden_field_tag("requestable[][enum]", "", value: item.enum_value.to_s, id: "requestable_enum_#{preferred_request_id}") if item.enum_value.present?
-        hidden += hidden_field_tag("requestable[][copy_number]", "", value: item.copy_number.to_s, id: "requestable_copy_number_#{preferred_request_id}")
-        hidden + hidden_field_tag("requestable[][status]", "", value: item['status'].to_s, id: "requestable_status_#{preferred_request_id}")
-      end
-
-      def hidden_fields_for_scsb(item:)
-        hidden = hidden_field_tag("requestable[][cgd]", "", value: item['cgd'].to_s, id: "requestable_cgd_#{item['id']}")
-        hidden += hidden_field_tag("requestable[][cc]", "", value: item['collection_code'].to_s, id: "requestable_collection_code_#{item['id']}")
-        hidden + hidden_field_tag("requestable[][use_statement]", "", value: item['use_statement'].to_s, id: "requestable_use_statement_#{item['id']}")
       end
 
       def single_pickup(is_charged, name, id, location)

--- a/app/views/requests/form/_requestable_checkbox.html.erb
+++ b/app/views/requests/form/_requestable_checkbox.html.erb
@@ -1,5 +1,5 @@
     <td class='request--select'>
       <%= hidden_field_tag 'requestable[][selected]', false, id: "hidden_selected_#{requestable.preferred_request_id}" %>
       <%= item_checkbox requestable, single_item_request %>
-      <%= hidden_fields_item requestable %>
+      <%= render Requests::ItemHiddenFieldsComponent.new(requestable) %>
     </td>

--- a/app/views/requests/form/_requestable_fill_in_field.html.erb
+++ b/app/views/requests/form/_requestable_fill_in_field.html.erb
@@ -2,7 +2,7 @@
   <td class='request--select'>
     <%= hidden_field_tag 'requestable[][selected]', false, id: "hidden_selected" %>
     <%= check_box_tag "requestable[][selected]", true, false, class: 'request--select', aria: { label: "Volume not listed"}, id: "requestable_selected" %>
-    <%= hidden_fields_item requestable %>
+    <%= render Requests::ItemHiddenFieldsComponent.new(requestable) %>
   </td>
   <td class='request--options' <%= 'colspan="2"'.html_safe unless table_sorter_present?(requestable_list) %>>
     <fieldset class="mb-3">

--- a/benchmarks/app/components/requests/item_hidden_fields_component.rb
+++ b/benchmarks/app/components/requests/item_hidden_fields_component.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+require 'benchmark/ips'
+require_relative '../../../benchmark_helpers'
+
+load_rails_classes
+
+bib = solr_doc_from_fixture_file 'spec/fixtures/raw/993569343506421.json'
+mfhd_id = '22693661550006421'
+location = JSON.parse(Rails.root.join('spec/fixtures/holding_locations/plasma_nb.json').read)
+holding_data = JSON.parse(bib[:holdings_1display])[mfhd_id]
+holding = Requests::Holding.new(mfhd_id:, holding_data:)
+item = Requests::Item.new(holding.items.first)
+patron = Requests::Patron.new(patron_hash: {}, user: User.new)
+
+view_context = Requests::FormController.new.view_context
+requestable_decorator = Requests::RequestableDecorator.new(
+  Requests::Requestable.new(bib:, holding:, item:, location:, patron:),
+  view_context
+)
+
+Benchmark.ips do |benchmark|
+  benchmark.report 'Requests::ItemHiddenFieldsComponent' do
+    view_context.render Requests::ItemHiddenFieldsComponent.new(requestable_decorator)
+  end
+end

--- a/benchmarks/benchmark_helpers.rb
+++ b/benchmarks/benchmark_helpers.rb
@@ -10,8 +10,8 @@ def write_holding_locations_to_rails_cache
   Rails.cache.write('holding_locations', locations_hash)
 end
 
-def solr_doc_from_fixture_file(_filepath)
-  fixture = JSON.parse(Rails.root.join('spec/fixtures/raw/993569343506421.json').read)
+def solr_doc_from_fixture_file(filepath)
+  fixture = JSON.parse(Rails.root.join(filepath).read)
   SolrDocument.new(fixture)
 end
 

--- a/spec/components/requests/item_hidden_fields_component_spec.rb
+++ b/spec/components/requests/item_hidden_fields_component_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+require 'rails_helper'
+RSpec.describe Requests::ItemHiddenFieldsComponent, type: :component, requests: true do
+  let(:bib) { SolrDocument.new id: 'abc123' }
+  let(:location) do
+    { code: 'location_code' }
+  end
+  let(:patron) { Requests::Patron.new(patron_hash: {}, user: User.new) }
+
+  it 'renders a hidden location fields' do
+    holding = Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' })
+    item = Requests::Item.new({ 'id' => "aaabbb", 'location' => 'place' }.with_indifferent_access)
+    requestable_decorator = Requests::RequestableDecorator.new(
+      Requests::Requestable.new(bib:, holding:, item:, location:, patron:),
+      Requests::FormController.new.view_context
+    )
+    rendered = render_inline described_class.new(requestable_decorator)
+
+    expect(rendered.css('input[type="hidden"][name="requestable[][location_code]"][id="requestable_location_aaabbb"][value="place"]')).to be_present
+  end
+
+  it 'renders a hidden barcode field' do
+    holding = Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' })
+    item = Requests::Item.new({ 'id' => "aaabbb", 'barcode' => '111222333' }.with_indifferent_access)
+    requestable_decorator = Requests::RequestableDecorator.new(
+      Requests::Requestable.new(bib:, holding:, item:, location:, patron:),
+      Requests::FormController.new.view_context
+    )
+    rendered = render_inline described_class.new(requestable_decorator)
+
+    expect(rendered.css('input[type="hidden"][name="requestable[][barcode]"][id="requestable_barcode_aaabbb"][value="111222333"]')).to be_present
+  end
+
+  it 'renders a hidden item enumeration field' do
+    holding = Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' })
+    item = Requests::Item.new({ 'id' => "aaabbb", 'enum_display' => 'vvv' }.with_indifferent_access)
+    requestable_decorator = Requests::RequestableDecorator.new(
+      Requests::Requestable.new(bib:, holding:, item:, location:, patron:),
+      Requests::FormController.new.view_context
+    )
+    rendered = render_inline described_class.new(requestable_decorator)
+
+    expect(rendered.css('input[type="hidden"][name="requestable[][enum]"][id="requestable_enum_aaabbb"][value="vvv"]')).to be_present
+  end
+
+  it 'renders a holding call number' do
+    holding = Requests::Holding.new(mfhd_id: "1594697", holding_data: { "location" => "Firestone Library", "library" => "Firestone Library", "location_code" => "f", "copy_number" => "0", "call_number" => "6251.9765", "call_number_browse" => "6251.9765" })
+    item = Requests::Item.new({ 'id' => "aaabbb", 'enum_display' => 'vvv' }.with_indifferent_access)
+    requestable_decorator = Requests::RequestableDecorator.new(
+      Requests::Requestable.new(bib:, holding:, item:, location:, patron:),
+      Requests::FormController.new.view_context
+    )
+
+    rendered = render_inline described_class.new(requestable_decorator)
+
+    expect(rendered.css('input[type="hidden"][name="requestable[][call_number]"][id="requestable_call_number_aaabbb"][value="6251.9765"]')).to be_present
+  end
+
+  it 'renders scsb hidden fields for a NYPL item' do
+    holding = Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' })
+    item = Requests::Item.new({ 'id' => "aaabbb", 'location_code' => 'scsbnypl', 'use_statement' => 'In Library Use', 'collection_code' => 'NA', 'cgd' => 'Shared' }.with_indifferent_access)
+    requestable_decorator = Requests::RequestableDecorator.new(
+      Requests::Requestable.new(bib:, holding:, item:, location:, patron:),
+      Requests::FormController.new.view_context
+    )
+
+    rendered = render_inline described_class.new(requestable_decorator)
+
+    expect(rendered.css('input[type="hidden"][name="requestable[][cgd]"][id="requestable_cgd_aaabbb"][value="Shared"]')).to be_present
+    expect(rendered.css('input[type="hidden"][name="requestable[][cc]"][id="requestable_collection_code_aaabbb"][value="NA"]')).to be_present
+    expect(rendered.css('input[type="hidden"][name="requestable[][use_statement]"][id="requestable_use_statement_aaabbb"][value="In Library Use"]')).to be_present
+  end
+end

--- a/spec/helpers/requests/application_helper_spec.rb
+++ b/spec/helpers/requests/application_helper_spec.rb
@@ -219,35 +219,11 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
     end
   end
 
-  describe "#hidden_fields_item" do
+  describe "#enum_copy_display" do
     let(:requestable) { instance_double(Requests::RequestableDecorator, stubbed_questions) }
-
-    context "with item location" do
-      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Item.new({ 'id' => "aaabbb", 'location' => 'place' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: 'place' } }
-      it 'shows hidden fields' do
-        expect(helper.hidden_fields_item(requestable)).to include '<input type="hidden" name="requestable[][location_code]" id="requestable_location_aaabbb" value="place" autocomplete="off" />'
-      end
-    end
-
-    context "with item barcode" do
-      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Item.new({ 'id' => "aaabbb", 'barcode' => '111222333' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
-      it 'shows hidden fields' do
-        expect(helper.hidden_fields_item(requestable)).to include '<input type="hidden" name="requestable[][barcode]" id="requestable_barcode_aaabbb" value="111222333" autocomplete="off" />'
-      end
-    end
-
-    context "with item enum" do
-      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Item.new({ 'id' => "aaabbb", 'enum_display' => 'vvv' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
-      it 'shows hidden fields' do
-        expect(helper.hidden_fields_item(requestable)).to include '<input type="hidden" name="requestable[][enum]" id="requestable_enum_aaabbb" value="vvv" autocomplete="off" />'
-      end
-    end
 
     context "with item enumeration" do
       let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Item.new({ id: "aaabbb", description: 'v.2 sss', copy_number: '0', enum_display: 'v.2' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
-      it 'shows hidden fields' do
-        expect(helper.hidden_fields_item(requestable)).to include '<input type="hidden" name="requestable[][bibid]" id="requestable_bibid_aaabbb" value="abc123" autocomplete="off" />'
-      end
       it 'hides the enum display if the copy number is zero (0)' do
         expect(helper.enum_copy_display(requestable.item)).to eq("v.2 sss")
       end
@@ -255,9 +231,6 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
 
     context "with item description" do
       let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Item.new({ id: "aaabbb", description: 'v2 sss', copy_number: '0' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
-      it 'shows hidden fields' do
-        expect(helper.hidden_fields_item(requestable)).to include '<input type="hidden" name="requestable[][bibid]" id="requestable_bibid_aaabbb" value="abc123" autocomplete="off" />'
-      end
       it 'hides the enum display if the copy number is zero (0)' do
         expect(helper.enum_copy_display(requestable.item)).to eq("v2 sss")
       end
@@ -265,26 +238,8 @@ RSpec.describe Requests::ApplicationHelper, type: :helper,
 
     context "with item description and copy" do
       let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Item.new({ id: "aaabbb", description: 'v2 sss', copy_number: '2' }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
-      it 'shows hidden fields' do
-        expect(helper.hidden_fields_item(requestable)).to include '<input type="hidden" name="requestable[][bibid]" id="requestable_bibid_aaabbb" value="abc123" autocomplete="off" />'
-      end
       it 'hides the enum display if the copy number is zero (0)' do
         expect(helper.enum_copy_display(requestable.item)).to eq("v2 sss Copy 2")
-      end
-    end
-
-    context "with holding call number" do
-      let(:holding) { Requests::Holding.new(mfhd_id: "1594697", holding_data: { "location" => "Firestone Library", "library" => "Firestone Library", "location_code" => "f", "copy_number" => "0", "call_number" => "6251.9765", "call_number_browse" => "6251.9765" }) }
-      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Item.new({ 'id' => "aaabbb" }.with_indifferent_access), holding:, location: { code: 'location_code' }, partner_holding?: false, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
-      it 'shows hidden fields' do
-        expect(helper.hidden_fields_item(requestable)).to include '<input type="hidden" name="requestable[][call_number]" id="requestable_call_number_aaabbb" value="6251.9765" autocomplete="off" />'
-      end
-    end
-
-    context "scsb item" do
-      let(:stubbed_questions) { { bib: { id: 'abc123' }, item: Requests::Item.new({ 'id' => "aaabbb" }.with_indifferent_access), holding: Requests::Holding.new(mfhd_id: 'mfhd1', holding_data: { key1: 'value1' }), location: { code: 'location_code' }, partner_holding?: true, preferred_request_id: 'aaabbb', item?: true, item_location_code: '' } }
-      it 'shows hidden fields' do
-        expect(helper.hidden_fields_item(requestable)).to eq '<input type="hidden" name="requestable[][bibid]" id="requestable_bibid_aaabbb" value="abc123" autocomplete="off" /><input type="hidden" name="requestable[][mfhd]" id="requestable_mfhd_aaabbb" value="mfhd1" autocomplete="off" /><input type="hidden" name="requestable[][location_code]" id="requestable_location_aaabbb" value="" autocomplete="off" /><input type="hidden" name="requestable[][item_id]" id="requestable_item_id_aaabbb" value="aaabbb" autocomplete="off" /><input type="hidden" name="requestable[][copy_number]" id="requestable_copy_number_aaabbb" value="" autocomplete="off" /><input type="hidden" name="requestable[][status]" id="requestable_status_aaabbb" value="" autocomplete="off" /><input type="hidden" name="requestable[][cgd]" id="requestable_cgd_aaabbb" value="" autocomplete="off" /><input type="hidden" name="requestable[][cc]" id="requestable_collection_code_aaabbb" value="" autocomplete="off" /><input type="hidden" name="requestable[][use_statement]" id="requestable_use_statement_aaabbb" value="" autocomplete="off" />'
       end
     end
   end


### PR DESCRIPTION
Keeping this as a draft until I have time to do some manual QA on staging...

To me, this is much easier to read as HTML+ERB than the previous implementation (which used string concatenation and Rails form helpers).  I think that the tests (which now use Nokogiri, rather than direct string comparison) will be less brittle to changes like the order of attributes within a tag.

It is also 4x as fast to avoid the Rails form helpers, for what it's worth (not that this helper was a bottleneck in any way):

Before:
```
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
Requests::ApplicationHelper#hidden_fields_item
                         2.214k i/100ms
Calculating -------------------------------------
Requests::ApplicationHelper#hidden_fields_item
                         22.325k (± 2.1%) i/s   (44.79 μs/i) -    112.914k in   5.060022s
```

After:
```
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
Requests::ItemHiddenFieldsComponent
                         8.453k i/100ms
Calculating -------------------------------------
Requests::ItemHiddenFieldsComponent
                         84.098k (± 1.3%) i/s   (11.89 μs/i) -    422.650k in   5.026524s
```