### PR TITLE
Compile Blacklight js using vite rather than sprockets

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -16,14 +16,4 @@
 //
 //= require bootstrap
 //
-// Required by Blacklight
-//= require blacklight/blacklight
 //= require babel/polyfill
-
-// Wait for the modal to open
-document.addEventListener('show.blacklight.blacklight-modal', function () {
-  // Wait for the form to be submitted successfully
-  $('.modal_form').on('ajax:success', function () {
-    Blacklight.Modal.hide();
-  });
-});

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -1,7 +1,7 @@
 import OrangelightUiLoader from '../orangelight/orangelight_ui_loader.es6';
-
 import AvailabilityUpdater from '../orangelight/availability_updater.js';
 import { luxImport } from '../orangelight/lux_import';
+import Blacklight from 'blacklight-frontend';
 import BlacklightRangeLimit from 'blacklight-range-limit';
 
 // boot stuff
@@ -10,6 +10,14 @@ Blacklight.onLoad(() => {
   loader.run();
 
   new AvailabilityUpdater();
+});
+
+// Wait for the modal to open
+document.addEventListener('show.blacklight.blacklight-modal', function () {
+  // Wait for the form to be submitted successfully
+  $('.modal_form').on('ajax:success', function () {
+    Blacklight.Modal.hide();
+  });
 });
 
 BlacklightRangeLimit.init({ onLoadHandler: Blacklight.onLoad });

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "@apollo/client": "^3.13.0",
     "@kurkle/color": "^0.4.0",
     "@vitejs/plugin-vue": "^6.0.6",
+    "blacklight-frontend": "^9.0.0",
     "blacklight-range-limit": "^9.2.0",
     "chart.js": "^4.5.1",
     "graphql": "^16.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -836,12 +836,24 @@ bidi-js@^1.0.3:
   dependencies:
     require-from-string "^2.0.2"
 
+blacklight-frontend@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/blacklight-frontend/-/blacklight-frontend-9.0.0.tgz#74fb324ca604465ae7b89aed2f8d3df5c097f9bd"
+  integrity sha512-lvNivnINpi2gS3XLugfpEljHQV1TXMrY/0g/c94NVnAvQgvIK/trdqAGQq2Y+cdLPFjs0+L+qO3EbxjgGTxmIA==
+  dependencies:
+    bootstrap ">=5.3.5 <6.0.0"
+
 blacklight-range-limit@^9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/blacklight-range-limit/-/blacklight-range-limit-9.2.0.tgz#9314f36c185d7e8b79564dea480420e31e3d3bd0"
   integrity sha512-DLhS9JUnmpSZy+8nX5u5jfFBobPeoYwBDjcSQnuzD9/0DkO8FrIj8YDmOn9emeitvgbHfoqEYElPWamuzdirrg==
   dependencies:
     chart.js "^ 4.4.1"
+
+"bootstrap@>=5.3.5 <6.0.0":
+  version "5.3.8"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.8.tgz#6401a10057a22752d21f4e19055508980656aeed"
+  integrity sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==
 
 brace-expansion@^1.1.7:
   version "1.1.12"
@@ -2352,16 +2364,7 @@ string-argv@^0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2396,14 +2399,7 @@ string-width@^8.0.0:
     get-east-asian-width "^1.3.0"
     strip-ansi "^7.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
This has two benefits:

1. The vite bundle does not block rendering, so the user has to wait a bit less time before the page renders.
1. Vite is better at minifying JS size.  Sprockets used 19 kB (6 kB compressed) to provide the Blacklight JS, while Vite uses 7 kB (2 kB compressed)