### PR TITLE
Add aria-disabled to browse list pagination Next and Previous buttons on the first and last pages, respectively

### DIFF
--- a/app/views/orangelight/browsables/_browse_pagination.html.erb
+++ b/app/views/orangelight/browsables/_browse_pagination.html.erb
@@ -1,13 +1,13 @@
 <div class="previous">
   <% if @is_first %>
-    <%= content_tag(:a, raw(t 'blacklight.pagination_compact.previous'), class: "nav-link is-disabled") %>
+    <%= content_tag(:a, raw(t 'blacklight.pagination_compact.previous'), class: "nav-link is-disabled", aria: { disabled: true }) %>
   <% else %>
   <%= link_to raw(t 'blacklight.pagination_compact.previous'), @page_link + "start=#{@prev}", class: "nav-link" %>
 <% end %>
 </div>
 <div class="next">
   <% if @is_last %>
-    <%= content_tag(:a, raw(t 'blacklight.pagination_compact.next'), class: "nav-link is-disabled") %>
+    <%= content_tag(:a, raw(t 'blacklight.pagination_compact.next'), class: "nav-link is-disabled", aria: { disabled: true }) %>
   <% else %>
     <%= link_to raw(t 'blacklight.pagination_compact.next'), @page_link + "start=#{@next}", class: "nav-link" %>
   <% end %>

--- a/spec/features/accessibility_spec.rb
+++ b/spec/features/accessibility_spec.rb
@@ -27,8 +27,6 @@ describe "accessibility", type: :feature, js: true do
   end
   context "browse list page" do
     it 'complies with wcag2aa wcag21aa next button' do
-      # Issue: https://github.com/pulibrary/orangelight/issues/4837
-      pending('increase contrast for next button when on the last page and disabled')
       visit '/browse/call_numbers?rpp=10&start=10619849'
       expect(page).to be_axe_clean
         .according_to(:wcag2a, :wcag2aa, :wcag21a, :wcag21aa)

--- a/spec/views/orangelight/browsables/_browse_pagination_spec.rb
+++ b/spec/views/orangelight/browsables/_browse_pagination_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "browse_pagination partial", type: :view do
+  describe "#previous_button" do
+    context "on first page (no previous)" do
+      it "renders disabled state with aria-disabled attribute" do
+        assign :is_first, true
+        assign :page_link, '123'
+        rendered = render 'orangelight/browsables/browse_pagination'
+        parsed = Nokogiri::HTML::DocumentFragment.parse rendered
+
+        expect(parsed.css('a').attribute('aria-disabled').value).to eq 'true'
+      end
+    end
+  end
+end


### PR DESCRIPTION

I confirmed that aXe no longer complains about the color contrast issue.

I made this with questionable help from my local qwen coder + pi.

Closes #4837