### PR TITLE
Fix rendering of serials Location Has on show page

### DIFF
--- a/app/components/holdings/holding_notes_component.html.erb
+++ b/app/components/holdings/holding_notes_component.html.erb
@@ -1,4 +1,4 @@
-<div class="holding-details lux">
+<div class="holding-details">
   <%= if render_shelving_titles?
     render_list label: 'Shelving title', list_class: 'shelving-title', notes: holding['shelving_title']
   end %>

--- a/spec/system/show_page_holding_groups_spec.rb
+++ b/spec/system/show_page_holding_groups_spec.rb
@@ -19,4 +19,10 @@ RSpec.describe 'Holding groups on the show page', js: true do
       expect(page).to have_no_selector '.lux-badge'
     end
   end
+
+  it 'shows information about which volumes of a journal we have' do
+    stub_holding_locations
+    visit '/catalog/997218033506421'
+    expect(page).to have_text 'Vol. 1-v. 28 (published 2021)'
+  end
 end


### PR DESCRIPTION
PR #6104 inadvertently added a class class="lux", which causes an issue with Vue mounting/rendering.

In this commit, we remove the inner class="lux"

Closes #6130