### PR TITLE
[#5314] Remove remaining jQuery use from orangelight ui loader

### DIFF
--- a/app/javascript/orangelight/figgy_manifest_manager.js
+++ b/app/javascript/orangelight/figgy_manifest_manager.js
@@ -289,9 +289,9 @@ class FiggyThumbnailSet {
 }
 
 class FiggyManifestManager {
-  static buildThumbnailSet($elements) {
+  static buildThumbnailSet(elements) {
     return new FiggyThumbnailSet(
-      $elements,
+      window.jQuery(elements),
       loadResourcesByOrangelightIds,
       window.jQuery
     );

--- a/app/javascript/orangelight/orangelight_ui_loader.es6
+++ b/app/javascript/orangelight/orangelight_ui_loader.es6
@@ -50,9 +50,11 @@ export default class OrangelightUiLoader {
   }
 
   setup_viewers() {
-    const $elements = $('.document-thumbnail[data-bib-id]');
-    if ($elements.length > 0) {
-      const thumbnails = FiggyManifestManager.buildThumbnailSet($elements);
+    const elements = document.querySelectorAll(
+      '.document-thumbnail[data-bib-id]'
+    );
+    if (elements.length > 0) {
+      const thumbnails = FiggyManifestManager.buildThumbnailSet(elements);
       thumbnails.render();
     }
 


### PR DESCRIPTION
Closes #5314