### PR TITLE
Address violations of new semgrep rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,17 +129,6 @@ jobs:
       - store_artifacts:
           path:  ~/orangelight/tmp/capybara/
 
-  bearer:
-    docker:
-      - image: cimg/ruby:3.4
-    environment:
-      # Set to default branch of your repo
-      DEFAULT_BRANCH: main
-    steps:
-      - checkout
-      - run: curl -sfL https://raw.githubusercontent.com/Bearer/bearer/main/contrib/install.sh | sh -s -- -b /tmp
-      - run: CURRENT_BRANCH=$CIRCLE_BRANCH SHA=$CIRCLE_SHA1 /tmp/bearer scan .
-
   js_tests:
       executor: basic-executor
       steps:
@@ -251,7 +240,6 @@ workflows:
          requires:
           - build
       - reek
-      - bearer
       - semgrep
       - js_tests:
          requires:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,11 +11,11 @@ updates:
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 3
+      default-days: 7
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     open-pull-requests-limit: 5
     schedule:
       interval: "weekly"
     cooldown:
-      default-days: 3
+      default-days: 7

--- a/.github/workflows/add_to_project.yml
+++ b/.github/workflows/add_to_project.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd
         with:
           project-url: https://github.com/orgs/pulibrary/projects/55
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
* Pin a github action dependency to a specific commit
* Increase dependabot cooldown period to 7
* Remove bearer (it is installed using a curl, which semgrep is concerned about -- but also we have not found it very useful).