### PR TITLE
The github actions version needed a v prefix

### DIFF
--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@1.0.2
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/pulibrary/projects/55
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
Without it, we got the error:

```
Unable to resolve action `actions/add-to-project@1.0.2`, unable to find version `1.0.2`
```

See [this run](https://github.com/pulibrary/orangelight/actions/runs/22973763990/job/66696993233)