### PR TITLE
Update MarquandPageChargedItem service to check for marquand location, including the marquand recap locations.

### DIFF
--- a/app/models/requests/requestable.rb
+++ b/app/models/requests/requestable.rb
@@ -141,6 +141,10 @@ module Requests
       library_code == 'marquand' && !recap?
     end
 
+    def marquand_library?
+      library_code == 'marquand'
+    end
+
     def marquand_item?
       holding_library == 'marquand'
     end

--- a/app/models/requests/service_eligibility/marquand_page_charged_item.rb
+++ b/app/models/requests/service_eligibility/marquand_page_charged_item.rb
@@ -26,7 +26,7 @@ module Requests
             end
 
             def correct_location?
-              requestable.held_at_marquand_library?
+              requestable.marquand_library?
             end
 
             def patron_group_eligible?

--- a/spec/models/requests/router_spec.rb
+++ b/spec/models/requests/router_spec.rb
@@ -51,7 +51,7 @@ describe Requests::Router, vcr: { cassette_name: 'requests_router', record: :non
         { alma_managed?: true, in_process?: false,
           charged?: false, on_order?: false, aeon?: false,
           annex?: false,
-          recap?: false, recap_pf?: false, held_at_marquand_library?: false,
+          recap?: false, recap_pf?: false, held_at_marquand_library?: false, marquand_library?: false,
           item_data?: false, recap_edd?: false, scsb_in_library_use?: false, item:,
           library_code: 'ABC', eligible_for_library_services?: true,
           marquand_item?: false,
@@ -233,7 +233,7 @@ describe Requests::Router, vcr: { cassette_name: 'requests_router', record: :non
         before do
           stubbed_questions[:circulates?] = true
           stubbed_questions[:marquand_item?] = true
-          stubbed_questions[:held_at_marquand_library?] = true
+          stubbed_questions[:marquand_library?] = true
           stubbed_questions[:charged?] = true
         end
         it "returns marquand_page_charged_item in the services" do

--- a/spec/models/requests/service_eligibility/marquand_page_charged_item_spec.rb
+++ b/spec/models/requests/service_eligibility/marquand_page_charged_item_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Requests::ServiceEligibility::MarquandPageChargedItem, :requests 
     it 'returns true if all criteria are met' do
       requestable = instance_double(Requests::Requestable)
       allow(requestable).to receive_messages(
-        held_at_marquand_library?: true,
+        marquand_library?: true,
         alma_managed?: true,
         aeon?: false,
         charged?: true,
@@ -27,7 +27,7 @@ RSpec.describe Requests::ServiceEligibility::MarquandPageChargedItem, :requests 
     it 'does not consider in_process items eligible' do
       requestable = instance_double(Requests::Requestable)
       allow(requestable).to receive_messages(
-        held_at_marquand_library?: true,
+        marquand_library?: true,
         alma_managed?: true,
         aeon?: false,
         charged?: false,
@@ -43,7 +43,7 @@ RSpec.describe Requests::ServiceEligibility::MarquandPageChargedItem, :requests 
     it 'does not consider on_order items eligible' do
       requestable = instance_double(Requests::Requestable)
       allow(requestable).to receive_messages(
-        held_at_marquand_library?: true,
+        marquand_library?: true,
         alma_managed?: true,
         aeon?: false,
         charged?: false,
@@ -59,7 +59,7 @@ RSpec.describe Requests::ServiceEligibility::MarquandPageChargedItem, :requests 
     it 'does not consider non-Marquand items eligible' do
       requestable = instance_double(Requests::Requestable)
       allow(requestable).to receive_messages(
-        held_at_marquand_library?: false,
+        marquand_library?: false,
         alma_managed?: true,
         aeon?: false,
         charged?: true,
@@ -75,7 +75,7 @@ RSpec.describe Requests::ServiceEligibility::MarquandPageChargedItem, :requests 
     it 'does not consider non-charged items eligible' do
       requestable = instance_double(Requests::Requestable)
       allow(requestable).to receive_messages(
-        held_at_marquand_library?: true,
+        marquand_library?: true,
         alma_managed?: true,
         aeon?: false,
         charged?: false,

--- a/spec/models/requests/user_group_spec.rb
+++ b/spec/models/requests/user_group_spec.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples 'shared request type tests' do
     { alma_managed?: true, in_process?: false,
       charged?: false, on_order?: false, aeon?: false,
       annex?: false,
-      recap?: false, recap_pf?: false, held_at_marquand_library?: false,
+      recap?: false, recap_pf?: false, held_at_marquand_library?: false, marquand_library?: false,
       item_data?: false, recap_edd?: false, scsb_in_library_use?: false, item:,
       library_code: 'ABC', eligible_for_library_services?: true,
       marquand_item?: false }
@@ -77,7 +77,7 @@ RSpec.shared_examples 'shared request type tests' do
   end
 
   it 'with a marquand in library use page charged item request' do
-    stubbed_questions[:held_at_marquand_library?] = true
+    stubbed_questions[:marquand_library?] = true
     stubbed_questions[:marquand_item?] = true
     stubbed_questions[:charged?] = true
     expect(router.calculate_services).to eq(marquand_page_charged_item_services)


### PR DESCRIPTION
closes #5615 

Update MarquandPageChargedItem service to check for marquand location, including the marquand recap locations.

related to [#5615]