### PR TITLE
SCSB holding with items in Supervised use

### DIFF
--- a/app/components/holdings/location_services_component.rb
+++ b/app/components/holdings/location_services_component.rb
@@ -34,7 +34,7 @@ class Holdings::LocationServicesComponent < ViewComponent::Base
           AeonRequestButtonComponent.new(document:, holding: holding_hash, url_class: Requests::NonAlmaAeonUrl)
         elsif items && items.length > 1
           RequestButtonComponent.new(doc_id:, holding_id:, location: location_rules, open_holdings:)
-        elsif aeon_location?
+        elsif aeon_location? || (scsb_location? && scsb_supervised_items?)
           AeonRequestButtonComponent.new(document:, holding: holding_hash)
         elsif scsb_location?
           RequestButtonComponent.new(doc_id:, location: location_rules, holding:, open_holdings:)
@@ -129,5 +129,10 @@ class Holdings::LocationServicesComponent < ViewComponent::Base
 
       def items
         holding['items']
+      end
+
+      def scsb_supervised_items?
+        return false unless items
+        items.all? { |item| item['use_statement']&.casecmp('supervised use')&.zero? }
       end
 end

--- a/spec/components/holdings/location_services_component_spec.rb
+++ b/spec/components/holdings/location_services_component_spec.rb
@@ -201,11 +201,11 @@ RSpec.describe Holdings::LocationServicesComponent, type: :component do
       expect(rendered.to_s).to include 'data-requestable="true"'
       expect(rendered.to_s).to include 'data-holding-id="6670178"'
       expect(rendered.to_s).to include '<a '
-      expect(rendered.to_s).not_to include 'title="Request to view in Reading Room"'
+      expect(rendered.to_s).to include "Reading Room Request"
       # The general scsbnypl location is *not* an aeon location, but if the holding use_statement is "Supervised Use",
       # it goes through aeon.
       expect(rendered.to_s).to include 'data-aeon="false"'
-      expect(rendered.to_s).to include 'href="/requests/SCSB-6593031?aeon=true"'
+      expect(rendered.to_s).to include 'href="https://princeton.aeon.atlas-sys.com/logon?Action=10'
     end
   end
 


### PR DESCRIPTION
closes #5510
closes #5511 

If the record has a SCSB holding with items in Supervised use
Then display the 'Reading Room Request' button
and direct the user to the AEON page.

related to [#5510]
related to [#5511]