### PR TITLE
Don't include incorrect barcodes in the Aeon url

### DIFF
--- a/app/models/requests/aeon_url.rb
+++ b/app/models/requests/aeon_url.rb
@@ -58,7 +58,7 @@ module Requests
       end
 
       def item
-        @item ||= item_from_holding || item_from_document || Item.new({})
+        @item ||= item_from_holding || item_from_host || Item.new({})
       end
 
       def item_from_holding
@@ -66,8 +66,8 @@ module Requests
         Item.new(item_hash.with_indifferent_access) if item_hash
       end
 
-      def item_from_document
-        item_hash = @document.holdings_all_display.values.first&.fetch('items', nil)&.first
+      def item_from_host
+        item_hash = @document.host_holdings.values.first&.fetch('items', nil)&.first
         Item.new(item_hash.with_indifferent_access) if item_hash
       end
 

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -203,11 +203,10 @@ class SolrDocument
   end
 
   # host_id an Array of host id(s)
-  # appends the host_id in each host_holding
-  # merges host_holding in holdings
+  # Returns a hash of holdings from this record's host(s), if any
   # :reek:NestedIterators
-  def holdings_with_host_id(holdings)
-    host_id.reduce(holdings) do |all_holdings, id|
+  def host_holdings
+    host_id&.reduce({}) do |all_holdings, id|
       host_holdings = JSON.parse(doc_by_id(id)&.dig("holdings_1display") || '{}')
       if host_holdings.blank?
         all_holdings
@@ -216,7 +215,7 @@ class SolrDocument
           host_holdings.transform_values { |holding| holding.merge("mms_id" => id) }
         )
       end
-    end
+    end || {}
   end
 
   # Returns the holdings_1display of the record plus the holdings_1display of the host record
@@ -226,9 +225,7 @@ class SolrDocument
                    .transform_values { |holding| holding.merge("mms_id" => solr_document_id) }
 
     return holdings if host_id.blank?
-    # Append the host_id in the host_holdings
-    # merge the host_holdings in holdings
-    holdings_with_host_id(holdings)
+    holdings.merge(host_holdings)
   end
 
   def physical_holding?

--- a/spec/components/holdings/location_services_component_spec.rb
+++ b/spec/components/holdings/location_services_component_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe Holdings::LocationServicesComponent, type: :component do
     end
 
     it 'generates an aeon link including data from the host and constituent record' do
-      allow(document).to receive(:holdings_all_display).and_return({ 'host_id' => { 'items' => [{ 'barcode' => 'host123' }] } })
+      allow(document).to receive(:host_holdings).and_return({ 'host_id' => { 'items' => [{ 'barcode' => 'host123' }] } })
       expect(rendered.to_s).to include '<td class="location-services service-always-requestable"'
       expect(rendered.to_s).to include 'data-open="false"'
       expect(rendered.to_s).to include 'data-requestable="true"'
@@ -314,7 +314,7 @@ RSpec.describe Holdings::LocationServicesComponent, type: :component do
       allow(holding).to receive(:dig).and_return("99125038613506421")
     end
     it 'generates an aeon link including data from the host and constituent record' do
-      allow(document).to receive(:holdings_all_display).and_return({ 'host_id' => { 'items' => [{ 'barcode' => 'host123' }] } })
+      allow(document).to receive(:host_holdings).and_return({ 'host_id' => { 'items' => [{ 'barcode' => 'host123' }] } })
 
       expect(rendered.to_s).to include '<td class="location-services service-always-requestable"'
       expect(rendered.to_s).to include 'data-open="false"'

--- a/spec/models/requests/aeon_url_spec.rb
+++ b/spec/models/requests/aeon_url_spec.rb
@@ -129,4 +129,23 @@ RSpec.describe Requests::AeonUrl, requests: true do
       expect(subject).to include("ItemInfo1=For+conservation+reasons%2C+access+is+granted+for+compelling+reasons+only.")
     end
   end
+  context 'when the document has some holdings with items and some without' do
+    let(:holdings) do
+      {
+        "123" => { "items" => [{ "barcode" => "BARCODE" }] },
+        "456" => {}
+      }
+    end
+
+    it 'shows the barcode that is relevant to the holding' do
+      url = described_class.new(document:, holding: holdings.slice("123"))
+      expect(url.to_s).to include 'ItemNumber=BARCODE'
+    end
+
+    it 'shows does not include a barcode for the holding without items' do
+      url = described_class.new(document:, holding: holdings.slice("456"))
+      expect(url.to_s).not_to include 'ItemNumber'
+      expect(url.to_s).not_to include 'BARCODE'
+    end
+  end
 end


### PR DESCRIPTION
Before this commit, we used `holdings_all_display` as a fallback source of item information when an item was not provided.  This had the benefit of providing holding information from the host record when viewing a constituent record with no holdings of its own.  However, it had the drawback of providing completely incorrect barcodes in cases where a record had multiple holdings and some of the holdings had no items.

This commit slightly re-purposes the `holdings_with_host_id` method to provide only holdings from the host record, and uses that as the fallback in `AeonUrl`, so that we no longer get item information from other holdings on the same record.

Closes #5410