### PR TITLE
Implement our own JSON-P requests

### DIFF
--- a/app/javascript/orangelight/book_covers.es6
+++ b/app/javascript/orangelight/book_covers.es6
@@ -1,11 +1,35 @@
+import { requestJsonP } from './json_p.es6';
+
+// This function has to be part of the global window object, because
+// it is the callback for a JsonP request
+window.addBookCoversToDom = (data) => {
+  Object.entries(data).forEach(([id, info]) => {
+    if (info.thumbnail_url) {
+      const identifier_type = id.split(':')[0];
+      const id_value = id.split(':')[1];
+      const type_matches = $(`*[data-${identifier_type}]`);
+      const thumbnail_element = type_matches.filter((i, element) => {
+        return $(element).data(identifier_type).indexOf(id_value) != -1;
+      })[0];
+      const thumbnail_url = info.thumbnail_url
+        .replace(/zoom=./, 'zoom=1')
+        .replace('&edge=curl', '');
+      const new_thumbnail = $(`<img alt='' src='${thumbnail_url}'>`);
+      $(thumbnail_element).html('');
+      $(thumbnail_element).append(new_thumbnail);
+    }
+  });
+};
+
 export default class BookCoverManager {
-  constructor() {
+  constructor(requestFn = null) {
     this.google_url =
-      'https://books.google.com/books?callback=?&jscmd=viewapi&bibkeys=';
+      'https://books.google.com/books?callback=addBookCoversToDom&jscmd=viewapi&bibkeys=';
     this.identifiers = {
       isbn: 'isbn',
       oclc: 'http://purl.org/library/oclcnum',
     };
+    this.requestFn = requestFn || requestJsonP;
     this.find_book_covers();
   }
 
@@ -29,26 +53,7 @@ export default class BookCoverManager {
 
   fetch_identifiers(ids) {
     const url = `${this.google_url}${ids.join(',')}`;
-    $.getJSON(url).done(this.process_results);
-  }
-
-  process_results(data) {
-    Object.entries(data).forEach(([id, info]) => {
-      if (info.thumbnail_url) {
-        const identifier_type = id.split(':')[0];
-        const id_value = id.split(':')[1];
-        const type_matches = $(`*[data-${identifier_type}]`);
-        const thumbnail_element = type_matches.filter((i, element) => {
-          return $(element).data(identifier_type).indexOf(id_value) != -1;
-        })[0];
-        const thumbnail_url = info.thumbnail_url
-          .replace(/zoom=./, 'zoom=1')
-          .replace('&edge=curl', '');
-        const new_thumbnail = $(`<img alt='' src='${thumbnail_url}'>`);
-        $(thumbnail_element).html('');
-        $(thumbnail_element).append(new_thumbnail);
-      }
-    });
+    this.requestFn(url);
   }
 
   find_identifiers(identifier_type, property) {

--- a/app/javascript/orangelight/json_p.es6
+++ b/app/javascript/orangelight/json_p.es6
@@ -1,0 +1,14 @@
+// Certain legacy endpoints require using a technique called JSON-P
+// (see https://en.wikipedia.org/wiki/JSONP)
+// Rather than doing a simple fetch() call, these endpoints (e.g. Google Books)
+// require us to add a <script> tag to the DOM.  The src of the <script>
+// should include the name of a callback function that will handle the
+// data that is retrieved.
+function requestJsonP(url) {
+  const script = document.createElement('script');
+  script.setAttribute('src', url);
+  script.setAttribute('type', 'text/javascript');
+  document.documentElement.firstChild.appendChild(script);
+}
+
+export { requestJsonP };

--- a/spec/javascript/orangelight/book_covers.spec.js
+++ b/spec/javascript/orangelight/book_covers.spec.js
@@ -1,0 +1,48 @@
+import { describe } from 'vitest';
+import BookCoverManager from '../../../app/javascript/orangelight/book_covers.es6';
+
+describe('BookCoverManager', () => {
+  it('can request ISBNs', () => {
+    const requestFn = () =>
+      window.addBookCoversToDom({
+        'isbn:9789592750111': {
+          bib_key: 'isbn:9789592750111',
+          thumbnail_url:
+            'https://books.google.com/books/content?id=I9gLAQAAMAAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=5',
+        },
+      });
+    window.document.body.innerHTML = `<span vocab="http://id.loc.gov/vocabulary/identifiers/">
+    <meta property="isbn" itemprop="isbn" content="9789592750111">
+</span>
+<div class="document-thumbnail" data-isbn="[&quot;9789592750111&quot;]"><div class="default"></div></div>`;
+
+    new BookCoverManager(requestFn);
+
+    const image = document.querySelector('img');
+    expect(image.getAttribute('src')).toEqual(
+      'https://books.google.com/books/content?id=I9gLAQAAMAAJ&printsec=frontcover&img=1&zoom=1'
+    );
+  });
+
+  it('can request OCLC numbers', () => {
+    const requestFn = () =>
+      window.addBookCoversToDom({
+        'oclc:1328062335': {
+          bib_key: 'oclc:1328062335',
+          thumbnail_url:
+            'https://books.google.com/books/content?id=I9gLAQAAMAAJ\u0026printsec=frontcover\u0026img=1\u0026zoom=5',
+        },
+      });
+    window.document.body.innerHTML = `<span vocab="http://id.loc.gov/vocabulary/identifiers/">
+    <meta property="http://purl.org/library/oclcnum" content="1328062335">
+</span>
+<div class="document-thumbnail" data-oclc="[&quot;1328062335&quot;]"><div class="default"></div></div>`;
+
+    new BookCoverManager(requestFn);
+
+    const image = document.querySelector('img');
+    expect(image.getAttribute('src')).toEqual(
+      'https://books.google.com/books/content?id=I9gLAQAAMAAJ&printsec=frontcover&img=1&zoom=1'
+    );
+  });
+});


### PR DESCRIPTION
jQuery's `$.getJSON` function can request JSON using the [JSON-P strategy](https://en.wikipedia.org/wiki/JSONP), which is needed for certain legacy APIs like Google Books.

Since we'd like to move away from jQuery, and since Google Books does not offer the same functionality (requesting multiple ISBNs and OCLC numbers at once) in their more modern APIs, we implement our own JSON-P

Helps with #5310