### PR TITLE
Add language tags to Related works on the show page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -325,7 +325,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'aat_s', label: 'Getty AAT genre', component: Orangelight::ProcessVocabularyComponent
     config.add_show_field 'local_subject_display', label: 'Local Subjects', component: Orangelight::ProcessVocabularyComponent
     config.add_show_field 'fast_subject_display', label: 'FaST Subject(s)', component: Orangelight::ProcessVocabularyComponent
-    config.add_show_field 'related_works_1display', label: 'Related work(s)', helper_method: :name_title_hierarchy
+    config.add_show_field 'related_works_1display', label: 'Related work(s)', author_title_links: true, language_tag: true
     config.add_show_field 'series_display', label: 'Series', series_link: true, language_tag: true
     config.add_show_field 'contains_1display', label: 'Contains', helper_method: :name_title_hierarchy
     config.add_show_field 'data_source_display', label: 'Data source', browse_link: :name_title

--- a/app/processors/orangelight/author_title_links_processor.rb
+++ b/app/processors/orangelight/author_title_links_processor.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+module Orangelight
+  class AuthorTitleLinksProcessor < Blacklight::Rendering::AbstractStep
+    include ActionView::Helpers::UrlHelper
+
+    def render
+      if config.author_title_links
+        next_step linked
+      else
+        next_step values
+      end
+    end
+
+    private
+
+      # :reek:NestedIterators
+      # :reek:TooManyStatements
+      def linked
+        values.map do |raw|
+          parsed = JSON.parse(raw)
+          parsed.map do |heading|
+            full_name_title = heading.join(' ')
+            with_links = heading.each_with_index.map do |part, index|
+              field = index.zero? ? 'author_s' : 'name_title_browse_s'
+              search_query = StringFunctions.trim_punctuation(heading[0..index].join(' '))
+              link_to part, "/?f[#{field}][]=#{CGI.escape search_query}", class: 'search-name-title', dir: part.dir
+            end
+            (with_links + [link_to('[Browse]', "/browse/name_titles?q=#{CGI.escape full_name_title}", class: 'browse-name-title', dir: full_name_title.dir)])
+              .join(' ')
+              .html_safe # rubocop:disable Rails/OutputSafety
+          end
+        end.flatten
+      end
+  end
+end

--- a/config/initializers/blacklight.rb
+++ b/config/initializers/blacklight.rb
@@ -5,6 +5,7 @@ ActiveSupport::Reloader.to_prepare do
                                                 Orangelight::BrowseLinkProcessor,
                                                 Orangelight::LinkToFacetProcessor,
                                                 Orangelight::LinkToSearchValueProcessor,
+                                                Orangelight::AuthorTitleLinksProcessor,
                                                 Orangelight::MarkAsSafeProcessor,
                                                 Orangelight::ReferenceNoteUrlProcessor,
                                                 Orangelight::SeriesLinkProcessor,

--- a/spec/processors/orangelight/author_title_links_processor_spec.rb
+++ b/spec/processors/orangelight/author_title_links_processor_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Orangelight::AuthorTitleLinksProcessor do
+  it 'renders tags for each segment of the hierarchy' do
+    processor = described_class.new(
+      ["[[\"Beaumarchais, Pierre Augustin Caron de, 1732-1799.\",\"Barbier de Séville.\"]]"],
+      Blacklight::Configuration::Field.new(author_title_links: true),
+      SolrDocument.new,
+      {},
+      { context: 'show' },
+      [Blacklight::Rendering::Terminator]
+    )
+    rendered = processor.render.map { Nokogiri::HTML.fragment(it) }
+    expect(rendered.length).to eq 1
+    links = rendered[0].css('a')
+    expect(links.length).to eq 3
+    expect(links.map(&:text)).to eq [
+      'Beaumarchais, Pierre Augustin Caron de, 1732-1799.',
+      'Barbier de Séville.',
+      '[Browse]'
+    ]
+    expect(links.map { it.attr('href') }).to eq [
+      '/?f[author_s][]=Beaumarchais%2C+Pierre+Augustin+Caron+de%2C+1732-1799',
+      '/?f[name_title_browse_s][]=Beaumarchais%2C+Pierre+Augustin+Caron+de%2C+1732-1799.+Barbier+de+Se%CC%81ville',
+      '/browse/name_titles?q=Beaumarchais%2C+Pierre+Augustin+Caron+de%2C+1732-1799.+Barbier+de+Se%CC%81ville.'
+    ]
+  end
+end


### PR DESCRIPTION
Prior to this commit, this field was rendered by a helper function named name_title_hierarchy.  The rendering pipeline was not consulted at all, so adding `language_tag: true` in the catalog controller had no effect.

This commit adds a new processor to the rendering pipeline that creates the same output as name_title_hierarchy, and migrates the field to use it (as well as adding language_tag: true)

Helps with #2906