### PR TITLE
Remove unnecessary test cleanup

### DIFF
--- a/spec/javascript/orangelight/availability_search_results.spec.js
+++ b/spec/javascript/orangelight/availability_search_results.spec.js
@@ -301,8 +301,6 @@ describe('AvailabilitySearchResults', function () {
       '[data-scsb-barcode="AR02546990"]'
     );
     expect(holding_status_ar02546990.textContent).toBe('Request');
-    fetchSpy.mockRestore();
-    processSpy.mockRestore();
   });
 
   describe('request_search_results_availability', () => {
@@ -384,9 +382,6 @@ describe('AvailabilitySearchResults', function () {
         'http://mock_url/bibliographic/availability.json?bib_ids=99125410673606421,9949378963506421'
       );
       expect(processSpy).toHaveBeenCalledWith(mockJson);
-
-      fetchSpy.mockRestore();
-      processSpy.mockRestore();
     });
     test('returns early when no bib IDs are found', () => {
       document.body.innerHTML = '<div class="documents-list"></div>';
@@ -396,7 +391,6 @@ describe('AvailabilitySearchResults', function () {
       searchResults.request_search_results_availability();
 
       expect(fetchSpy).not.toHaveBeenCalled();
-      fetchSpy.mockRestore();
     });
   });
 
@@ -458,9 +452,6 @@ describe('AvailabilitySearchResults', function () {
 
     expect(fetchSpy).toHaveBeenCalled();
     expect(processSpy).toHaveBeenCalledWith(mockJson);
-
-    fetchSpy.mockRestore();
-    processSpy.mockRestore();
   });
 
   describe('update_availability_undetermined', () => {

--- a/spec/javascript/orangelight/availability_show.spec.js
+++ b/spec/javascript/orangelight/availability_show.spec.js
@@ -114,10 +114,6 @@ describe('AvailabilityShow', function () {
         'http://mock_url/availability?scsb_id=15084779'
       );
       expect(processSpy).toHaveBeenCalledWith(mockJson);
-
-      fetchSpy.mockRestore();
-      processSpy.mockRestore();
-      consoleLogSpy.mockRestore();
     });
 
     test('handles fetch errors properly', async () => {
@@ -143,9 +139,6 @@ describe('AvailabilityShow', function () {
           'Failed to retrieve availability data for the SCSB record SCSB-15084779'
         )
       );
-
-      fetchSpy.mockRestore();
-      errorSpy.mockRestore();
     });
   });
 
@@ -170,9 +163,6 @@ describe('AvailabilityShow', function () {
 
       expect(scsbSpy).toHaveBeenCalled();
       expect(regularSpy).not.toHaveBeenCalled();
-
-      scsbSpy.mockRestore();
-      regularSpy.mockRestore();
     });
 
     test('calls request_show_availability for non-SCSB records', () => {
@@ -196,9 +186,6 @@ describe('AvailabilityShow', function () {
 
       expect(scsbSpy).not.toHaveBeenCalled();
       expect(regularSpy).toHaveBeenCalledWith(true);
-
-      scsbSpy.mockRestore();
-      regularSpy.mockRestore();
     });
   });
 
@@ -461,9 +448,6 @@ describe('AvailabilityShow', function () {
     expect(holding_status.classList.contains('lux-text-style')).toBe(true);
     expect(holding_status.classList.contains('green')).toBe(true);
     expect(holding_status.textContent).toBe('Some Available');
-
-    fetchSpy.mockRestore();
-    processSpy.mockRestore();
   });
 
   test('request_availability uses fetch for available NON SCSB record and calls process_single on success', async () => {
@@ -511,9 +495,6 @@ describe('AvailabilityShow', function () {
     expect(holding_status.classList.contains('lux-text-style')).toBe(true);
     expect(holding_status.classList.contains('green')).toBe(true);
     expect(holding_status.textContent).toBe('Available');
-
-    fetchSpy.mockRestore();
-    processSpy.mockRestore();
   });
   test('record in temporary location shows as available', () => {
     // Set up DOM exactly like the working test
@@ -703,10 +684,6 @@ describe('AvailabilityShow', function () {
       holding_records,
       '99125489799906421'
     );
-
-    fetchSpy.mockRestore();
-    processSpy.mockRestore();
-    update_single.mockRestore();
   });
   test('cluster record page with both a SCSB and Alma holding', async () => {
     document.body.innerHTML = `
@@ -862,9 +839,6 @@ describe('AvailabilityShow', function () {
       expect(locationTextMarquand.textContent).toBe(
         'Marquand Library - Remote Storage: Marquand Use Only'
       );
-
-      fetchSpy.mockRestore();
-      processSpy.mockRestore();
     });
     test('it will not update holding location group label when it has more than one holdings and only one of them has changed in Alma', async () => {
       document.body.innerHTML = `
@@ -1026,9 +1000,6 @@ describe('AvailabilityShow', function () {
       expect(locationTextMarquand.textContent).toBe(
         'Marquand Library - Remote Storage: Marquand Use Only'
       );
-
-      fetchSpy.mockRestore();
-      processSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
We have the following already, so these are redundant:

```
afterEach(() => vi.clearAllMocks();)
```