### PR TITLE
[circleci] don't install node just to run rubocop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,7 +182,7 @@ jobs:
     steps:
       - attach_workspace:
           at: '~/orangelight'
-      - setup-bundler-and-node
+      - ruby/install-deps
       - run: bundle exec rubocop
   erblint:
     executor: basic-executor


### PR DESCRIPTION
[In this circleci run, the rubocop check failed](https://app.circleci.com/pipelines/github/pulibrary/orangelight/7956/workflows/e597d738-2ab8-489d-877a-319857f5a1df/jobs/47430) because downloading node timed out.

Node isn't needed for rubocop, so let's avoid installing it for that check.