### PR TITLE
Remove unneeded expectation

### DIFF
--- a/smoke_spec/smoke_spec.rb
+++ b/smoke_spec/smoke_spec.rb
@@ -23,7 +23,6 @@ RSpec.describe 'Deployed environment', :staging_test do
     it 'can be performed' do
       visit uri
       expect(page).to have_link('Edit search')
-      expect(page).to have_content("You searched for:")
       expect(page).to have_content("Potato")
     end
   end


### PR DESCRIPTION
'You searched for' does not exist in the search results page.