### PR TITLE
Display Available when the status label is Available or On site access

### DIFF
--- a/app/javascript/orangelight/vue_components/holding_group_availability.vue
+++ b/app/javascript/orangelight/vue_components/holding_group_availability.vue
@@ -44,7 +44,7 @@ function summary() {
   );
   if (
     availabilityLabels.every((label) =>
-      ['Available', 'On-site Access'].includes(label.trim())
+      ['Available', 'On-site access'].includes(label.trim())
     )
   ) {
     return 'Available';

--- a/spec/javascript/orangelight/vue_components/holding_group_availability.spec.js
+++ b/spec/javascript/orangelight/vue_components/holding_group_availability.spec.js
@@ -31,14 +31,14 @@ describe('HoldingGroupAvailability', () => {
     });
   });
 
-  describe('when the group has a single holding and it is On-site Access', () => {
+  describe('when the group has a single holding and it is On-site access', () => {
     beforeEach(() => {
       document = new JSDOM(`
             <details>
               <div id="vue-mount"></div>
               <table>
                 <tr class="holding-block">
-                  <span class="availability-icon">On-site Access</span>
+                  <span class="availability-icon">On-site access</span>
                 </tr>
               </table>
             </details>`).window.document;


### PR DESCRIPTION
closes #5403

The labels are returned from the availability JS
The label was not matching because of a capital letter

related to [#5403]


@caroldh @ellen-aa Do we want to keep the logic we had and it wasn't working properly or change the display accordingly and when it is on-site access then display on-site access? 

### Display of the initial logic
<img width="1304" height="617" alt="Available" src="https://github.com/user-attachments/assets/c2ea55c9-f067-401c-81d5-322d8765db1a" />


### Display following the ticket request
<img width="1115" height="528" alt="On-site access" src="https://github.com/user-attachments/assets/0bd56126-78cc-434a-b317-a6594a1385c6" />
