### PR TITLE
Stop calling deprecated view partial search_sidebar

### DIFF
--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,8 +1,11 @@
+<% conf = blacklight_config.view_config(document_index_view_type) %>
 <div class="col-12">
-  <%= render blacklight_config&.view_config(document_index_view_type)&.constraints_component.new(search_state: search_state) %>
+  <%= render conf&.constraints_component.new(search_state: search_state) %>
 </div>
 <div id="sidebar" class="col-12 col-md-4">
-  <%= render 'search_sidebar' %>
+  <%= render conf.sidebar_component.new(blacklight_config:,
+                                      response: @response,
+                                      view_config: conf) %>
 </div>
 
 <div id="content" class="col-12 col-md-8">


### PR DESCRIPTION
It was deprecated in https://github.com/projectblacklight/blacklight/commit/0c202f8bb88f2f4cfbf5c1673cdb44b675d2e85c#diff-a832bc305fae009c6a150a45efa7ee3bbaf60d01fc2f1a770135d55dddad5be1