### PR TITLE
A quick implementation test of the Solr Group selecting feature

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -746,6 +746,12 @@ class CatalogController < ApplicationController
       return true if request.env['HTTP_USER_AGENT'].blank?
       request.bot?
     }
+    config.default_solr_params = {
+      'group': true,
+      'group.field': 'cluster_id',
+      'group.limit': -1,
+      'group.ngroups': true
+    }
   end
 
   def sms_mappings

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -758,7 +758,8 @@ class CatalogController < ApplicationController
   end
 
   def index
-    solrize_boolean_params
+    result_grouping
+    # solrize_boolean_params
     if no_search_yet?
       render_empty_search
     elsif bot_is_attempting_expensive_search?
@@ -821,6 +822,11 @@ class CatalogController < ApplicationController
 
     def json_request?
       request.format.json?
+    end
+
+    def result_grouping
+      @search_state = search_state.reset(search_state.params.merge(fl: "title_display,holdings_1display", group: { field: "cluster_id" }))
+      # /select?fl=title_display,holdings_1display,cluster_id,&group=true&group.field=cluster_id&rows=1000&group.limit=-1&sort=score%20desc&group.sort=score%20desc
     end
 
     def render_empty_search

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -764,14 +764,20 @@ class CatalogController < ApplicationController
   end
 
   def index
-    result_grouping
-    # solrize_boolean_params
+    group_params = result_grouping
+    solrize_boolean_params
+    @search_state = search_state.reset(search_state.params.merge(group_params)) if group_params.present?
     if no_search_yet?
       render_empty_search
     elsif bot_is_attempting_expensive_search?
       head :uri_too_long
     else
       super
+      # The following grouping code is so that I can view in the search results page only the clusters with more than one document.
+      # Every record has a cluster_id even if it is not a duplicate
+      # groups = @response.dig('grouped', 'cluster_id', 'groups') || []
+      # @multi_doc_groups = groups.select { |g| g.dig('doclist', 'numFound').to_i > 1 }
+
     end
   rescue ActionController::BadRequest
     render file: Rails.public_path.join('x400.html'), layout: true, status: :bad_request
@@ -831,7 +837,20 @@ class CatalogController < ApplicationController
     end
 
     def result_grouping
-      @search_state = search_state.reset(search_state.params.merge(fl: "title_display,holdings_1display", group: { field: "cluster_id" }))
+      # http://localhost:3000/catalog?sort=score+desc&group=true&group.field=cluster_id&group.limit=-1&group.main=true&group.sort=score+desc&search_field=all_fields&q=cluster_id%3Aa6c4234c-bca8-4a47-9b62-ef16679fc50b
+      # assumption that we want it only for keyword search
+      return unless params[:q].present? && params[:search_field] == 'all_fields'
+
+      {
+        group: 'true',
+        'group.field': 'cluster_id',
+        'group.limit': -1,
+        'group.main': 'true',
+        'group.sort': 'score desc',
+        'sort': 'score desc'
+      }
+
+      # @search_state = search_state.reset(search_state.params.merge(group_params))
       # /select?fl=title_display,holdings_1display,cluster_id,&group=true&group.field=cluster_id&rows=1000&group.limit=-1&sort=score%20desc&group.sort=score%20desc
     end
 

--- a/app/views/catalog/_search_results.html.erb
+++ b/app/views/catalog/_search_results.html.erb
@@ -28,7 +28,7 @@
 <%- if @response.empty? %>
   <%= render "zero_results" %>
 <%- elsif render_grouped_response? %>
-  <%= Deprecation.silence(Blacklight::RenderPartialsHelperBehavior) { render_grouped_document_index } %>
+  <%= render 'group' %>
 <%- else %>
   <%= render_document_index @response.documents %>
 <%- end %>

--- a/lib/tasks/pulsearch.rake
+++ b/lib/tasks/pulsearch.rake
@@ -40,6 +40,6 @@ namespace :pulsearch do
   private
 
     def url_for_file(file)
-      "https://raw.githubusercontent.com/pulibrary/pul_solr/main/solr_configs/catalog-production-v3/#{file}"
+      "https://raw.githubusercontent.com/pulibrary/pul_solr/result-grouping-clusterid/solr_configs/catalog-production-v3/#{file}"
     end
 end

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -506,7 +506,10 @@
    <!-- these title-index display fields are NOT multi-valued -->
    <field name="title_display" type="text" indexed="true" stored="true" multiValued="false"/>
    <field name="title_vern_display" type="text" indexed="true" stored="true" multiValued="false"/>
-
+   
+   <!-- cluster id holds the id of the deduplication cluster -->
+   <field name="cluster_id" type="string" indexed="true" stored="true" multiValued="false"/>
+   
     <!-- these fields are also used for display, so they must be stored -->
    <field name="isbn_t" type="isbn" indexed="true" stored="true" multiValued="true"/>
    <field name="lccn_s" type="lccn" indexed="true" stored="true" multiValued="true"/>

--- a/solr/conf/solrconfig.xml
+++ b/solr/conf/solrconfig.xml
@@ -329,6 +329,7 @@
         id,
         score,
         author_display,
+        cluster_id,
         marc_relator_display,
         format,
         pub_created_display,


### PR DESCRIPTION
This is a quick proof of concept for Solr's result grouping feature. Assuming the XML marc files are preprocessed and each cluster is assigned a unique cluster_id - in our case, a uuid- we can group on cluster_id and configure SOLR to return 'grouped' results. 

Blacklight supports rendering grouped results and includes a view component that I didn't test. We can customize this work using Blacklight's configuration settings, or not.

The grouped search results are generated in SOLR . There is no primary cluster record indexed with merged metadata. If we decide to index a primary cluster record, we can revisit this approach and evaluate it in that context.

Next steps:
We could aggregate the holdings of each cluster into the record with the highest score and retain only that record in the cluster (primary record). 

We're still evaluating the different approaches for implementing deduplication. 

```
`http://localhost:62987/solr/bibdata-core-development/select?fl=title_display,holdings_1display,cluster_id,&group=true&group.field=cluster_id&rows=1000&group.limit=-1&sort=score%20desc&group.sort=score%20desc`

    - rows is set to 1000 so that it lists all the groups. we know that are less than 1000
    - group needs to be set to true so that it groups the results
    - group.field is cluster_id
    - group.limit is set to -1 so that we get all documents per group
    - sort is score desc so that we sort groups by relevance score first
    - group.sort is score desc so that the documents within each group are sorted by relevance score with highest first
```

related to https://github.com/pulibrary/bibdata/pull/3382
related to https://github.com/pulibrary/dacs_handbook/issues/321
related to https://github.com/pulibrary/pul_solr/pull/555
