### PR TITLE
Update feedback controller:

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -67,12 +67,16 @@ class FeedbackController < ApplicationController
 
     def build_report_biased_results_form
       @biased_results_form = ReportBiasedResultsForm.new(
-        biased_results_params
+        context: biased_results_params['context']
       )
     end
 
     def biased_results_params
       params.require(:report_biased_results_form).permit(:context)
+    end
+
+    def search_results_url(biased_params)
+      search_catalog_url(q: biased_params['q'])
     end
 
     def page_url(params)

--- a/spec/controllers/feedback_controller_spec.rb
+++ b/spec/controllers/feedback_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe FeedbackController, type: :controller do
     it "routes to the Report Biased Results form" do
       get :report_biased_results, params: {
         report_biased_results_form: {
-          q: "cats"
+          context: "http://example.com/?q=cats"
         }
       }
       expect(response).to be_successful


### PR DESCRIPTION
- Update build_report_biased_results_form to match the pattern used in other form builders. construct a url from params and pass them as the context

helps with upgrading to rails 8.1.1