### PR TITLE
Downcase patron group hash value

### DIFF
--- a/app/models/requests/patron.rb
+++ b/app/models/requests/patron.rb
@@ -43,17 +43,17 @@ module Requests
     end
 
     def patron_group
-      patron_hash[:patron_group]
+      patron_hash[:patron_group]&.downcase
     end
 
     def core_patron_group?
-      core_patron_groups = %w[P REG GRAD SENR UGRD SUM]
+      core_patron_groups = %w[p reg grad senr ugrd sum]
       core_patron_groups.include?(patron_group)
     end
 
     def affiliate_patron_group?
-      provider = %w[ACCESS Affiliate-P Affiliate GST]
-      provider.include?(patron_group)
+      affiliate_patron_groups = %w[access affiliate-p affiliate gst]
+      affiliate_patron_groups.include?(patron_group)
     end
 
     def university_id

--- a/app/models/requests/service_eligibility/abstract_on_shelf.rb
+++ b/app/models/requests/service_eligibility/abstract_on_shelf.rb
@@ -36,7 +36,7 @@ module Requests
           end
 
           def allowed_patron_groups
-            @allowed_patron_groups ||= %w[P REG GRAD SENR UGRD SUM]
+            @allowed_patron_groups ||= %w[p reg grad senr ugrd sum]
           end
 
           attr_reader :requestable, :user, :patron

--- a/app/models/requests/service_eligibility/aeon.rb
+++ b/app/models/requests/service_eligibility/aeon.rb
@@ -22,7 +22,7 @@ module Requests
       end
 
       def allowed_patron_groups
-        @allowed_patron_groups ||= %w[P REG GRAD SENR UGRD SUM]
+        @allowed_patron_groups ||= %w[p reg grad senr ugrd sum]
       end
 
     private


### PR DESCRIPTION
In the past we have added the patron group value in lower case or the wrong capitalization . As a result the validation didn't work. 
It's better to compare everything down cased to avoid mistakes