### PR TITLE
Remove unused field-hierarchy CSS rule

### DIFF
--- a/app/assets/stylesheets/components/record--subject.scss
+++ b/app/assets/stylesheets/components/record--subject.scss
@@ -1,10 +1,5 @@
 @import "variables/colors";
 
-.field-hierarchy {
-  text-decoration: underline;
-  color: shade-color($orange, 10%);
-}
-
 .search-subject:hover,
 .search-title:hover,
 .search-name-title:hover {


### PR DESCRIPTION
It was originally added by some jquery, see https://github.com/pulibrary/orangelight/blob/41c587415bd497de5d69be46315cb1d1b514d331/app/assets/javascripts/orangelight.js#L7

We don't have this jquery or anything else adding this class anymore.