### PR TITLE
Only load CSS needed for the requests form when on the requests form

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,6 @@
 //= link_tree ../images
 //= link application.js
 //= link application.css
+//= link requests.css
 //= link print.css
 //= link requests/application.js

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -47,7 +47,6 @@
 @use 'components/universal-viewer';
 @use 'shame';
 
-@use "datatables";
 
 @use "blacklight_marc_customizations";
 @use "lux_customizations";
@@ -68,7 +67,6 @@
 @import 'components/record--descriptions'; // needs to override some styles in bootstrap
 @import 'components/record--need-help.scss'; // needs to be after blacklight @use since it overrides some of the blacklight css);
 @import 'components/record--sidebar'; // needs to be after blacklight @use since it overrides some of the blacklight css
-@import 'components/request'; // needs to override some styles in bootstrap
 @import 'components/search'; // needs to be after blacklight @use since it overrides some of the blacklight css
 @import 'components/skip-links'; // needs to be after blacklight @use since it overrides some of the blacklight css
 @import 'components/tables'; // needs to override some styles in bootstrap

--- a/app/assets/stylesheets/requests.scss
+++ b/app/assets/stylesheets/requests.scss
@@ -1,0 +1,2 @@
+@use "datatables";
+@use 'components/request';

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
     <% if controller.controller_name == "form" %>
       <%= javascript_include_tag 'requests/application' %>
       <%= vite_javascript_tag 'requests' %>
+      <%= stylesheet_link_tag 'requests', media: 'screen' %>
     <% else  %>
       <%= javascript_include_tag "application" %>
       <%= vite_javascript_tag 'application' %>


### PR DESCRIPTION
Reduces the CSS bundle needed for the home page, show page, search results, etc. by 16 kB.