### PR TITLE
Add 'Firestone Circulation' in the in process statuses that orangelight expects from bibdata

### DIFF
--- a/app/models/requests/requestable.rb
+++ b/app/models/requests/requestable.rb
@@ -177,7 +177,7 @@ module Requests
       end
 
       def in_process_statuses
-        ["Acquisitions and Cataloging", "In Process"]
+        ["Acquisitions and Cataloging", "In Process", "Firestone Circulation"]
       end
   end
 end


### PR DESCRIPTION
Add 'Firestone Circulation' in the in process statuses that orangelight expects from bibdata

Bibdata update is in https://github.com/pulibrary/bibdata/pull/3178 
This was discussed in the circ meeting on April 8, 2026