### PR TITLE
Remove Jquery - Update status display to use vanilla JS

### DIFF
--- a/app/javascript/orangelight/status_display.js
+++ b/app/javascript/orangelight/status_display.js
@@ -1,41 +1,49 @@
 export default class StatusDisplay {
   setAvailableStatus(element) {
-    element.text('Available').addClass('green strong');
+    element.textContent = 'Available';
+    element.classList.add('green', 'strong');
     return element;
   }
 
   setSomeAvailableStatus(element) {
-    element.text('Some Available').addClass('green strong');
+    element.textContent = 'Some Available';
+    element.classList.add('green', 'strong');
     return element;
   }
 
   setOnSiteAccessStatus(element) {
-    element.text('On-site access').addClass('green strong');
+    element.textContent = 'On-site access';
+    element.classList.add('green', 'strong');
     return element;
   }
 
   setUnavailableStatus(element) {
-    element.text('Unavailable').addClass('red strong');
+    element.textContent = 'Unavailable';
+    element.classList.add('red', 'strong');
     return element;
   }
 
   setRequestStatus(element) {
-    element.text('Request').addClass('gray strong');
+    element.textContent = 'Request';
+    element.classList.add('gray', 'strong');
     return element;
   }
 
   setAskStaffStatus(element) {
-    element.text('Ask Staff').addClass('gray strong');
+    element.textContent = 'Ask Staff';
+    element.classList.add('gray', 'strong');
     return element;
   }
 
   setUndeterminedStatus(element) {
-    element.text('Undetermined').addClass('gray strong');
+    element.textContent = 'Undetermined';
+    element.classList.add('gray', 'strong');
     return element;
   }
 
   setLoadingStatus(element) {
-    element.text('Loading...').addClass('gray strong');
+    element.textContent = 'Loading...';
+    element.classList.add('gray', 'strong');
     return element;
   }
 }

--- a/spec/javascript/orangelight/availability.spec.js
+++ b/spec/javascript/orangelight/availability.spec.js
@@ -63,24 +63,28 @@ describe('AvailabilityUpdater', function () {
     bibdata_response = JSON.parse(bibdata_response);
     u.process_results_list(bibdata_response);
 
-    const available_result = $(
+    const available_result = document.querySelector(
       `*[data-record-id="${avail_id}"] .lux-text-style`
     );
 
-    expect(available_result.hasClass('green strong')).toBe(true);
-    expect(available_result.text()).toEqual('Available');
+    expect(available_result.classList.contains('green')).toBe(true);
+    expect(available_result.classList.contains('strong')).toBe(true);
+    expect(available_result.textContent).toEqual('Available');
 
-    const unavailable_result = $(
+    const unavailable_result = document.querySelector(
       `*[data-record-id="${unavail_id}"] .lux-text-style`
     );
 
-    expect(unavailable_result.hasClass('gray')).toBe(true);
-    expect(unavailable_result.text()).toEqual('Request');
+    expect(unavailable_result.classList.contains('gray')).toBe(true);
+    expect(unavailable_result.textContent).toEqual('Request');
 
-    const mixed_result = $(`*[data-record-id="${mixed_id}"] .lux-text-style`);
+    const mixed_result = document.querySelector(
+      `*[data-record-id="${mixed_id}"] .lux-text-style`
+    );
 
-    expect(mixed_result.hasClass('green strong')).toBe(true);
-    expect(mixed_result.text()).toEqual('Some Available');
+    expect(mixed_result.classList.contains('green')).toBe(true);
+    expect(mixed_result.classList.contains('strong')).toBe(true);
+    expect(mixed_result.textContent).toEqual('Some Available');
   });
 
   test('search results availability for records in temporary locations says Available', () => {
@@ -452,7 +456,7 @@ describe('AvailabilityUpdater', function () {
     const u = new updater();
     u.id = '99124187703506421';
     expect(av_element[0].textContent).not.toContain('Request');
-    u.apply_availability_label(av_element, holding_data, false);
+    u.apply_availability_label(av_element[0], holding_data, false);
     expect(av_element[0].textContent).toContain('Ask Staff');
     expect(
       document.querySelector(
@@ -494,7 +498,7 @@ describe('AvailabilityUpdater', function () {
     const holding_data =
       res_share_response['99118399983506421']['RES_SHARE$IN_RS_REQ'];
     expect(element[0].textContent).not.toContain('Unavailable');
-    u.apply_availability_label(element, holding_data, false);
+    u.apply_availability_label(element[0], holding_data, false);
     expect(element[0].textContent).toContain('Unavailable');
     expect(
       document.querySelector(
@@ -609,7 +613,7 @@ describe('AvailabilityUpdater', function () {
     );
     const holding_data =
       res_share_response['99118399983506421']['RES_SHARE$IN_RS_REQ'];
-    u.apply_availability_label(element, holding_data, false);
+    u.apply_availability_label(element[0], holding_data, false);
     u.update_single(res_share_response, u.id);
     expect(
       document.querySelector(
@@ -669,7 +673,7 @@ describe('AvailabilityUpdater', function () {
     );
     const holding_data =
       res_share_response['99125535710106421']['RES_SHARE$IN_RS_REQ'];
-    u.apply_availability_label(element, holding_data, false);
+    u.apply_availability_label(element[0], holding_data, false);
     u.process_result(u.id, res_share_response['99125535710106421']);
     expect(
       document

--- a/spec/javascript/orangelight/status_display.spec.js
+++ b/spec/javascript/orangelight/status_display.spec.js
@@ -2,46 +2,46 @@ import StatusDisplay from '../../../app/javascript/orangelight/status_display.js
 
 describe('StatusDisplay', () => {
   let statusDisplay;
-  let $el;
+  let element;
 
   beforeEach(() => {
     statusDisplay = new StatusDisplay();
     document.body.innerHTML = '<span id="test"></span>';
-    $el = $('#test');
+    element = document.getElementById('test');
   });
 
   test('setAvailableStatus sets text and classes', () => {
-    statusDisplay.setAvailableStatus($el);
-    expect($el.text()).toBe('Available');
-    expect($el.hasClass('green')).toBe(true);
-    expect($el.hasClass('strong')).toBe(true);
+    statusDisplay.setAvailableStatus(element);
+    expect(element.textContent).toBe('Available');
+    expect(element.classList.contains('green')).toBe(true);
+    expect(element.classList.contains('strong')).toBe(true);
   });
 
   test('setOnSiteAccessStatus sets text and classes', () => {
-    statusDisplay.setOnSiteAccessStatus($el);
-    expect($el.text()).toBe('On-site access');
-    expect($el.hasClass('green')).toBe(true);
-    expect($el.hasClass('strong')).toBe(true);
+    statusDisplay.setOnSiteAccessStatus(element);
+    expect(element.textContent).toBe('On-site access');
+    expect(element.classList.contains('green')).toBe(true);
+    expect(element.classList.contains('strong')).toBe(true);
   });
 
   test('setUnavailableStatus sets text and classes', () => {
-    statusDisplay.setUnavailableStatus($el);
-    expect($el.text()).toBe('Unavailable');
-    expect($el.hasClass('red')).toBe(true);
-    expect($el.hasClass('strong')).toBe(true);
+    statusDisplay.setUnavailableStatus(element);
+    expect(element.textContent).toBe('Unavailable');
+    expect(element.classList.contains('red')).toBe(true);
+    expect(element.classList.contains('strong')).toBe(true);
   });
 
   test('setRequestStatus sets text and classes', () => {
-    statusDisplay.setRequestStatus($el);
-    expect($el.text()).toBe('Request');
-    expect($el.hasClass('gray')).toBe(true);
-    expect($el.hasClass('strong')).toBe(true);
+    statusDisplay.setRequestStatus(element);
+    expect(element.textContent).toBe('Request');
+    expect(element.classList.contains('gray')).toBe(true);
+    expect(element.classList.contains('strong')).toBe(true);
   });
 
   test('setAskStaffStatus sets text and classes', () => {
-    statusDisplay.setAskStaffStatus($el);
-    expect($el.text()).toBe('Ask Staff');
-    expect($el.hasClass('gray')).toBe(true);
-    expect($el.hasClass('strong')).toBe(true);
+    statusDisplay.setAskStaffStatus(element);
+    expect(element.textContent).toBe('Ask Staff');
+    expect(element.classList.contains('gray')).toBe(true);
+    expect(element.classList.contains('strong')).toBe(true);
   });
 });


### PR DESCRIPTION
Update availability.es6 and the related specs to
expect a DOM native element and not a jQuery object.

closes #5390
related to #3913 