### PR TITLE
Firestone Library with gfa pickup PB is a microform delivery location.

### DIFF
--- a/app/models/requests/pick_up_locations/annex_pick_up_locations.rb
+++ b/app/models/requests/pick_up_locations/annex_pick_up_locations.rb
@@ -32,7 +32,7 @@ module Requests
 
       # :reek:UtilityFunction
       def valid_annex_pickup?(location_hash)
-        ['PA', 'PB', 'PK', 'PL', 'PM', 'PT', 'PW', 'QA', 'QC', 'QL', 'QP', 'QT', 'QX'].include?(location_hash[:gfa_pickup])
+        ['PA', 'PK', 'PL', 'PM', 'PT', 'PW', 'QA', 'QC', 'QL', 'QP', 'QT', 'QX'].include?(location_hash[:gfa_pickup])
       end
 
       def delivery_locations

--- a/spec/models/requests/pick_up_locations/annex_pick_up_locations_spec.rb
+++ b/spec/models/requests/pick_up_locations/annex_pick_up_locations_spec.rb
@@ -6,12 +6,13 @@ RSpec.describe Requests::PickUpLocations::AnnexPickUpLocations, :requests do
     form = instance_double(Requests::Form, default_pick_ups: [{ label: 'Stokes Library', gfa_pickup: 'PM' }])
     custom_locations = [
       { label: "Valid Custom Location", gfa_pickup: "QA", pick_up_location_code: "custom1", staff_only: false },
-      { label: "Invalid Custom Location", gfa_pickup: "PF", pick_up_location_code: "custom2", staff_only: false }
+      { label: "Invalid Custom Location", gfa_pickup: "PF", pick_up_location_code: "custom2", staff_only: false },
+      { label: "Invalid Custom Location", gfa_pickup: "PB", pick_up_location_code: "custom3", staff_only: false }
     ]
     requestable = instance_double(Requests::RequestableDecorator, location: { delivery_locations: custom_locations })
     locations = described_class.new(form:, requestable:)
 
-    # Only the first custom location should be returned (QA is valid, PF is not)
+    # Only the first custom location should be returned (QA is valid, PF and PB are not)
     expect(locations.call).to eq([custom_locations[0]])
   end
 


### PR DESCRIPTION
We dont have microforms in annex.
This is part of https://github.com/pulibrary/orangelight/issues/6056 We forgot to mention in the ticket that PB should be removed Pf is rejected based on the logic that is not the holding location `firestone$pf`

related to #6056
