### PR TITLE
Use a single component for all top fields field rendering

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -316,7 +316,6 @@ detectors:
     - BibdataStatus
     - IlliadStatus
     - ScsbStatus
-    - AlwaysShowMetadataFieldComponent
     - BookmarkButtonComponent
     - DisplayMoreFieldComponent
     - FormatFacetItemComponent

--- a/app/components/always_show_metadata_field_component.rb
+++ b/app/components/always_show_metadata_field_component.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-class AlwaysShowMetadataFieldComponent < Blacklight::MetadataFieldComponent
-  def render?
-    true
-  end
-end

--- a/app/components/orangelight/metadata_field_component.rb
+++ b/app/components/orangelight/metadata_field_component.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# This is a more flexible version of Blacklight's MetadataFieldComponent, allowing you to
+# inject custom behavior for the labeler and whether or not to render
+class Orangelight::MetadataFieldComponent < Blacklight::MetadataFieldComponent
+  # :reek:BooleanParameter - it maintains compatibility with Blacklight::MetadataFieldComponent's API
+  # :reek:LongParameterList
+  # rubocop:disable Metrics/ParameterLists
+  def initialize(
+    field:, layout: nil, show: false, view_type: nil,
+    labeler: ->(show, field) { show ? show_field_label(field.label('show')) : index_field_label(field.label) },
+    should_render: ->(field) { field.render_field? }
+  )
+    super(field:, layout:, show:, view_type:)
+    @labeler = labeler
+    @should_render = should_render
+  end
+  # rubocop:enable Metrics/ParameterLists
+
+  def label
+    labeler.call(show, field)
+  end
+
+  def render?
+    should_render.call(field)
+  end
+
+    private
+
+      attr_reader :field, :labeler, :should_render, :show
+end

--- a/app/views/catalog/_show_top_fields.html.erb
+++ b/app/views/catalog/_show_top_fields.html.erb
@@ -6,11 +6,13 @@
     <% if render_top_field? document, field_name %>
       <% field_presenter = Blacklight::FieldPresenter.new(doc_presenter.view_context, document, field) %>
       <% if field_name == 'author_display' && document['marc_relator_display'] %>
-        <dt class="blacklight-<%= field_name.parameterize %>"><%= document['marc_relator_display'].first %></dt>
-        <dd class="blacklight-<%= field_name.parameterize %>"><%= field_presenter.render %></dd>
+        <%= render(Orangelight::MetadataFieldComponent.new(field: field_presenter,
+              show: true,
+              labeler: ->(_show, _field) { document['marc_relator_display'].first },
+              should_render: ->(_field) { true } )) %>
       <%# author is default if no marc relator, default for other fields -%>
       <% else %>
-        <%= render(AlwaysShowMetadataFieldComponent.new(field: field_presenter, show: true)) %>
+        <%= render(Orangelight::MetadataFieldComponent.new(field: field_presenter, show: true, should_render: ->(_field) { true })) %>
       <% end %>
     <% end %>
   <% end %>

--- a/spec/components/orangelight/metadata_field_component_spec.rb
+++ b/spec/components/orangelight/metadata_field_component_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+require 'rails_helper'
+RSpec.describe Orangelight::MetadataFieldComponent, type: :component do
+  it 'allows a custom label' do
+    field = instance_double(Blacklight::FieldPresenter, render_field?: true, render: ['My value'], key: 'field')
+    component = described_class.new(field:, labeler: ->(_show, _field) { 'My favorite field' })
+    rendered = render_inline component
+
+    expect(rendered.text).to include 'My favorite field'
+  end
+end


### PR DESCRIPTION
This is a Blacklight 9 compatibility issue.  Previously, we used a component called AlwaysShowMetadataFieldComponent to display the fields in the top fields except for the Author field, where we used some custom rendering that will not be compatible with Blacklight 9.

This commit makes the component more flexible to handle both cases, so we can use the same component and sidestep the Blacklight 9 compatibility issue in the Author field.

Helps with #5328 