### PR TITLE
Remove unused CSS

### DIFF
--- a/app/assets/stylesheets/components/dialog.scss
+++ b/app/assets/stylesheets/components/dialog.scss
@@ -36,11 +36,6 @@ dialog .dialog-content:focus-visible {
     outline: .25rem solid var(--color-princeton-orange-on-white) !important;
 }
 
-dialog .dialog-content .close-button:focus-visible {
-    border-radius: 20px;
-    outline: .25rem solid var(--color-princeton-orange-on-white) !important;
-}
-
 dialog .dialog-content a:focus-visible {
     border-radius: .1rem;
     outline: .25rem solid var(--color-princeton-orange-on-white) !important;


### PR DESCRIPTION
we don't have a `.close-button` class