### PR TITLE
Use holding source_id (if available) instead of the solr document id for Show page data-record-id attribute

### DIFF
--- a/app/components/holdings/holding_availability_component.rb
+++ b/app/components/holdings/holding_availability_component.rb
@@ -2,20 +2,26 @@
 # This component is responsible for rendering a holding's availability
 # (which will be provided by Javascript based on the DOM structure of
 # this component)
+# :reek:TooManyInstanceVariables
 class Holdings::HoldingAvailabilityComponent < ViewComponent::Base
-  def initialize(doc_id, holding_id, location_rules, temp_location_code)
+  def initialize(doc_id, holding_id, holding, location_rules, temp_location_code)
     @doc_id = doc_id
     @holding_id = holding_id
+    @holding = holding
     @location_rules = location_rules
     @temp_location_code = temp_location_code
   end
 
     private
 
-      attr_reader :doc_id, :holding_id, :temp_location_code
+      attr_reader :holding_id, :temp_location_code
 
       def aeon_location?
         location_rules[:aeon_location]
+      end
+
+      def doc_id
+        @holding['source_id'] || @doc_id
       end
 
       def location_rules

--- a/app/components/holdings/physical_holding_component.html.erb
+++ b/app/components/holdings/physical_holding_component.html.erb
@@ -19,7 +19,7 @@
         <span class="availability-icon lux-text-style red strong">Unavailable</span>
       </td>
     <% else %>
-      <%= render Holdings::HoldingAvailabilityComponent.new(doc_id, holding_id, location_rules, temp_location_code) %>
+      <%= render Holdings::HoldingAvailabilityComponent.new(doc_id, holding_id, holding, location_rules, temp_location_code) %>
     <% end %>
     <% if mapable? %>
       <%= render Holdings::LibmapButtonComponent.new(adapter, holding) %>

--- a/spec/components/holdings/holding_availability_component_spec.rb
+++ b/spec/components/holdings/holding_availability_component_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Holdings::HoldingAvailabilityComponent, type: :component do
     holding_availability = described_class.new(
       '994831543506421', # doc_id
       '22549882290006421', # holding_id
+      {}, # holding
       {}, # location_rules
       nil # temp_location_code
     )
@@ -20,10 +21,22 @@ RSpec.describe Holdings::HoldingAvailabilityComponent, type: :component do
     holding_availability = described_class.new(
       '994831543506421', # doc_id
       '22549882290006421', # holding_id
+      {}, # holding
       {}, # location_rules
       nil # temp_location_code
     )
     expect(render_inline(holding_availability).css('td span').attribute('class').value).to include 'availability-icon'
+  end
+
+  it "can use the holding source_id as the data-record-id if present" do
+    holding_availability = described_class.new(
+      '67890', # doc_id
+      '22549882290006421', # holding_id
+      { 'source_id' => '12345' }, # holding
+      {}, # location_rules
+      nil # temp_location_code
+    )
+    expect(render_inline(holding_availability).css('td').attribute('data-record-id').value).to eq '12345'
   end
 
   context "temp_location_code is RES_SHARE$IN_RS_REQ" do
@@ -31,6 +44,7 @@ RSpec.describe Holdings::HoldingAvailabilityComponent, type: :component do
       holding_availability = described_class.new(
         '994831543506421', # doc_id
         '22549882290006421', # holding_id
+        {}, # holding
         {}, # location_rules
         "RES_SHARE$IN_RS_REQ" # temp_location_code
       )
@@ -47,6 +61,7 @@ RSpec.describe Holdings::HoldingAvailabilityComponent, type: :component do
       holding_availability = described_class.new(
         '994831543506421', # doc_id
         '22549882290006421', # holding_id
+        {}, # holding
         {}, # location_rules
         "commons$stacks" # temp_location_code
       )


### PR DESCRIPTION
We use this attribute to connect bibdata availability response data with the appropriate holding on the show page.

Helps with #6107