### PR TITLE
Remove the special marquand location const which is not used anymore

### DIFF
--- a/app/javascript/orangelight/availability_base.js
+++ b/app/javascript/orangelight/availability_base.js
@@ -12,24 +12,13 @@ export default class AvailabilityBase {
       availability_element.classList.add('lux-text-style');
     }
     const { status_label, location } = availability_info;
-    const specialStatusLocations = [
-      'marquand$stacks',
-      'marquand$pj',
-      'marquand$ref',
-      'marquand$ph',
-      'marquand$fesrf',
-    ];
 
     if (availability_element) {
       availability_element.textContent = status_label;
     }
 
     if (status_label.toLowerCase() === 'unavailable') {
-      this.handle_availability_status(
-        location,
-        availability_element,
-        specialStatusLocations
-      );
+      this.handle_availability_status(location, availability_element);
     } else if (status_label.toLowerCase() === 'available') {
       this.status_display.setAvailableStatus(availability_element);
     } else if (status_label.toLowerCase() === 'some available') {
@@ -48,11 +37,7 @@ export default class AvailabilityBase {
     throw new Error('handleOnSiteAccessStatus must be implemented by subclass');
   }
 
-  handle_availability_status(
-    location,
-    availability_element,
-    specialStatusLocations
-  ) {
+  handle_availability_status(location, availability_element) {
     throw new Error(
       'handle_availability_status must be implemented by subclass'
     );

--- a/app/javascript/orangelight/availability_search_results.js
+++ b/app/javascript/orangelight/availability_search_results.js
@@ -5,12 +5,6 @@
   unavailable -> Request
   available -> Available
   some available -> Available
-  specialStatusLocations -> Request 
-      'marquand$stacks',
-      'marquand$pj',
-      'marquand$ref',
-      'marquand$ph',
-      'marquand$fesrf',
 */
 import AvailabilityBase from './availability_base.js';
 
@@ -163,11 +157,7 @@ export default class AvailabilitySearchResults extends AvailabilityBase {
     }
   }
 
-  handle_availability_status(
-    location,
-    availability_element,
-    specialStatusLocations
-  ) {
+  handle_availability_status(location, availability_element) {
     this.status_display.setRequestStatus(availability_element);
   }
 

--- a/app/javascript/orangelight/availability_show.js
+++ b/app/javascript/orangelight/availability_show.js
@@ -6,12 +6,8 @@
   'RES_SHARE$IN_RS_REQ' -> Unavailable
   available -> Available
   some available -> Some Available
-  Locations with special status-> Ask Staff 
-      'marquand$stacks',
-      'marquand$pj',
-      'marquand$ref',
-      'marquand$ph',
-      'marquand$fesrf',
+  Everything that has a bibdata status Unavailable and is in
+    marquand$* location -> Ask Staff
 */
 
 import AvailabilityBase from './availability_base.js';

--- a/spec/javascript/orangelight/availability_show.spec.js
+++ b/spec/javascript/orangelight/availability_show.spec.js
@@ -411,32 +411,12 @@ describe('AvailabilityShow', function () {
 
     test('handle_availability_status sets Ask Staff for marquand locations', () => {
       const element = document.createElement('span');
-      const specialStatusLocations = ['marquand$stacks'];
 
-      availabilityShow.handle_availability_status(
-        'marquand$stacks',
-        element,
-        specialStatusLocations
-      );
+      availabilityShow.handle_availability_status('marquand$stacks', element);
 
       expect(element.classList.contains('gray')).toBe(true);
       expect(element.classList.contains('strong')).toBe(true);
       expect(element.textContent).toBe('Ask Staff');
-    });
-
-    test('handle_availability_status sets Unavailable for non-marquand locations', () => {
-      const element = document.createElement('span');
-      const specialStatusLocations = ['RES_SHARE$IN_RS_REQ'];
-
-      availabilityShow.handle_availability_status(
-        'RES_SHARE$IN_RS_REQ',
-        element,
-        specialStatusLocations
-      );
-
-      expect(element.classList.contains('red')).toBe(true);
-      expect(element.classList.contains('strong')).toBe(true);
-      expect(element.textContent).toBe('Unavailable');
     });
   });
 


### PR DESCRIPTION
This commit removes the special location const which was used and added
a couple of years ago and currenlty was unused and stale code. This rule was checking 5 specific marquand locations and added the Ask Staff display.
Later the code was refactored to consider all marquand locations where items are not in place - Unavailable -
and basically ignored the rule of the 5 marquand locations.