### PR TITLE
Never update the library location display when temporary location is RES_SHARE$IN_RS_REQ

### DIFF
--- a/app/javascript/orangelight/availability_search_results.js
+++ b/app/javascript/orangelight/availability_search_results.js
@@ -304,6 +304,8 @@ export default class AvailabilitySearchResults extends AvailabilityBase {
   }
 
   #getAvailabilityElement(record_id, holding_id) {
+    // The following query selector will not return for temporary RES_SHARE$IN_RS_REQ.
+    // This is the desired behavior for this temporary location.
     return document.querySelector(
       `*[data-availability-record='true'][data-record-id='${record_id}'][data-holding-id='${holding_id}'] .lux-text-style`
     );

--- a/app/javascript/orangelight/availability_show.js
+++ b/app/javascript/orangelight/availability_show.js
@@ -92,11 +92,13 @@ export default class AvailabilityShow extends AvailabilityBase {
           id,
           holding_id
         );
-        this.#updateHoldingLocation(
-          label,
-          availability_element,
-          holding_records[id]
-        );
+        if (holding_id !== 'RES_SHARE$IN_RS_REQ') {
+          this.#updateHoldingLocation(
+            label,
+            availability_element,
+            holding_records[id]
+          );
+        }
         this.apply_availability_label(availability_element, availability_info);
       }
       return result;


### PR DESCRIPTION
closes #5500

Update #update_single to consider the temporary location RES_SHARE$IN_RS_REQ
In this case when the temporary location is RES_SHARE$IN_RS_REQ the library location should display the permanent library and not what we retrieve from the bibdata response.

related to [#5500]