### PR TITLE
Update lux to 7.10 to use the new Tab interface component

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bootstrap": "^5.3.8",
     "chart.js": "^4.5.1",
     "graphql": "^16.14.2",
-    "lux-design-system": "^7.9.0",
+    "lux-design-system": "^7.10.0",
     "serialize-javascript": "^7.1.0",
     "vue": "^3.5.41"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1858,10 +1858,10 @@ lru-cache@^11.5.2:
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.5.2.tgz#00e16665c90c620fba14a3c368732a976493f760"
   integrity sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==
 
-lux-design-system@^7.9.0:
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-7.9.0.tgz#cbd5f282e31d694b968626732a60e57e869b4c8f"
-  integrity sha512-czNjpIy14tAp+u3V+dCcFkPn4zkSW34fxHU/BENwKkDwcNzPwIKxdW8nPUJ+mIV8AZplPLYdHaSm+fAFB6Ba4w==
+lux-design-system@^7.10.0:
+  version "7.10.0"
+  resolved "https://registry.yarnpkg.com/lux-design-system/-/lux-design-system-7.10.0.tgz#9e61b0a49639ff132dc648ccb596111fdcea36c2"
+  integrity sha512-YIl/hu57i+elrrz99cE5fAkqq3vTVSXcf7zPnBhc1BF3j35bQVM47iS6clYNMZUyqkAbtbyYLxiWAlRxSMQZpg==
   dependencies:
     core-js "^3.8.3"
     register-service-worker "^1.7.2"


### PR DESCRIPTION
see https://github.com/pulibrary/lux-design-system/releases/tag/v7.10.0

related to https://github.com/pulibrary/orangelight/issues/6025