### PR TITLE
Upgrade rails-health-monitor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,8 +31,7 @@ gem 'faraday-cookie_jar'
 gem "ffi", force_ruby_platform: true
 gem 'flipflop'
 gem 'global'
-# Pinning to 12.4.0 due to Rails 7.1 compatibility issue in 12.4.1
-gem 'health-monitor-rails', '12.4.0'
+gem 'health-monitor-rails', '12.9.0'
 # Static pages
 gem 'high_voltage'
 gem 'honeybadger'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -329,7 +329,7 @@ GEM
       rake (>= 13)
     hashdiff (1.2.1)
     hashie (5.0.0)
-    health-monitor-rails (12.4.0)
+    health-monitor-rails (12.9.0)
       railties (>= 6.1)
     high_voltage (4.0.0)
     honeybadger (5.29.1)
@@ -825,7 +825,7 @@ DEPENDENCIES
   ffi
   flipflop
   global
-  health-monitor-rails (= 12.4.0)
+  health-monitor-rails (= 12.9.0)
   high_voltage
   honeybadger
   jbuilder (~> 2.0)


### PR DESCRIPTION
The latest version uses lease_connection for Rails 8.1.
For a Rails version before 8 it falls back to connection.

helps with upgrading rails to 8.1.1