### PR TITLE
use pkg-manager: yarn to install yarn

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,8 @@ commands:
       - node/install:
           install-yarn: true
           node-version: '24.3.0'
+      - node/install-packages:
+          pkg-manager: yarn
       - run:
           name: Check current version of node
           command: node -v


### PR DESCRIPTION
fixes

```
Latest version of Yarn is 1.22.22
Checking if YARN is already installed...
A different version of Yarn is installed (1.22.19); removing it
^@^@Installing YARN v1.22.22

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
mv: cannot stat 'yarn-v1.22.22/*': No such file or directory

Exited with code exit status 1
```
