### PR TITLE
Use the same error message for the help forms and the feedback form.

### DIFF
--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -9,11 +9,11 @@ class ContactController < ApplicationController
       if @form.valid? && @form.submit
         flash_now_success('Your question has been submitted')
       else
-        flash_now_error('There was a problem submitting your question')
+        flash_now_error(t('blacklight.ask_a_question.form.ticket_submission_error'))
       end
-    rescue StandardError => e
-      flash_now_error('There was a problem submitting your question')
-      Rails.logger.error("AskAQuestion submission failed: #{e.class} - #{e.message}")
+    rescue StandardError
+      flash_now_error(t('blacklight.ask_a_question.form.ticket_submission_error'))
+      Rails.logger.error(t('blacklight.ask_a_question.form.ticket_submission_error'))
     end
     respond_to do |format|
       format.js
@@ -29,11 +29,11 @@ class ContactController < ApplicationController
       if @form.valid? && @form.submit
         flash_now_success('Your suggestion has been submitted')
       else
-        flash_now_error('There was a problem submitting your suggestion')
+        flash_now_error(t('blacklight.suggest_correction.form.ticket_submission_error'))
       end
-    rescue StandardError => e
-      flash_now_error('There was a problem submitting your suggestion')
-      Rails.logger.error("SuggestCorrection submission failed: #{e.class} - #{e.message}")
+    rescue StandardError
+      flash_now_error(t('blacklight.suggest_correction.form.ticket_submission_error'))
+      Rails.logger.error(t('blacklight.suggest_correction.form.ticket_submission_error'))
     end
     respond_to do |format|
       format.js
@@ -49,11 +49,11 @@ class ContactController < ApplicationController
       if @form.valid? && @form.submit
         flash_now_success('Your missing item report has been submitted')
       else
-        flash_now_error('There was a problem submitting your missing item report')
+        flash_now_error(t('blacklight.missing_item.form.ticket_submission_error'))
       end
-    rescue StandardError => e
-      flash_now_error('There was a problem submitting your missing item report')
-      Rails.logger.error("MissingItem submission failed: #{e.class} - #{e.message}")
+    rescue StandardError
+      flash_now_error(t('blacklight.missing_item.form.ticket_submission_error'))
+      Rails.logger.error(t('blacklight.missing_item.form.ticket_submission_error'))
     end
     respond_to do |format|
       format.js

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -41,7 +41,7 @@ en:
       error: 'Please fill in the required form values.'
       return: 'Back to the previous page.'
       confirmation: 'Thank you for your comments. They are helpful as we work to improve this Library service.'
-      ticket_submission_error: 'The feedback form is encountering a processing error related to your submission. For assistance, please reach out via email at ereference@princeton.edu.'
+      ticket_submission_error: 'The feedback form is currently having an issue processing your message, please reach out to ereference@princeton.edu via email for help.'
     holdings:
       linked: 'Other versions'
       online: 'Available Online'
@@ -91,12 +91,15 @@ en:
     ask_a_question:
       form:
         title: 'Ask a Question'
+        ticket_submission_error: 'The feedback form is currently having an issue processing your message, please reach out to ereference@princeton.edu via email for help.'
     suggest_correction:
       form:
         title: 'Suggest a Correction'
+        ticket_submission_error: 'The feedback form is currently having an issue processing your message, please reach out to ereference@princeton.edu via email for help.'
     missing_item:
       form:
         title: 'Report a Missing Item'
+        ticket_submission_error: 'The feedback form is currently having an issue processing your message, please reach out to ereference@princeton.edu via email for help.'
     email:
       form:
         title: 'Email the catalog record and (optional) message.'

--- a/spec/controllers/contact_controller_spec.rb
+++ b/spec/controllers/contact_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ContactController, type: :controller do
       }, format: :js
 
       expect(response).to be_successful
-      expect(flash.now[:error]).to eq('There was a problem submitting your question')
+      expect(flash.now[:error]).to eq(I18n.t('blacklight.ask_a_question.form.ticket_submission_error'))
     end
   end
   describe "#missing_item" do
@@ -72,7 +72,7 @@ RSpec.describe ContactController, type: :controller do
       }, format: :js
 
       expect(response).to be_successful
-      expect(flash.now[:error]).to eq('There was a problem submitting your missing item report')
+      expect(flash.now[:error]).to eq(I18n.t('blacklight.missing_item.form.ticket_submission_error'))
     end
   end
   describe "#suggestion" do
@@ -107,7 +107,7 @@ RSpec.describe ContactController, type: :controller do
       }, format: :js
 
       expect(response).to be_successful
-      expect(flash.now[:error]).to eq('There was a problem submitting your suggestion')
+      expect(flash.now[:error]).to eq(I18n.t('blacklight.suggest_correction.form.ticket_submission_error'))
     end
   end
 end


### PR DESCRIPTION
closes #5563 

When it fails to submit the form display the following error:
`The feedback form is currently having an issue processing your message, please reach out to ereference@princeton.edu via email for help.`