### PR TITLE
Replace getJson with fetch - 1st block

### DIFF
--- a/app/javascript/orangelight/availability.es6
+++ b/app/javascript/orangelight/availability.es6
@@ -36,17 +36,28 @@ export default class AvailabilityUpdater {
       );
 
       for (let i = 0; i < batches.length; i++) {
-        const batch_url = `${this.bibdata_base_url}/bibliographic/availability.json?bib_ids=${batches[i].join()}`;
-        console.log(`batch: ${i}, url: ${batch_url}`);
-        $.getJSON(batch_url, this.process_results_list).fail(
-          (jqXHR, _textStatus, errorThrown) => {
-            // Log that there were problems fetching a batch. Unfortunately we don't know exactly
-            // which batch so we cannot include that information.
+        let batch_ids = batches[i].join(',');
+        let batch_url =
+          this.bibdata_base_url +
+          '/bibliographic/availability.json?bib_ids=' +
+          batch_ids;
+        console.log('batch: ' + i + ', url: ' + batch_url);
+        fetch(batch_url)
+          .then((response) => {
+            if (!response.ok) {
+              throw new Error(`HTTP status: ${response.status}`);
+            }
+            return response.json();
+          })
+          .then((data) => {
+            this.process_results_list(data);
+          })
+
+          .catch((error) => {
             console.error(
-              `Failed to retrieve availability data for batch. HTTP status: ${jqXHR.status}: ${errorThrown}`
+              `Failed to retrieve availability data for batch. ${error}`
             );
-          }
-        );
+          });
       }
 
       // a show page


### PR DESCRIPTION
Use Fetch in request_availability
Remove $.getJSON
Replace jquery in this block of code
New specs for fetch - use Promise(setImmediate)
to wait for all microtask to finish before continuing

related to [#3913]


This part of the code is what you see in the dev tools console as
```

Requested at 2025-11-13T14:20:02.306Z, batch size: 10, batches: 2, ids: 13
batch: 0, url: https://bibdata-staging.lib.princeton.edu/bibliographic/availability.json?bib_ids=99131551630306421,99131551629706421,99131551633006421,99131551630806421,99131272360206421,99131272360006421,99131272559606421,99131272370806421,99131272365006421,99131272367806421
batch: 1, url: https://bibdata-staging.lib.princeton.edu/bibliographic/availability.json?bib_ids=99131592119006421,99131494079906421,99129167963206421
```