### PR TITLE
Skip links: fix a regression where they are not visible when you focus them

### DIFF
--- a/app/assets/stylesheets/components/skip-links.scss
+++ b/app/assets/stylesheets/components/skip-links.scss
@@ -2,7 +2,6 @@
     height: 2rem;
 }
 #skip-link a {
-    @include visually-hidden;
     @include visually-hidden-focusable;
     position: sticky !important;
     margin: .2rem 0;

--- a/spec/system/skip_links_spec.rb
+++ b/spec/system/skip_links_spec.rb
@@ -2,6 +2,13 @@
 
 require 'rails_helper'
 
+RSpec::Matchers.define :be_off_screen do
+  match do |selector|
+    # Check to see if the element is clipped as in bootstrap visually hidden
+    page.execute_script("return window.getComputedStyle(document.querySelector('#{selector}')).clip?.includes('rect(0')")
+  end
+end
+
 describe 'skip links', type: :system do
   before do
     stub_holding_locations
@@ -12,6 +19,13 @@ describe 'skip links', type: :system do
       it 'only has two skip links' do
         visit '/catalog?q=Uec4rvei7Aoxa'
         expect(page).to have_selector('#skip-link a', count: 2, visible: false)
+      end
+
+      it 'makes the skip link visible when focusing', js: true do
+        visit '/catalog?q=Uec4rvei7Aoxa'
+        expect('#skip-link a').to be_off_screen
+        page.execute_script('document.querySelector("#skip-link a").focus()')
+        expect('#skip-link a').not_to be_off_screen
       end
     end
 


### PR DESCRIPTION
I'm sure I introduced this at some point while mucking around with SCSS, but I'm not sure when...

Before:


<img width="658" height="232" alt="A grey area shows at the top of the screen but there is no link in it" src="https://github.com/user-attachments/assets/104bd204-49be-4620-b1e7-627ecbdcafcc" />

After:

<img width="591" height="231" alt="A Skip to Search link appears in the grey area at the top of the screen" src="https://github.com/user-attachments/assets/b87b89ca-59b8-4ff5-a319-cf578d5b47cb" />