### PR TITLE
Remove non-working focus management for modals

### DIFF
--- a/app/javascript/orangelight/orangelight_ui_loader.es6
+++ b/app/javascript/orangelight/orangelight_ui_loader.es6
@@ -11,19 +11,9 @@ export default class OrangelightUiLoader {
     this.setup_availability();
     this.setup_linked_records();
     this.setup_show_more_fields();
-    this.setup_modal_focus();
     this.setup_viewers();
     this.setup_book_covers();
     handleBtnKeyDown();
-  }
-
-  setup_modal_focus() {
-    $('body').on('shown.bs.modal', (event) => {
-      $(event.target)
-        .find('input[type!="hidden"],textarea:enabled')
-        .first()
-        .focus();
-    });
   }
 
   setup_availability() {

--- a/spec/javascript/orangelight/orangelight_ui_loader.spec.js
+++ b/spec/javascript/orangelight/orangelight_ui_loader.spec.js
@@ -8,38 +8,6 @@ describe('OrangelightUiLoader', function () {
     expect(loader).not.toBe(undefined);
   });
 
-  test('Focus on First Element', () => {
-    document.body.innerHTML =
-      '<div id="blacklight-modal">' +
-      '<input type="hidden" id="one">' +
-      '<input type="tel" id="two">' +
-      '<input type="text" id="three"></div>';
-    const l = new loader();
-    l.setup_modal_focus();
-    expect(document.activeElement.id).toEqual('');
-
-    // trigger event
-    $('#blacklight-modal').trigger('shown.bs.modal');
-    // check for focus
-    expect(document.activeElement.id).toEqual('two');
-  });
-
-  test('Focus on first textarea', () => {
-    document.body.innerHTML =
-      '<div id="blacklight-modal">' +
-      '<input type="hidden" id="one">' +
-      '<textarea id="two-but-textarea"></textarea>' +
-      '<input type="text" id="three"></div>';
-    const l = new loader();
-    l.setup_modal_focus();
-    expect(document.activeElement.id).toEqual('');
-
-    // trigger event
-    $('#blacklight-modal').trigger('shown.bs.modal');
-    // check for focus
-    expect(document.activeElement.id).toEqual('two-but-textarea');
-  });
-
   test("Doesn't call Figgy if there's no IDs to call", () => {
     document.body.innerHTML = '';
     const spy = vi.spyOn(FiggyManifestManager, 'buildThumbnailSet');


### PR DESCRIPTION
This code attempted to automatically focus the first input in a modal when a modal was opened.  However, the event is never triggered in practice, so this focus does not actually happen in any of the modal forms I tried (SMS, Email, Ask a question, or Suggest a correction).

Let's remove this non-working code.

Helps with #5314 by removing jQuery code