### PR TITLE
Add validate_user_supplied_enum_for_print validation

### DIFF
--- a/app/models/requests/selected_items_validator.rb
+++ b/app/models/requests/selected_items_validator.rb
@@ -10,10 +10,20 @@ module Requests
       record.errors.add(:items, { "empty_set" => { 'text' => 'Please Select an Item to Request!', 'type' => 'options' } }) unless record.items.size >= 1 && !record.items.any? { |item| defined? item.selected }
       record.items.each do |selected|
         validate_selected(record, selected)
+        validate_user_supplied_enum_for_print(record, selected)
       end
     end
 
     private
+
+      # :reek:UtilityFunction
+      def validate_user_supplied_enum_for_print(record, selected)
+        item_id = selected['item_id']
+        delivery_type = selected["delivery_mode_#{item_id}"]
+        # Only validate if user_supplied_enum field exists and print type is selected
+        return unless selected.key?('user_supplied_enum') && selected['selected'] == 'true' && delivery_type == 'print' && selected['user_supplied_enum'].to_s.strip.blank?
+        record.errors.add(:items, 'Please specify the volume/part/issue information for your request.')
+      end
 
       def validate_selected(record, selected)
         return unless selected['selected'] == 'true'

--- a/spec/models/requests/selected_items_validator_spec.rb
+++ b/spec/models/requests/selected_items_validator_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Requests::SelectedItemsValidator do
+  let(:validator) { described_class.new({}) }
+  let(:record) { instance_double(Requests::Submission, errors: ActiveModel::Errors.new(self), items: []) }
+
+  describe '#validate_user_supplied_enum_for_print' do
+    it 'adds an error when selected, print delivery, and user_supplied_enum is blank' do
+      selected_item = {
+        'selected' => 'true',
+        'item_id' => '123',
+        'delivery_mode_123' => 'print',
+        'user_supplied_enum' => ''
+      }
+      expect do
+        validator.send(:validate_user_supplied_enum_for_print, record, selected_item)
+      end.to change { record.errors[:items].size }.by(1)
+      expect(record.errors[:items]).to include('Please specify the volume/part/issue information for your request.')
+    end
+
+    it 'does not add error when user_supplied_enum is present' do
+      selected_item = {
+        'selected' => 'true',
+        'item_id' => '123',
+        'delivery_mode_123' => 'print',
+        'user_supplied_enum' => 'Vol. 1'
+      }
+      expect do
+        validator.send(:validate_user_supplied_enum_for_print, record, selected_item)
+      end.not_to(change { record.errors[:items].size })
+    end
+
+    it 'does not add error when not selected' do
+      selected_item = {
+        'selected' => 'false',
+        'item_id' => '123',
+        'delivery_mode_123' => 'print',
+        'user_supplied_enum' => ''
+      }
+      expect do
+        validator.send(:validate_user_supplied_enum_for_print, record, selected_item)
+      end.not_to(change { record.errors[:items].size })
+    end
+
+    it 'does not add error when delivery_type is not print' do
+      selected_item = {
+        'selected' => 'true',
+        'item_id' => '123',
+        'delivery_mode_123' => 'edd',
+        'user_supplied_enum' => ''
+      }
+      expect do
+        validator.send(:validate_user_supplied_enum_for_print, record, selected_item)
+      end.not_to(change { record.errors[:items].size })
+    end
+  end
+end


### PR DESCRIPTION
to validate the record for user supplied information in the user_supplied_enum input field when
it exists and patron selects pickup delivery mode

related to #5342


examples to test:

[requests/9917277953506421](https://catalog.princeton.edu/requests/9917277953506421?aeon=false&mfhd=22484023570006421&open_holdings=Forrestal+Annex+-+Stacks)

[requests/9987128103506421](https://catalog.princeton.edu/requests/9987128103506421?aeon=false&mfhd=22562489830006421&open_holdings=Forrestal+Annex+-+A)

[requests/994264203506421](https://catalog.princeton.edu/requests/994264203506421?aeon=false&mfhd=22697849080006421&open_holdings=Lewis+Library+-+Serials+%28Off-Site%29)
