### PR TITLE
Display the lux alert when submitting one of the 'Need Help?' forms

### DIFF
--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -1,35 +1,62 @@
 # frozen_string_literal: true
 class ContactController < ApplicationController
+  # :reek:DuplicateMethodCall
+  # :reek:TooManyStatements
+  # :reek:UncommunicativeVariableName
   def question
     @form = AskAQuestionForm.new(question_params)
-    if @form.valid? && @form.submit
-      flash[:success] = 'Your question has been submitted'
-
-      render "question_success"
-    else
-      render partial: "catalog/ask_a_question_form", locals: { form: @form }, status: :unprocessable_content
+    begin
+      if @form.valid? && @form.submit
+        flash_now_success('Your question has been submitted')
+      else
+        flash_now_error('There was a problem submitting your question')
+      end
+    rescue StandardError => e
+      flash_now_error('There was a problem submitting your question')
+      Rails.logger.error("AskAQuestion submission failed: #{e.class} - #{e.message}")
+    end
+    respond_to do |format|
+      format.js
     end
   end
 
+  # :reek:DuplicateMethodCall
+  # :reek:TooManyStatements
+  # :reek:UncommunicativeVariableName
   def suggestion
     @form = SuggestCorrectionForm.new(suggestion_params)
-    if @form.valid? && @form.submit
-      flash[:success] = 'Your suggestion has been submitted'
-
-      render "suggestion_success"
-    else
-      render partial: "catalog/suggest_correction_form", locals: { form: @form }, status: :unprocessable_content
+    begin
+      if @form.valid? && @form.submit
+        flash_now_success('Your suggestion has been submitted')
+      else
+        flash_now_error('There was a problem submitting your suggestion')
+      end
+    rescue StandardError => e
+      flash_now_error('There was a problem submitting your suggestion')
+      Rails.logger.error("SuggestCorrection submission failed: #{e.class} - #{e.message}")
+    end
+    respond_to do |format|
+      format.js
     end
   end
 
+  # :reek:DuplicateMethodCall
+  # :reek:TooManyStatements
+  # :reek:UncommunicativeVariableName
   def missing_item
     @form = MissingItemForm.new(missing_item_params)
-    if @form.valid? && @form.submit
-      flash[:success] = 'Your feedback has been submitted'
-
-      render "missing_item_success"
-    else
-      render partial: "catalog/missing_item_form", locals: { form: @form }, status: :unprocessable_content
+    begin
+      if @form.valid? && @form.submit
+        flash_now_success('Your missing item report has been submitted')
+      else
+        flash_now_error('There was a problem submitting your missing item report')
+      end
+    rescue StandardError => e
+      flash_now_error('There was a problem submitting your missing item report')
+      Rails.logger.error("MissingItem submission failed: #{e.class} - #{e.message}")
+    end
+    respond_to do |format|
+      format.js
     end
   end
 
@@ -45,5 +72,13 @@ class ContactController < ApplicationController
 
     def missing_item_params
       params[:missing_item_form].permit!
+    end
+
+    def flash_now_error(message)
+      flash.now[:error] = message
+    end
+
+    def flash_now_success(message)
+      flash.now[:success] = message
     end
 end

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -14,4 +14,5 @@ Blacklight.onLoad(() => {
 
 BlacklightRangeLimit.init({ onLoadHandler: Blacklight.onLoad });
 
+window.luxImport = luxImport;
 luxImport();

--- a/app/javascript/orangelight/lux_import.js
+++ b/app/javascript/orangelight/lux_import.js
@@ -21,40 +21,38 @@ import BookmarkButton from './vue_components/bookmark_button.vue';
 import HoldingGroupAvailability from './vue_components/holding_group_availability.vue';
 
 export function luxImport() {
-  const app = createApp({});
-  const createMyApp = () => createApp(app);
+  const elements = document.getElementsByClassName('lux');
+  for (let i = 0; i < elements.length; i++) {
+    const el = elements[i];
+    if (!el || el.dataset.vueMounted) continue; // Skip if already mounted or null
+    const app = createApp({});
+    app
+      .component('lux-alert', LuxAlert)
+      .component('lux-badge', LuxBadge)
+      .component('lux-icon-arrow-down', LuxIconArrowDown)
+      .component('lux-icon-arrow-right', LuxIconArrowRight)
+      .component('lux-icon-base', LuxIconBase)
+      .component('lux-icon-search', LuxIconSearch)
+      .component('lux-library-footer', LuxLibraryFooter)
+      .component('lux-card', LuxCard)
+      .component('lux-show-more', LuxShowMore)
+      .component('lux-text-style', LuxTextStyle)
+      .component('online-options', OnlineOptions)
+      .component('orangelight-header', OrangelightHeader)
+      .component('bookmark-login-dialog', BookmarkLoginDialog)
+      .component('bookmark-all-button', BookmarkAllButton)
+      .component('bookmark-button', BookmarkButton)
+      .component('holding-group-availability', HoldingGroupAvailability)
+      .mount(el);
+    el.dataset.vueMounted = 'true';
+  }
 
-  document.addEventListener('DOMContentLoaded', () => {
-    const elements = document.getElementsByClassName('lux');
-    for (let i = 0; i < elements.length; i++) {
-      createMyApp()
-        .component('lux-alert', LuxAlert)
-        .component('lux-badge', LuxBadge)
-        .component('lux-icon-arrow-down', LuxIconArrowDown)
-        .component('lux-icon-arrow-right', LuxIconArrowRight)
-        .component('lux-icon-base', LuxIconBase)
-        .component('lux-icon-search', LuxIconSearch)
-        .component('lux-library-footer', LuxLibraryFooter)
-        .component('lux-card', LuxCard)
-        .component('lux-show-more', LuxShowMore)
-        .component('lux-text-style', LuxTextStyle)
-        .component('online-options', OnlineOptions)
-        .component('orangelight-header', OrangelightHeader)
-        .component('bookmark-login-dialog', BookmarkLoginDialog)
-        .component('bookmark-all-button', BookmarkAllButton)
-        .component('bookmark-button', BookmarkButton)
-        .component('holding-group-availability', HoldingGroupAvailability)
-        .mount(elements[i]);
-    }
-    const vueapp = createApp({});
-    const createVueApp = () => createApp(vueapp);
-    const multiselects = document.getElementsByClassName(
-      'multiselect-combobox'
-    );
-    for (let i = 0; i < multiselects.length; i++) {
-      createVueApp()
-        .component('multiselect-combobox', MultiselectCombobox)
-        .mount(multiselects[i]);
-    }
-  });
+  const multiselects = document.getElementsByClassName('multiselect-combobox');
+  for (let i = 0; i < multiselects.length; i++) {
+    const el = multiselects[i];
+    if (!el || el.dataset.vueMounted) continue;
+    const app = createApp({});
+    app.component('multiselect-combobox', MultiselectCombobox).mount(el);
+    el.dataset.vueMounted = 'true';
+  }
 }

--- a/app/views/catalog/_ask_a_question_form.html.erb
+++ b/app/views/catalog/_ask_a_question_form.html.erb
@@ -16,7 +16,10 @@
     <%= f.input_field :message, as: :text, style: "width: 100%" %><br>
     <%= f.input :context, as: :hidden %>
     <%= f.input :title, as: :hidden %>
-    <%= f.input :feedback_desc, as: :hidden %>
+    <div class="visually-hidden">
+      <%= f.label :feedback_desc %>
+      <%= f.input_field :feedback_desc %>
+    </div>
     <div class="modal-footer">
       <button type="button" class="btn btn-secondary" data-bl-dismiss="modal">Cancel</button>
       <%= f.submit "Send", class: "btn btn-primary", id: 'submit-question' %>

--- a/app/views/catalog/_missing_item_form.html.erb
+++ b/app/views/catalog/_missing_item_form.html.erb
@@ -16,7 +16,10 @@
     <%= f.input_field :message, as: :text, style: "width: 100%" %><br>
     <%= f.input :context, as: :hidden %>
     <%= f.input :title, as: :hidden %>
-    <%= f.input :feedback_desc, as: :hidden %>
+    <div class="visually-hidden">
+      <%= f.label :feedback_desc %>
+      <%= f.input_field :feedback_desc %>
+    </div>
     <div class="modal-footer">
       <button type="button" class="btn btn-secondary" data-bl-dismiss="modal">Cancel</button>
       <%= f.submit "Send", class: "btn btn-primary", id: 'submit-question' %>

--- a/app/views/catalog/_suggest_correction_form.html.erb
+++ b/app/views/catalog/_suggest_correction_form.html.erb
@@ -18,7 +18,10 @@
     <%= f.input_field :message, as: :text, style: "width: 100%" %><br>
     <%= f.input :context, as: :hidden %>
     <%= f.input :title, as: :hidden %>
-    <%= f.input :feedback_desc, as: :hidden %>
+    <div class="visually-hidden">
+      <%= f.label :feedback_desc %>
+      <%= f.input_field :feedback_desc %>
+    </div>
     <div class="modal-footer">
     <button type="button" class="btn btn-secondary" data-bl-dismiss="modal">Cancel</button>
     <%= f.submit "Send", class: "btn btn-primary", id: 'submit-suggestion' %>

--- a/app/views/contact/missing_item.js.erb
+++ b/app/views/contact/missing_item.js.erb
@@ -1,0 +1,3 @@
+$(".flash_messages .container").html("<%= j(render partial: '/shared/flash_msg') %>");
+$(".modal").modal("hide");
+if (luxImport) { luxImport(); }

--- a/app/views/contact/missing_item_success.html.erb
+++ b/app/views/contact/missing_item_success.html.erb
@@ -1,6 +1,0 @@
-<%= render Blacklight::System::ModalComponent.new do |component| %>
-  <% component.with_title { t('blacklight.missing_item.form.title') } %>
-
-  <%= render partial: '/shared/flash_msg' %>
-  <span data-blacklight-modal="close"></span>
-<% end %>

--- a/app/views/contact/question.js.erb
+++ b/app/views/contact/question.js.erb
@@ -1,0 +1,3 @@
+$(".flash_messages .container").html("<%= j(render partial: '/shared/flash_msg') %>");
+$(".modal").modal("hide");
+if (luxImport) { luxImport(); }

--- a/app/views/contact/question_success.html.erb
+++ b/app/views/contact/question_success.html.erb
@@ -1,6 +1,0 @@
-<%= render Blacklight::System::ModalComponent.new do |component| %>
-  <% component.with_title { t('blacklight.question.form.title') } %>
-
-  <%= render partial: '/shared/flash_msg' %>
-  <span data-blacklight-modal="close"></span>
-<% end %>

--- a/app/views/contact/suggestion.js.erb
+++ b/app/views/contact/suggestion.js.erb
@@ -1,0 +1,3 @@
+$(".flash_messages .container").html("<%= j(render partial: '/shared/flash_msg') %>");
+$(".modal").modal("hide");
+if (luxImport) { luxImport(); }

--- a/app/views/contact/suggestion_success.html.erb
+++ b/app/views/contact/suggestion_success.html.erb
@@ -1,6 +1,0 @@
-<%= render Blacklight::System::ModalComponent.new do |component| %>
-  <% component.with_title { t('blacklight.suggestion.form.title') } %>
-
-  <%= render partial: '/shared/flash_msg' %>
-  <span data-blacklight-modal="close"></span>
-<% end %>

--- a/spec/controllers/contact_controller_spec.rb
+++ b/spec/controllers/contact_controller_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe ContactController, type: :controller do
+  before do
+    stub_libanswers_api
+  end
+  describe "#question" do
+    let(:ask_a_question_form) { instance_double(AskAQuestionForm) }
+    before do
+      allow(AskAQuestionForm).to receive(:new).and_return(ask_a_question_form)
+    end
+    it "successfully posts a question and receives a flash message" do
+      allow(ask_a_question_form).to receive(:valid?).and_return(true)
+      allow(ask_a_question_form).to receive(:submit).and_return(true)
+      post :question, params: {
+        ask_a_question_form: {
+          name: "test",
+          email: "test@princeton.edu",
+          message: "Test message"
+        }
+      }, format: :js
+
+      expect(response).to be_successful
+      expect(flash.now[:success]).to eq('Your question has been submitted')
+    end
+    it "handles an unsuccessful submission and receives a flash error message" do
+      allow(ask_a_question_form).to receive(:valid?).and_return(false)
+      allow(ask_a_question_form).to receive(:submit).and_return(false)
+
+      post :question, params: {
+        ask_a_question_form: {
+          name: "test",
+          email: "test@princeton.edu",
+          message: ""
+        }
+      }, format: :js
+
+      expect(response).to be_successful
+      expect(flash.now[:error]).to eq('There was a problem submitting your question')
+    end
+  end
+  describe "#missing_item" do
+    let(:missing_item_form) { instance_double(MissingItemForm) }
+    before do
+      allow(MissingItemForm).to receive(:new).and_return(missing_item_form)
+    end
+    it "successfully posts a missing item report and receives a flash message" do
+      allow(missing_item_form).to receive(:valid?).and_return(true)
+      allow(missing_item_form).to receive(:submit).and_return(true)
+      post :missing_item, params: {
+        missing_item_form: {
+          name: "test",
+          email: "test@princeton.edu",
+          message: "Test message"
+        }
+      }, format: :js
+
+      expect(response).to be_successful
+      expect(flash.now[:success]).to eq('Your missing item report has been submitted')
+    end
+    it "handles an unsuccessful submission and receives a flash error message" do
+      allow(missing_item_form).to receive(:valid?).and_return(false)
+      allow(missing_item_form).to receive(:submit).and_return(false)
+
+      post :missing_item, params: {
+        missing_item_form: {
+          name: "test",
+          email: "test@princeton.edu",
+          message: ""
+        }
+      }, format: :js
+
+      expect(response).to be_successful
+      expect(flash.now[:error]).to eq('There was a problem submitting your missing item report')
+    end
+  end
+  describe "#suggestion" do
+    let(:suggest_correction_form) { instance_double(SuggestCorrectionForm) }
+    before do
+      allow(SuggestCorrectionForm).to receive(:new).and_return(suggest_correction_form)
+    end
+    it "successfully posts a suggestion and receives a flash message" do
+      allow(suggest_correction_form).to receive(:valid?).and_return(true)
+      allow(suggest_correction_form).to receive(:submit).and_return(true)
+      post :suggestion, params: {
+        suggest_correction_form: {
+          name: "test",
+          email: "test@princeton.edu",
+          message: "Test message"
+        }
+      }, format: :js
+
+      expect(response).to be_successful
+      expect(flash.now[:success]).to eq('Your suggestion has been submitted')
+    end
+    it "handles an unsuccessful submission and receives a flash error message" do
+      allow(suggest_correction_form).to receive(:valid?).and_return(false)
+      allow(suggest_correction_form).to receive(:submit).and_return(false)
+
+      post :suggestion, params: {
+        suggest_correction_form: {
+          name: "test",
+          email: "test@princeton.edu",
+          message: ""
+        }
+      }, format: :js
+
+      expect(response).to be_successful
+      expect(flash.now[:error]).to eq('There was a problem submitting your suggestion')
+    end
+  end
+end

--- a/spec/requests/feedback_forms_spec.rb
+++ b/spec/requests/feedback_forms_spec.rb
@@ -39,10 +39,10 @@ RSpec.describe "feedback forms", type: :request, libanswers: true do
         action: "question",
         ask_a_question_form: {
           name: "TestUser", email: "test@test-domain.org", message: "Why?"
-        }
+        }, format: :js
       }
       expect(response).to be_successful
-      expect(flash[:success]).to eq('Your question has been submitted')
+      expect(flash.now[:success]).to eq('Your question has been submitted')
     end
   end
 end

--- a/spec/system/ask_a_question_form_spec.rb
+++ b/spec/system/ask_a_question_form_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe AskAQuestionForm, libanswers: true do
+RSpec.describe AskAQuestionForm, libanswers: true, js: true do
   context 'when a robot fills in the hidden honeypot field' do
     before do
       visit '/ask_a_question?ask_a_question_form%5Bid%5D=99101035463506421&ask_a_question_form%5Btitle%5D=Age+of+empires+%3A+art+of+the+Qin+and+Han+dynasties+%2F+Zhixin+Jason+Sun+%3B+with+contributions+by+I-tien+Hsing%2C+Cary+Y.+Liu%2C+Pengliang+Lu%2C+Lillian+Lan-ying+Tseng%2C+Yang+Hong%2C+Robin+D.+S.+Yates%2C+Zhonglin+Yukina+Zhang.'

--- a/spec/system/suggest_correction_form_spec.rb
+++ b/spec/system/suggest_correction_form_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-RSpec.describe SuggestCorrectionForm, libanswers: true do
+RSpec.describe SuggestCorrectionForm, libanswers: true, js: true do
   context 'when a robot fills in the hidden honeypot field' do
     before do
       visit '/suggest_correction?suggest_correction_form[id]=99105509673506421&suggest_correction_form[title]=Princeton+international.'


### PR DESCRIPTION
closes #5579

The issue:
* Rails ujs remote: true expects a format.js template.
* The lux-alert components needed to be remounted to get the lux styles. Otherwise after the 2 fixes we were getting a plain text.

Solution:
* Use flash.now[:success] for AJAX requests
* Create three different js.erb templates to update the flash message
with the rendered partial
* In the js.erb template call window.luxImport() to mount and style the lux-alert component
* Refactored luxImport function to mount components on all .lux elements
every time it's called not only on page load
* Rescue if an exception is raised - in this case display the flash message
* Display the flash message if
@form.valid? returns false or
@from.submit returns false and no exception is raised

related to [#5579]