### PR TITLE
Hide Request button behind FlipFlop for the following marquand locations

### DIFF
--- a/app/components/holdings/location_services_component.rb
+++ b/app/components/holdings/location_services_component.rb
@@ -29,6 +29,7 @@ class Holdings::LocationServicesComponent < ViewComponent::Base
       # :reek:TooManyStatements
       def button_component
         return nil if Flipflop.hide_marquand_special_collections_request_button? && marquand_special_collections?
+        return nil if Flipflop.hide_marquand_non_rare_request_button? && marquand_non_rare?
         if holding_id == 'thesis' || numismatics?
           AeonRequestButtonComponent.new(document:, holding: holding_hash, url_class: Requests::NonAlmaAeonUrl)
         elsif items && items.length > 1
@@ -86,6 +87,10 @@ class Holdings::LocationServicesComponent < ViewComponent::Base
 
       def marquand_special_collections?
         location_rules && location_rules[:code].end_with?('$t', '$x', '$rrx', '$pz', '$fbx', '$ebx')
+      end
+
+      def marquand_non_rare?
+        location_rules && location_rules[:code].end_with?('$fesrf', '$ltop', '$mic', '$ms', '$msref', '$pj', '$pv', '$ref', '$pjm', '$res', '$rp', '$saf', '$stacks', '$tech', '$wr')
       end
 
       # Example of a temporary holding, in this case holding_id is : firestone$res3hr

--- a/config/features.rb
+++ b/config/features.rb
@@ -48,4 +48,8 @@ Flipflop.configure do
   feature :hide_marquand_special_collections_request_button,
   default: false,
   description: "When on / true, it hides the request button for Marquand Special Collections 'marquand$t','marquand$x','marquand$rrx', 'marquand$pz', 'marquand$fbx', 'marquand$ebx'."
+
+  feature :hide_marquand_non_rare_request_button,
+  default: false,
+  description: "When on / true, it hides the request button for Marquand Non-Rare Collections '$fesrf', '$ltop', '$mic', '$ms', '$msref', '$pj', '$pv', '$ref', '$pjm', '$res', '$rp', '$saf', '$stacks', '$tech', '$wr'."
 end

--- a/spec/components/holdings/location_services_component_spec.rb
+++ b/spec/components/holdings/location_services_component_spec.rb
@@ -380,7 +380,7 @@ RSpec.describe Holdings::LocationServicesComponent, type: :component do
   end
 
   describe 'when the location is Marquand Special Collections' do
-    let(:holding_id) { 'marquand$fbx' }
+    let(:holding_id) { '221067105550006421' }
     let(:location_rules) do
       {
         'label': "Remote Storage (ReCAP): Marquand Library Use Only Rare Books",
@@ -421,7 +421,7 @@ RSpec.describe Holdings::LocationServicesComponent, type: :component do
 
       it 'does not render a request button' do
         expect(rendered.to_s).to include '<td class="location-services service-always-requestable"'
-        expect(rendered.to_s).not_to include "Request"
+        expect(rendered.to_s).not_to include "Reading Room Request"
       end
     end
     context 'when FlipFlop feature hide_marquand_special_collections_request_button is off' do
@@ -432,6 +432,59 @@ RSpec.describe Holdings::LocationServicesComponent, type: :component do
       it 'renders a request button' do
         expect(rendered.to_s).to include '<td class="location-services service-always-requestable"'
         expect(rendered.to_s).to include "Reading Room Request"
+      end
+    end
+  end
+
+  describe 'when the location is Marquand non rare' do
+    let(:holding_id) { '22729708660006421' }
+    let(:location_rules) do
+      { 'label': "Tang Reading Room Remote Storage: Marquand Use Only",
+        'code': "marquand$fesrf",
+        'aeon_location': false,
+        'recap_electronic_delivery_location': false, 'open': false,
+        'requestable': true,
+        'always_requestable': true,
+        'circulates': false,
+        'remote_storage': "", 'fulfillment_unit': "Closed",
+        'url': "https://bibdata.princeton.edu/locations/holding_locations/marquand$fesrf.json",
+        'library': { 'label': "Marquand Library", 'code': "marquand", 'order': 0 },
+        'holding_library': nil }
+    end
+    let(:holding) do
+      { 'location_code': "marquand$fesrf",
+        'location': "Tang Reading Room Remote Storage: Marquand Use Only",
+        'library': "Marquand Library",
+        'call_number': "ND1042 .C485 2013q Oversize",
+        'call_number_browse': "ND1042 .C485 2013q Oversize", 'sub_location': ["Oversize"],
+        'items': [{ 'holding_id': "22729708660006421", 'description': "vol.6",
+                    'id': "23729708570006421", 'status_at_load': "0",
+                    'barcode': "32101108680719", 'copy_number': "0" }],
+        'location_has': ["Vol. 1-v. 6"],
+        'supplements': [nil], 'indexes': [nil],
+        'mms_id': "9975702033506421" }.with_indifferent_access
+    end
+    before do
+      allow(adapter).to receive(:document).and_return(document)
+    end
+    context 'when FlipFlop feature hide_marquand_non_rare_request_button is on' do
+      before do
+        allow(Flipflop).to receive(:hide_marquand_non_rare_request_button?).and_return(true)
+      end
+
+      it 'does not render a request button' do
+        expect(rendered.to_s).to include '<td class="location-services service-conditional"'
+        expect(rendered.to_s).not_to include "Request"
+      end
+    end
+    context 'when FlipFlop feature hide_marquand_non_rare_request_button is off' do
+      before do
+        allow(Flipflop).to receive(:hide_marquand_non_rare_request_button?).and_return(false)
+      end
+
+      it 'renders a request button' do
+        expect(rendered.to_s).to include '<td class="location-services service-conditional"'
+        expect(rendered.to_s).to include "Request"
       end
     end
   end


### PR DESCRIPTION
closes #5415 

hide the request button from 1/8 to 1/26 for the following marquand locations : 
$fesrf', '$ltop', '$mic', '$ms', '$msref', '$pj', '$pv', '$ref', '$pjm', '$res', '$rp', '$saf', '$stacks', '$tech', '$wr'

related to [#5415]