### PR TITLE
Remove incorrect border-spacing rule

### DIFF
--- a/app/assets/stylesheets/components/facets.scss
+++ b/app/assets/stylesheets/components/facets.scss
@@ -99,13 +99,7 @@ ul.facet-values {
 }
 
 ul.facet-values {
-  border-spacing: 0 .3em;
   margin-bottom: 0;
-
-  .facet-values,
-  > ul {
-    border-spacing: 0;
-  }
 }
 
 .pivot-facet .pivot-facet {


### PR DESCRIPTION
border-spacing only has an effect on tables, but the facets are presented as a list, not a table.