### PR TITLE
Use consistent blue colors in secondary header (aka search bar)

### DIFF
--- a/app/assets/stylesheets/components/header--secondary.scss
+++ b/app/assets/stylesheets/components/header--secondary.scss
@@ -18,18 +18,9 @@
   padding: 0;
 }
 
-// Bookmarks and Course Reserves
 .header__secondary .user-utils {
-  // z-index: 2;
-  // padding-right: 0;
-  // margin-top: -46px;
-  // width: 70%;
-  // float: right;
-  // text-align: center;
 
   @media (min-width: $bp-large) {
-    // width: 30%;
-    // margin-top: 0;
     justify-content: flex-end;
     flex-basis: 0;
     flex-grow: 1;
@@ -48,7 +39,6 @@
     background: transparent;
     padding: 1rem;
     margin: 0;
-    color: shade-color($blue, 3);
 
     &:hover,
     &:focus,
@@ -64,4 +54,8 @@
       }
     }
   }
+}
+
+.header__secondary a {
+    color: var(--color-bleu-de-france-dark);
 }


### PR DESCRIPTION
Previously, the 'Advanced Search' and 'Bookmarks' links were slightly different shades.