### PR TITLE
Remove some not useful CSS from requests

### DIFF
--- a/app/assets/stylesheets/requests/request.scss
+++ b/app/assets/stylesheets/requests/request.scss
@@ -46,18 +46,9 @@
   font-size: 1.2rem; 
 }
 
-.delivery-option {
-  font-size: 1.2rem;
-  margin-bottom: 0.8rem;
-}
-
 td.request--options .card {
   margin-bottom: 1.6rem;
   padding: 1rem;
-}
-
-.selected {
-  background-color: rgba(149, 189, 228, 0.1) !important;
 }
 
 input[type="checkbox"],


### PR DESCRIPTION
* The .delivery-option class is not used
* The .selected class is used, but the color is so transparent that it does not make any visual difference.