### PR TITLE
Remove our own definition of pe-none class

### DIFF
--- a/app/assets/stylesheets/shame.scss
+++ b/app/assets/stylesheets/shame.scss
@@ -106,11 +106,6 @@
   text-decoration: underline;
 }
 
-// Bootstrap 5 will include the .pe-none class
-.pe-none {
-  pointer-events: none;
-}
-
 // bootstrap 4 sets vertical-align to middle, which makes the "X" icon in the footer look wrong
 svg {
   vertical-align: unset;


### PR DESCRIPTION
Bootstrap 5 defines it for us.