### PR TITLE
Fix mismatched tags in pagination

### DIFF
--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -129,5 +129,5 @@ en:
       librarian_view: 'Staff view'
     pagination_compact:
       previous: '<span class="d-none d-lg-inline">&laquo; </span><span>Previous</span>'
-      next: '<span>Next</span><span class="d-none d-lg-inline"> &raquo;<span>'
+      next: '<span>Next</span><span class="d-none d-lg-inline"> &raquo;</span>'
     back_to_search: '<span class="icon-moveback"></span> <span class="d-none d-lg-inline">Back to search</span>'


### PR DESCRIPTION
This led to an odd display in the top pagination on the last page of search results or bookmarks.

Before:
<img width="1052" height="841" alt="the Next button does not match the Previous button, it contains extra 61-69 of 69 inside the button" src="https://github.com/user-attachments/assets/284468f7-2c91-4911-996b-33b0b92c418e" />

After:
<img width="1024" height="739" alt="the buttons match, and the 61-69 of 69 is now outside the buttons as it is on other pages" src="https://github.com/user-attachments/assets/242a43a1-556f-435d-bd94-4cb5b5e191aa" />
