### PR TITLE
Remove PJ from the valid annex locations for pickup

### DIFF
--- a/app/models/requests/pick_up_locations/annex_pick_up_locations.rb
+++ b/app/models/requests/pick_up_locations/annex_pick_up_locations.rb
@@ -34,7 +34,7 @@ module Requests
       def valid_annex_pickup?(location_hash)
         # This excludes PQ (Plasma) and PH (Mudd), which are not valid but are currently listed as pickup locations
         # in bibdata holding_locations.json
-        ['PA', 'PB', 'PF', 'PJ', 'PK', 'PL', 'PM', 'PT', 'PW', 'QA', 'QC', 'QL', 'QP', 'QT', 'QX'].include?(location_hash[:gfa_pickup])
+        ['PA', 'PB', 'PF', 'PK', 'PL', 'PM', 'PT', 'PW', 'QA', 'QC', 'QL', 'QP', 'QT', 'QX'].include?(location_hash[:gfa_pickup])
       end
 
       def delivery_locations

--- a/spec/models/requests/pick_up_locations/annex_pick_up_locations_spec.rb
+++ b/spec/models/requests/pick_up_locations/annex_pick_up_locations_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe Requests::PickUpLocations::AnnexPickUpLocations, :requests do
   it 'filters out invalid pickup locations' do
     form = instance_double(Requests::Form, default_pick_ups: [{ label: 'Stokes Library', gfa_pickup: 'PM' }])
     custom_locations = [
-      { label: "Valid Custom Location", gfa_pickup: "PJ", pick_up_location_code: "custom1", staff_only: false },
+      { label: "Valid Custom Location", gfa_pickup: "QA", pick_up_location_code: "custom1", staff_only: false },
       { label: "Invalid Custom Location", gfa_pickup: "ZZ", pick_up_location_code: "custom2", staff_only: false }
     ]
     requestable = instance_double(Requests::RequestableDecorator, location: { delivery_locations: custom_locations })
     locations = described_class.new(form:, requestable:)
 
-    # Only the first custom location should be returned (PJ is valid, ZZ is not)
+    # Only the first custom location should be returned (QA is valid, ZZ is not)
     expect(locations.call).to eq([custom_locations[0]])
   end
 


### PR DESCRIPTION
closes #6057

`{label: "Marquand Library of Art and Archaeology", gfa_pickup: "PJ", pick_up_location_code: "marquand", staff_only: false}`


<img width="1705" height="969" alt="annex with default pick ups does not include Marquand as a pickup" src="https://github.com/user-attachments/assets/e4ccfd06-3e51-4cbf-90f0-fa0381aa100c" />

