### PR TITLE
Reduce bootstrap js package size

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,8 +12,5 @@
 //
 //= require jquery3
 //= require rails-ujs
-//= require popper
-//
-//= require bootstrap
 //
 //= require babel/polyfill

--- a/app/javascript/entrypoints/application.js
+++ b/app/javascript/entrypoints/application.js
@@ -3,6 +3,14 @@ import AvailabilityUpdater from '../orangelight/availability_updater.js';
 import { luxImport } from '../orangelight/lux_import';
 import Blacklight from 'blacklight-frontend';
 import BlacklightRangeLimit from 'blacklight-range-limit';
+import '@popperjs/core';
+import 'bootstrap/js/dist/alert';
+import 'bootstrap/js/dist/button';
+import 'bootstrap/js/dist/collapse';
+import Dropdown from 'bootstrap/js/dist/dropdown';
+import 'bootstrap/js/dist/modal';
+
+window.bootstrap = { Dropdown };
 
 // boot stuff
 Blacklight.onLoad(() => {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
     "@vitejs/plugin-vue": "^6.0.6",
     "blacklight-frontend": "^9.0.0",
     "blacklight-range-limit": "^9.2.0",
+    "bootstrap": "^5.3.8",
     "chart.js": "^4.5.1",
     "graphql": "^16.13.2",
     "lux-design-system": "^7.7.1",
+    "@popperjs/core": "^2.11.8",
     "serialize-javascript": "^7.0.5",
     "vue": "^3.5.33"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -386,6 +386,11 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
+"@popperjs/core@^2.11.8":
+  version "2.11.8"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
+  integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
+
 "@rolldown/binding-android-arm64@1.0.0-rc.17":
   version "1.0.0-rc.17"
   resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz#0a502a88c39d0ffa81aa30b561dade6f6217dcc5"
@@ -850,7 +855,7 @@ blacklight-range-limit@^9.2.0:
   dependencies:
     chart.js "^ 4.4.1"
 
-"bootstrap@>=5.3.5 <6.0.0":
+"bootstrap@>=5.3.5 <6.0.0", bootstrap@^5.3.8:
   version "5.3.8"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.8.tgz#6401a10057a22752d21f4e19055508980656aeed"
   integrity sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==
@@ -2365,6 +2370,7 @@ string-argv@^0.3.2:
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
 "string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.3:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2400,6 +2406,7 @@ string-width@^8.0.0:
     strip-ansi "^7.1.0"
 
 "strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
* Use vite rather than sprockets
* Use only the js we need

This reduces the total bundled JS size by 104 kB (uncompressed) or 18 kB (compressed).

Specifically:

||Before|After|
|---|---|---|
|sprockets package|609 kB|448 kB|
|vite package|368 kB|425 kB|
|sprockets compressed|160 kB|125 kB|
|vite compressed|115 kB|132 kB|