### PR TITLE
Remove the logic that checks if requested: true then it should use the illiad service

### DIFF
--- a/app/models/requests/form.rb
+++ b/app/models/requests/form.rb
@@ -44,7 +44,7 @@ module Requests
     # Does this request object have any available copies?
     def any_loanable_copies?
       requestable_unrouted.any? do |requestable|
-        !(requestable.requested? || requestable.charged? || (requestable.aeon? || !requestable.circulates? || requestable.partner_holding? || requestable.on_reserve?))
+        !(requestable.charged? || (requestable.aeon? || !requestable.circulates? || requestable.partner_holding? || requestable.on_reserve?))
       end
     end
 

--- a/app/models/requests/service_eligibility/ill.rb
+++ b/app/models/requests/service_eligibility/ill.rb
@@ -21,7 +21,7 @@ module Requests
         private
 
           def requestable_eligible?
-            !requestable.aeon? && (requestable.charged? || requestable.requested?) && !requestable.marquand_item? &&
+            !requestable.aeon? && requestable.charged? && !requestable.marquand_item? &&
               (!any_loanable || requestable.enumerated? || requestable.preservation_conservation?)
           end
 

--- a/spec/models/requests/service_eligibility/ill_spec.rb
+++ b/spec/models/requests/service_eligibility/ill_spec.rb
@@ -19,18 +19,6 @@ RSpec.describe Requests::ServiceEligibility::ILL, requests: true do
       expect(eligibility.eligible?).to be(true)
     end
 
-    it 'returns true if the item is requested' do
-      allow(requestable).to receive_messages(
-          aeon?: false,
-          alma_managed?: true,
-          charged?: false,
-          requested?: true,
-          marquand_item?: false
-        )
-
-      expect(eligibility.eligible?).to be(true)
-    end
-
     it 'returns false if it is an aeon resource' do
       allow(requestable).to receive_messages(
           aeon?: true,
@@ -51,7 +39,7 @@ RSpec.describe Requests::ServiceEligibility::ILL, requests: true do
           alma_managed?: true,
           aeon?: false,
           charged?: true,
-          requested?: true,
+          requested?: false,
           marquand_item?: false
         )
 


### PR DESCRIPTION
keep the item requested attribute since it exists in the availability response and
we will use it later
Remove the logic that checks if requested: true then it should use the illiad service