### PR TITLE
Dense vector - example implementation of semantic search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ codeql_results.csv
 # Yalc
 .yalc/*
 yalc.lock
+spec/fixtures/embeddings

--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,3 @@ codeql_results.csv
 # Yalc
 .yalc/*
 yalc.lock
-spec/fixtures/embeddings

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -764,12 +764,10 @@ class CatalogController < ApplicationController
   end
 
   def index
-    
-    if params[:search_field] == 'text_embeddings'
-      rewrite_semantic_query
-    else
-      solrize_boolean_params
-    end
+    return redirect_to semantic_path(q: params[:q], search_field: 'text_embeddings') if params[:search_field] == 'text_embeddings' && params[:q].present?
+
+    solrize_boolean_params
+
     if no_search_yet?
       render_empty_search
     elsif bot_is_attempting_expensive_search?
@@ -828,31 +826,33 @@ class CatalogController < ApplicationController
     end
   end
 
-  # def semantic_search
-  #   params.permit(:q)
-  #   solr = RSolr.connect url: Blacklight.connection_config[:url]
-  #   response = solr.get '/semantic', params: {q: "{!knn f=text_embeddings topK=10}[0.010338805615901947,0.02806314453482628,0.020983939990401268]" }
-  # end
+  def semantic_search
+    query = params[:q].to_s.strip
+    if query.blank?
+      flash[:error] = "Please enter a search phrase"
+      redirect_to catalog_index_path
+    end
+
+    vector = TextEmbeddingService.new(query).query_to_vector
+    knn_q = "{!knn f=text_embeddings topK=10}#{vector}"
+
+    # solr = RSolr.connect url: Blacklight.connection_config[:url]
+    # response = solr.get '/semantic', params: {q: knn_q}
+
+    params[:search_field] = "text_embeddings"
+    # use the knn query in the solr search
+    knn_state = search_state.reset(search_state.params.merge(q: knn_q, search_field: "text_embeddings"))
+    @search_state = knn_state
+    @response, @document_list = search_service.search_results
+
+    # display the user's input query in the search box
+    @search_state = search_state.reset(search_state.params.merge(q: query, search_field: "text_embeddings"))
+
+    render :index
+    # christina remember to rescue it
+  end
 
   private
-    def rewrite_semantic_query
-      return if params[:q].blank?
-      return if params[:q].start_with?('{!knn')
-      vector = params[:q].to_s.tr('[]', '').strip
-      knn_q = "{!knn f=text_embeddings topK=10}[#{vector}]"
-      # params[:q] = Orangelight::SemanticSearchService.new(params[:q]).to_vector_query
-      params[:q] = knn_q
-      @search_state = search_state.reset(search_state.params.merge(q: knn_q))
-    end
-
-    def semantic_knn_query
-      return unless params[:search_field] == 'text_embeddings'
-      return if params[:q].blank?
-      return if params[:q].start_with?('{!knn')
-      vector_query = params[:q].to_s.strip
-      # vector_query = Orangelight::SemanticSearchService.new(params[:q]).to_vector_query
-      params[:q] = "{!knn f=text_embeddings topK=10}[#{vector_query}]"
-    end
 
     def json_request?
       request.format.json?

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -705,6 +705,12 @@ class CatalogController < ApplicationController
       field.label = 'Call number (browse)'
       field.placeholder_text = 'e.g. P19.737.3'
     end
+    config.add_search_field('text_embeddings') do |field|
+      field.include_in_advanced_search = false
+      field.label = 'Semantic search'
+      field.placeholder_text = ''
+      field.qt = '/semantic'
+    end
 
     # "sort results by" select (pulldown)
     # label in pulldown is followed by the name of the SOLR field to sort by and
@@ -758,7 +764,12 @@ class CatalogController < ApplicationController
   end
 
   def index
-    solrize_boolean_params
+    
+    if params[:search_field] == 'text_embeddings'
+      rewrite_semantic_query
+    else
+      solrize_boolean_params
+    end
     if no_search_yet?
       render_empty_search
     elsif bot_is_attempting_expensive_search?
@@ -817,7 +828,31 @@ class CatalogController < ApplicationController
     end
   end
 
+  # def semantic_search
+  #   params.permit(:q)
+  #   solr = RSolr.connect url: Blacklight.connection_config[:url]
+  #   response = solr.get '/semantic', params: {q: "{!knn f=text_embeddings topK=10}[0.010338805615901947,0.02806314453482628,0.020983939990401268]" }
+  # end
+
   private
+    def rewrite_semantic_query
+      return if params[:q].blank?
+      return if params[:q].start_with?('{!knn')
+      vector = params[:q].to_s.tr('[]', '').strip
+      knn_q = "{!knn f=text_embeddings topK=10}[#{vector}]"
+      # params[:q] = Orangelight::SemanticSearchService.new(params[:q]).to_vector_query
+      params[:q] = knn_q
+      @search_state = search_state.reset(search_state.params.merge(q: knn_q))
+    end
+
+    def semantic_knn_query
+      return unless params[:search_field] == 'text_embeddings'
+      return if params[:q].blank?
+      return if params[:q].start_with?('{!knn')
+      vector_query = params[:q].to_s.strip
+      # vector_query = Orangelight::SemanticSearchService.new(params[:q]).to_vector_query
+      params[:q] = "{!knn f=text_embeddings topK=10}[#{vector_query}]"
+    end
 
     def json_request?
       request.format.json?

--- a/app/services/text_embedding_service.rb
+++ b/app/services/text_embedding_service.rb
@@ -17,9 +17,11 @@ class TextEmbeddingService
     end
     raise "Embedding API error: #{response.status} - #{response.body}" unless response.success?
 
-    vector = response.body['embedding_binary']
+    # for testing purposes we're doing the round here and in bibdata.
+    # if the results are satisfiying we move the precision limit in the embedding python service
+    vector = response.body['embedding'].map { |e| e.round(6) }
 
-    raise 'Embedding API response missing embedding_binary array' unless vector.is_a?(Array)
+    raise 'Embedding API response missing embedding array' unless vector.is_a?(Array)
 
     vector
   end

--- a/app/services/text_embedding_service.rb
+++ b/app/services/text_embedding_service.rb
@@ -3,13 +3,34 @@
 
 class TextEmbeddingService
   def initialize(query)
-    @query = query
+    @query = query.to_s
   end
 
   def query_to_vector
     # we will host sentence transormers and
-    # the embedding process on a separate VM
+    # the embedding process on a separate VM EmbeddingService
+    # we have built a FastAPI in python to do this workq
     # this method will return the encoded query we pass in the search box
-    [0.010338805615901947, 0.02806314453482628, 0.020983939990401268]
+    # [90,78,68,92,108,82,-9,74,103,-55,-66,-121,108,44,70,-80,-73,-26,-69,-8,-22,-106,-8,-42,-22,-89,127,-1,85,66,108,118,2,71,59,78,26,-67,10,66,-91,-76,-128,-127,4,31,-9,-96,98,29,-25,74,39,-70,100,-90,106,-51,57,-32,-70,-35,0,63,52,20,-35,126,99,-60,-107,92,-103,93,-60,120,-117,18,-79,-78,-64,-128,-123,-67,-60,-56,27,100,-117,86,-9,37,-126,33,43,70]
+    response = connection.post('/embedding') do |req|
+      req.body = { text: @query }
+    end
+    raise "Embedding API error: #{response.status} - #{response.body}" unless response.success?
+
+    vector = response.body['embedding_binary']
+
+    raise 'Embedding API response missing embedding_binary array' unless vector.is_a?(Array)
+
+    vector
   end
+
+  private
+
+    def connection
+      @connection ||= Faraday.new(url: ENV.fetch('EMBEDDING_BASE', 'http://localhost:8000')) do |faraday|
+        faraday.request :json
+        faraday.response :json
+        faraday.adapter Faraday.default_adapter
+      end
+    end
 end

--- a/app/services/text_embedding_service.rb
+++ b/app/services/text_embedding_service.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+# This service will connect to a VM that hosts the sentence transformers and the embedding process
+
+class TextEmbeddingService
+  def initialize(query)
+    @query = query
+  end
+
+  def query_to_vector
+    # we will host sentence transormers and
+    # the embedding process on a separate VM
+    # this method will return the encoded query we pass in the search box
+    [0.010338805615901947, 0.02806314453482628, 0.020983939990401268]
+  end
+end

--- a/app/services/text_embedding_service.rb
+++ b/app/services/text_embedding_service.rb
@@ -19,7 +19,7 @@ class TextEmbeddingService
 
     # for testing purposes we're doing the round here and in bibdata.
     # if the results are satisfiying we move the precision limit in the embedding python service
-    vector = response.body['embedding'].map { |e| e.round(6) }
+    vector = response.body['embedding']
 
     raise 'Embedding API response missing embedding array' unless vector.is_a?(Array)
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,7 +58,7 @@ Rails.application.routes.draw do
 
   get '/numismatics', to: 'catalog#numismatics'
 
-  # get '/semantic_search', to: 'catalog#semantic_search'
+  get '/semantic', to: 'catalog#semantic_search'
 
   devise_for :users,
              controllers: { omniauth_callbacks: 'users/omniauth_callbacks', sessions: 'sessions' },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,6 +57,9 @@ Rails.application.routes.draw do
   get '/advanced', to: 'catalog#advanced_search'
 
   get '/numismatics', to: 'catalog#numismatics'
+
+  # get '/semantic_search', to: 'catalog#semantic_search'
+
   devise_for :users,
              controllers: { omniauth_callbacks: 'users/omniauth_callbacks', sessions: 'sessions' },
              skip: %i[passwords registration]

--- a/lib/tasks/pulsearch.rake
+++ b/lib/tasks/pulsearch.rake
@@ -20,7 +20,7 @@ namespace :pulsearch do
     desc 'Posts fixtures to Solr'
     task :index do
       solr = RSolr.connect url: Blacklight.connection_config[:url]
-      ['spec/fixtures/alma', 'spec/fixtures/raw'].each do |dir|
+      ['spec/fixtures/embeddings'].each do |dir|
         Dir["#{dir}/**/*.json"].each do |file_path|
           doc = JSON.parse(File.read(file_path))
           solr.add doc
@@ -40,6 +40,6 @@ namespace :pulsearch do
   private
 
     def url_for_file(file)
-      "https://raw.githubusercontent.com/pulibrary/pul_solr/main/solr_configs/catalog-production-v3/#{file}"
+      "https://raw.githubusercontent.com/pulibrary/pul_solr/catalog-denseVector/solr_configs/#{config_path}/conf/#{file}"
     end
 end

--- a/lib/tasks/pulsearch.rake
+++ b/lib/tasks/pulsearch.rake
@@ -20,7 +20,7 @@ namespace :pulsearch do
     desc 'Posts fixtures to Solr'
     task :index do
       solr = RSolr.connect url: Blacklight.connection_config[:url]
-      ['spec/fixtures/embeddings'].each do |dir|
+      ['spec/fixtures/alma', 'spec/fixtures/raw', 'spec/fixtures/embeddings'].each do |dir|
         Dir["#{dir}/**/*.json"].each do |file_path|
           doc = JSON.parse(File.read(file_path))
           solr.add doc

--- a/lib/tasks/pulsearch.rake
+++ b/lib/tasks/pulsearch.rake
@@ -40,6 +40,6 @@ namespace :pulsearch do
   private
 
     def url_for_file(file)
-      "https://raw.githubusercontent.com/pulibrary/pul_solr/catalog-denseVector/solr_configs/#{config_path}/conf/#{file}"
+      "https://raw.githubusercontent.com/pulibrary/pul_solr/catalog-denseVector/solr_configs/catalog-production-v3/#{file}"
     end
 end

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -470,7 +470,8 @@
       users normally should not need to know about them.
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
-    <fieldType name="knn_vector" class="solr.DenseVectorField" vectorDimension="3" similarityFunction="cosine" knnAlgorithm="hnsw" hnswMaxConnections="10" hnswBeamWidth="40" />
+    <!-- <fieldType name="knn_vector" class="solr.DenseVectorField" vectorDimension="768" vectorEncoding="BYTE" similarityFunction="cosine" knnAlgorithm="hnsw" hnswMaxConnections="10" hnswBeamWidth="40" /> -->
+    <fieldType name="knn_vector" class="solr.DenseVectorField" vectorDimension="96" vectorEncoding="BYTE" similarityFunction="dot_product" />
  </types>
 
 

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -470,6 +470,7 @@
       users normally should not need to know about them.
      -->
     <fieldType name="point" class="solr.PointType" dimension="2" subFieldSuffix="_d"/>
+    <fieldType name="knn_vector" class="solr.DenseVectorField" vectorDimension="3" similarityFunction="cosine" knnAlgorithm="hnsw" hnswMaxConnections="10" hnswBeamWidth="40" />
  </types>
 
 
@@ -547,6 +548,8 @@
 
     <!-- MARCXML field - stores the full MARCXML record as a string -->
    <field name="marcxml" type="string" indexed="false" stored="true" multiValued="false"/>
+   <!-- DenseVectorField field for semantic search -->
+   <field name="text_embeddings" type="knn_vector" indexed="true" stored="true"/>
 
     <!-- Dynamic field definitions.  If a field name is not found, dynamicFields
         will be used if the name matches any of the patterns.

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -385,7 +385,20 @@
       <str name="defType">lucene</str>
     </lst>
   </requestHandler>
-  
+
+  <requestHandler name="/semantic" class="solr.SearchHandler" initParams="searchParams">
+    <!-- a lucene request handler for using the JSON Query DSL, for semantic search
+         Using a separate request handler as a work around to
+         https://issues.apache.org/jira/browse/SOLR-16916
+    -->
+    <!-- default values for query parameters can be specified, these
+         will be overridden by parameters in the request
+      -->
+    <lst name="defaults">
+      <str name="defType">lucene</str>
+    </lst>
+  </requestHandler>
+
   <!-- for requests to get a single document; use id=666 instead of q=id:666 -->
   <requestHandler name="document" class="solr.SearchHandler" >
     <lst name="defaults">

--- a/spec/fixtures/embeddings/scsb_update_1_batch_1.json
+++ b/spec/fixtures/embeddings/scsb_update_1_batch_1.json
@@ -22,9 +22,9 @@
     "publisher_citation_display": "Houghton Mifflin company",
     "text": "The bright land    The bright land Fairbank, Janet Ayer 1932 4 p 3525 1 pages   Houghton Mifflin company a",
     "text_embeddings": [
-      0.9,
-      0.88,
-      0.99
+      0.005065082106739283,
+      0.020983939990401268,
+      -0.011023974977433681
     ]
   }
 ]

--- a/spec/fixtures/embeddings/scsb_update_1_batch_1.json
+++ b/spec/fixtures/embeddings/scsb_update_1_batch_1.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "9923849243506421",
+    "title_display": "Vercinge\u0301torix. Histoire du pays gaulois depuis ses origines jusqu'a\u0300 la conque\u0302te romaine",
+    "author_display": "Colomb, Georges",
+    "pub_date_display": 1947,
+    "description_display": "282 pages",
+    "publisher_citation_display": "A Fayard",
+    "text": "Vercinge\u0301torix. Histoire du pays gaulois depuis ses origines jusqu'a\u0300 la conque\u0302te romaine    Vercinge\u0301torix. Histoire du pays gaulois depuis ses origines jusqu'a\u0300 la conque\u0302te romaine Colomb, Georges 1947 282 pages 2 e\u0301d  A Fayard a",
+    "text_embeddings": [
+      0.010338805615901947,
+      0.02806314453482628,
+      0.01864738017320633
+    ]
+  },
+  {
+    "id": "9923843813506421",
+    "title_display": "The bright land",
+    "author_display": "Fairbank, Janet Ayer",
+    "pub_date_display": 1932,
+    "description_display": "4 p 3525 1 pages",
+    "publisher_citation_display": "Houghton Mifflin company",
+    "text": "The bright land    The bright land Fairbank, Janet Ayer 1932 4 p 3525 1 pages   Houghton Mifflin company a",
+    "text_embeddings": [
+      0.9,
+      0.88,
+      0.99
+    ]
+  }
+]

--- a/spec/services/test_embedding_service_spec.rb
+++ b/spec/services/test_embedding_service_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# RSpec.describe TextEmbeddingService do
+#     describe '#query_to_vector' do
+#       let(:query) { 'This is a test query' }
+#       let(:service) { described_class.new(query) }
+#       let(:embedding_response) do
+#         {
+#           'embedding_binary' => [90, 78, 68, 92, 108, 26, -67, 10, 66, -91, -76, -128, -127, 4]
+#         }
+#       end
+#     end
+# end


### PR DESCRIPTION
related to https://github.com/pulibrary/dacs_handbook/issues/351

A first attempt to add semantic search in the catalog using the existing search box and a new entry in the dropdown - 'semantic search'. 

The text embeddings were generated in my local environment using the [nearestNeighbor](https://github.com/pulibrary/dedup-text-embeddings/pull/1) branch from https://github.com/pulibrary/dedup-text-embeddings

We can do some more research on how we would like to update the UI:
- For example a new search box just for semantic search ?
- A toggle button that will switch to the semantic search and do the submit ?
- A new view that has the similar suggestions ?
- etc.

- friends with https://github.com/pulibrary/pul_solr/pull/549/changes#r3320191466
- related to https://github.com/pulibrary/dacs_handbook/issues/351

- The embeddings in this example have only 3 dimensions to match the denseVector field in https://github.com/pulibrary/pul_solr/pull/549/changes#r3320191466. Of course 3 dimensions is just for mocking up the workflow and is not in any way a realistic vector dimension.

- The model `multi-qa-mpnet-base-cos-v1` is one of the semantic search models and by default produces vectors with 768 dimensions. We can and must reduce the dimensionality ,for performance, disk size and search speed, without loosing semantic significance, for example by using PCA (Principal Component Analysis). PCA was used to test similarity and as one of the deduplication approaches. Or a different method that reduces dimensionality. - I'm familiar with PCA and this is why I have used it. 

An estimate of the size using 768 dimensions:
100,000 records 211M*10 = 2110M
For 22,000,000 records 464,200MB ~ 464.2 G

The model can also be trained and through the training, reduce dimensionality. 

- There are other models that we can test and some are built and trained using MRL (Matryoshka Representation Learning). In this case we just need to pass the number of dimensions that we want it to use. 

- Example of a search using the solr /semantic handler `http://localhost:3000/semantic?q=the+land+of+the+world&search_field=text_embeddings`


<img width="1499" height="800" alt="semantic search results" src="https://github.com/user-attachments/assets/1f7b7c21-7c19-4baa-bb10-1fbab3b7c2c7" />
