### PR TITLE
Remove back-to-top button CSS

### DIFF
--- a/app/assets/stylesheets/components/buttons.scss
+++ b/app/assets/stylesheets/components/buttons.scss
@@ -222,36 +222,6 @@ header .navbar-nav > li > a {
   padding-bottom: 10px;
 }
 
-.back-to-top {
-    background: image-url("up-arrow.svg") center 50% no-repeat rgba(255,255,255,.8);
-    bottom: 30px;
-    display: none;
-    height: 40px;
-    overflow: hidden;
-    position: fixed;
-    right: 10px;
-    text-decoration: none;
-    text-indent: 100%;
-    white-space: nowrap;
-    width: 40px;
-
-    @media only screen and (min-width: 768px) {
-      bottom: 20px;
-      right: 20px;
-    }
-
-    @media only screen and (min-width: 1024px) {
-      bottom: 30px;
-      height: 60px;
-      right: 30px;
-      width: 60px;
-    }
-
-  &:hover{
-    text-decoration: none;
-  }
-}
-
 .login-button {
   margin-bottom: 5px;
 }


### PR DESCRIPTION
As @rladdusaw [pointed out](https://github.com/pulibrary/orangelight/pull/5375#issuecomment-3554232325), we no longer have this button, so we don't need the corresponding CSS either.