### PR TITLE
Fix bug related to patron_group lib

### DIFF
--- a/app/models/requests/service_eligibility/abstract_on_shelf.rb
+++ b/app/models/requests/service_eligibility/abstract_on_shelf.rb
@@ -35,7 +35,7 @@ module Requests
           end
 
           def allowed_patron_groups
-            @allowed_patron_groups ||= %w[p reg grad senr ugrd sum]
+            @allowed_patron_groups ||= %w[p reg grad senr ugrd sum lib]
           end
 
           attr_reader :requestable, :user, :patron

--- a/app/models/requests/service_eligibility/aeon.rb
+++ b/app/models/requests/service_eligibility/aeon.rb
@@ -22,7 +22,7 @@ module Requests
       end
 
       def allowed_patron_groups
-        @allowed_patron_groups ||= %w[p reg grad senr ugrd sum]
+        @allowed_patron_groups ||= %w[p reg grad senr ugrd sum lib]
       end
 
     private


### PR DESCRIPTION
abstract_on_shelf and aeon have extra check for the patron group in the #allowed_patron_groups that we missed in a previous commit https://github.com/pulibrary/orangelight/pull/5978