### PR TITLE
json_ld abstract field stores the full content of the summary_note_display catalog field

### DIFF
--- a/app/models/concerns/blacklight/document/json_ld.rb
+++ b/app/models/concerns/blacklight/document/json_ld.rb
@@ -136,7 +136,7 @@ module Blacklight::Document::JsonLd
   end
 
   def abstract
-    (self['summary_note_display'] || []).first
+    (self['summary_note_display'] || []).join(',')
   end
 
   # Numbers from the Digital Cicognara Library (DCL)

--- a/spec/fixtures/alma/9952615993506421.json
+++ b/spec/fixtures/alma/9952615993506421.json
@@ -57,7 +57,7 @@
     "New Jersey"
   ],
   "summary_note_display": [
-    "Commentary on Talkhīṣ al-Miftāḥ by Jalāl al-Dīn al-Qazwīnī (d. 739/1338), an abridgment of part 3 of Miftāḥ al-ʻulūm by al-Sakkākī (d. 626/1229), on al-Maʻānī wa-al-bayān. This copy has several ḥāshiyah on the margins and between the lines of the main text. On fol. 3a are short texts written so as to create several circles. The text is followed on fol. 107b by a short text by a later hand."
+    "Commentary on Talkhīṣ al-Miftāḥ by Jalāl al-Dīn al-Qazwīnī (d. 739/1338), an abridgment of part 3 of Miftāḥ al-ʻulūm by al-Sakkākī (d. 626/1229), on al-Maʻānī wa-al-bayān. This copy has several ḥāshiyah on the margins and between the lines of the main text. On fol. 3a are short texts written so as to create several circles. The text is followed on fol. 107b by a short text by a later hand.","a single red line or a double red line","Red brown leather doublure with a gilt fillet border and a central interlace"
   ],
   "notes_display": [
     "Ms. codex.",

--- a/spec/models/json_ld_spec.rb
+++ b/spec/models/json_ld_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe Blacklight::Document::JsonLd do
     context 'with a special collections codex' do
       let(:id) { '9952615993506421' }
       it 'creates a jsonld document' do
-        expect(doc['abstract']).to include('an abridgment of part 3 of Miftāḥ al-ʻulūm')
+        expect(doc['abstract']).to include('an abridgment of part 3 of Miftāḥ al-ʻulūm', 'line or a double red line', 'Red brown leather doublure with a gilt fillet border and a central interlace')
       end
     end
 


### PR DESCRIPTION
closes #5527

summary_note_display field is an array and can have more than one elements

We want the json.ld `abstract` field to be a string of all of the elements in the array not just the first

Related to [#5527]

Deployed in catalog-staging [example](https://catalog-staging.princeton.edu/catalog/9992315673506421.jsonld)