### PR TITLE
Remove redundant line

### DIFF
--- a/app/helpers/holdings_helper.rb
+++ b/app/helpers/holdings_helper.rb
@@ -57,7 +57,6 @@ module HoldingsHelper
       rendered_online_holdings_block = controller.view_context.render(Holdings::OnlineHoldingsIndexComponent.new(document:))
       return rendered_online_holdings_block if rendered_online_holdings_block.present?
 
-      check_availability = render_availability?
       accumulator << empty_link_online_holding_block
 
     else


### PR DESCRIPTION
There is a duplicate line a few lines up, and there has not been a chance for `check_availability` to mutate, and `render_availability?` should return the same value at any time during the request.