### PR TITLE
Fixes Uncaught TypeError: can't access property "childNodes", - addBookCoversToDom

### DIFF
--- a/app/javascript/orangelight/book_covers.es6
+++ b/app/javascript/orangelight/book_covers.es6
@@ -18,8 +18,10 @@ window.addBookCoversToDom = (data) => {
       const newThumbnail = document.createElement('img');
       newThumbnail.setAttribute('alt', '');
       newThumbnail.setAttribute('src', thumbnailUrl);
-      thumbnailElement.childNodes.forEach((element) => element.remove());
-      thumbnailElement.appendChild(newThumbnail);
+      if (thumbnailElement) {
+        thumbnailElement.childNodes.forEach((element) => element.remove());
+        thumbnailElement.appendChild(newThumbnail);
+      }
     }
   });
 };


### PR DESCRIPTION
Fixes Uncaught TypeError: can't access property "childNodes", a is undefined addBookCoversToDom

Cause of this error: the logic could not find an element with the expected data attribute. As a result thumnailElement is undefined and .childNodes throws an error.