### PR TITLE
PF is not a valid delivery location for annex items

### DIFF
--- a/app/models/requests/pick_up_locations/annex_pick_up_locations.rb
+++ b/app/models/requests/pick_up_locations/annex_pick_up_locations.rb
@@ -32,9 +32,7 @@ module Requests
 
       # :reek:UtilityFunction
       def valid_annex_pickup?(location_hash)
-        # This excludes PQ (Plasma) and PH (Mudd), which are not valid but are currently listed as pickup locations
-        # in bibdata holding_locations.json
-        ['PA', 'PB', 'PF', 'PK', 'PL', 'PM', 'PT', 'PW', 'QA', 'QC', 'QL', 'QP', 'QT', 'QX'].include?(location_hash[:gfa_pickup])
+        ['PA', 'PB', 'PK', 'PL', 'PM', 'PT', 'PW', 'QA', 'QC', 'QL', 'QP', 'QT', 'QX'].include?(location_hash[:gfa_pickup])
       end
 
       def delivery_locations

--- a/spec/models/requests/pick_up_locations/annex_pick_up_locations_spec.rb
+++ b/spec/models/requests/pick_up_locations/annex_pick_up_locations_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe Requests::PickUpLocations::AnnexPickUpLocations, :requests do
     form = instance_double(Requests::Form, default_pick_ups: [{ label: 'Stokes Library', gfa_pickup: 'PM' }])
     custom_locations = [
       { label: "Valid Custom Location", gfa_pickup: "QA", pick_up_location_code: "custom1", staff_only: false },
-      { label: "Invalid Custom Location", gfa_pickup: "ZZ", pick_up_location_code: "custom2", staff_only: false }
+      { label: "Invalid Custom Location", gfa_pickup: "PF", pick_up_location_code: "custom2", staff_only: false }
     ]
     requestable = instance_double(Requests::RequestableDecorator, location: { delivery_locations: custom_locations })
     locations = described_class.new(form:, requestable:)
 
-    # Only the first custom location should be returned (QA is valid, ZZ is not)
+    # Only the first custom location should be returned (QA is valid, PF is not)
     expect(locations.call).to eq([custom_locations[0]])
   end
 


### PR DESCRIPTION
closes #6056

Remove PF from the method that checks if a pickup location is valid for annex items
