### PR TITLE
Add lux-customization so that SOME AVAILABLE is within the green badge

### DIFF
--- a/app/assets/stylesheets/lux_customizations.scss
+++ b/app/assets/stylesheets/lux_customizations.scss
@@ -22,6 +22,13 @@
   background: var(--color-grayscale-light);
 }
 
+.when-closed .lux-badge {
+  height: 1.5rem;
+  font-size: .55rem;
+  padding: 0.8rem 0.5rem;
+  letter-spacing: 0.02rem;
+}
+
 .lux {
   // We use Libre Franklin since it is a variable font and is a new
   // recommendation from the Communications Office.  Once Lux includes


### PR DESCRIPTION
closes #5337

Add lux-customization for .when-closed .lux-badge
so that the SOME AVAILABLE is within the green badge and not exceeding past the edge


### screenshot with zoom 150% and screen width size 800px;
<img width="1200" height="1214" alt="screenshot with zoom 150% and screen width size 800px" src="https://github.com/user-attachments/assets/32d6f04f-db80-4dcc-a45f-b3df4d90f6fa" />


Check in catalog-qa https://catalog-qa.princeton.edu/catalog/9972125093506421
