### PR TITLE
Fix alignment of facet constraint value

### DIFF
--- a/app/assets/stylesheets/components/buttons.scss
+++ b/app/assets/stylesheets/components/buttons.scss
@@ -231,10 +231,3 @@ button.checkbox.bookmark_all {
   outline-offset: 0 !important;
 }
 
-.applied-filter .filter-name:after {
-  font-family: FontAwesome;
-  color: #777777;
-  content: "\f054";
-  font-size: 70%;
-  padding-left: 5px;
-}

--- a/app/assets/stylesheets/components/constraints.scss
+++ b/app/assets/stylesheets/components/constraints.scss
@@ -1,3 +1,9 @@
-.applied-filter {
-    height: 38px;
+#appliedParams {
+  .btn {
+    line-height: var(--line-height-heading);
+  }
+
+  .applied-filter .constraint-value .filter-name::after {
+    height: calc(var(--line-height-heading) * .92rem);
+  }
 }


### PR DESCRIPTION
Before
<img width="198" height="59" alt="the catalog has Format Book applied.  There is a carat between Format and Book, but it is lower on the screen than either of the words" src="https://github.com/user-attachments/assets/8bf4e868-740e-4921-b2d4-cc4d98ae77c0" />

After
<img width="197" height="60" alt="the catalog has Format Book applied.  The carat is aligned with the words Format and Book" src="https://github.com/user-attachments/assets/ccd67483-8fa6-4f42-837a-7ee5492b3682" />

