### PR TITLE
Accept only Google Books Full View Items.

### DIFF
--- a/app/javascript/orangelight/google_books_snippets.es6
+++ b/app/javascript/orangelight/google_books_snippets.es6
@@ -6,7 +6,7 @@ import { requestJsonP } from './json_p.es6';
 window.addGoogleBooksSnippetsToDom = (response) => {
   for (const key in response) {
     const result = response[key];
-    if (result.preview === 'partial' || result.preview === 'full') {
+    if (result.preview === 'full') {
       const previewString =
         result.preview.charAt(0).toUpperCase() + result.preview.slice(1);
       const url = new URL(result.preview_url);

--- a/spec/fixtures/google_book_search.json
+++ b/spec/fixtures/google_book_search.json
@@ -4,7 +4,7 @@
         "info_url": "https://books.google.com/books?id=5FTiCgAAQBAJ&source=gbs_ViewAPI",
         "preview_url": "https://books.google.com/books?id=5FTiCgAAQBAJ&printsec=frontcover&source=gbs_ViewAPI",
         "thumbnail_url": "https://books.google.com/books/content?id=5FTiCgAAQBAJ&printsec=frontcover&img=1&zoom=5&edge=curl",
-        "preview": "partial",
+        "preview": "full",
         "embeddable": true,
         "can_download_pdf": false,
         "can_download_epub": false,

--- a/spec/javascript/orangelight/google_books_snippets.spec.js
+++ b/spec/javascript/orangelight/google_books_snippets.spec.js
@@ -76,7 +76,7 @@ describe('GoogleBooksSnippets', function () {
     expect(li_elements.length).toEqual(0);
   });
 
-  test('insert_snippet adds the google book link to available content', async () => {
+  test('insert_snippet adds the google book link to available full text content', async () => {
     document.body.innerHTML =
       '<div class="wrapper"><div class="availability--online"><ul></ul></div><div class="availability--physical"></div></div>' +
       '<meta property="isbn" itemprop="isbn" content="9780618643103">' +
@@ -99,7 +99,7 @@ describe('GoogleBooksSnippets', function () {
     expect(li_elements.length).toEqual(1);
     const list_item = li_elements.item(0);
     expect(
-      list_item.textContent.startsWith('Google Books (Partial View)')
+      list_item.textContent.startsWith('Google Books (Full View)')
     ).toEqual(true);
     const anchor = list_item.getElementsByTagName('a').item(0);
     expect(anchor.getAttribute('href')).toEqual(expectedUrl);


### PR DESCRIPTION
This PR stops display partial google books items in the View Online section of the record page. 

For https://github.com/pulibrary/orangelight/issues/5503. 