### PR TITLE
Create github action to add maintenance tickets to the maintenance board

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -1,0 +1,17 @@
+name: Adds all maintenance issues to DACS maintenance board
+on:
+  issues:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@1.0.2
+        with:
+          project-url: https://github.com/orgs/pulibrary/projects/55
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: maintenance


### PR DESCRIPTION
...this is an experiment, mainly copy/pasted from [this documentation](https://github.com/actions/add-to-project)