### PR TITLE
Refactor and correct display of 856 links on catalog show page

### DIFF
--- a/app/components/holdings/full_online_holdings_component.html.erb
+++ b/app/components/holdings/full_online_holdings_component.html.erb
@@ -1,5 +1,16 @@
 <ul>
-  <%= electronic_access_links.html_safe %>
+  <% if electronic_access_links.any? %>
+    <% electronic_access_links.each do |link| %>
+      <li class="electronic-access">
+        <% if link.link_description %><%= link.link_description %>:<% end %>
+        <% if link.viewer_url? %>
+          <%= link_to link.link_text, link.url, class: 'electronic-access-link' %>
+        <% else %>
+          <a href="<%= link.url %>" target="_blank" rel="noopener" class="electronic-access-link"><%= link.first_text %><%= new_tab_icon %></a>
+        <% end %>
+      </li>
+    <% end %>
+  <% end %>
   <% portfolios.each do |portfolio| -%>
     <li class="electronic-access lux">
       <a href="<%= portfolio[:url] %>" target="_blank" rel="noopener" class="electronic-access-link">

--- a/app/components/holdings/full_online_holdings_component.rb
+++ b/app/components/holdings/full_online_holdings_component.rb
@@ -12,15 +12,10 @@ class Holdings::FullOnlineHoldingsComponent < ViewComponent::Base
 
   # Data from an 856 field used to render a link
   LinkData = Data.define(:url, :texts, :link_to) do
-    def electronic_access_link(new_tab_icon) = viewer_url? ? viewer_link : new_tab_link(new_tab_icon)
-
-    private
-
-      def viewer_url? = url.to_s.match?(%r{(/catalog/.+?#view)})
-      def first_text = texts.first
-      def link_text = first_text == 'arks.princeton.edu' ? 'Digital content' : first_text
-      def viewer_link = link_to.call(link_text, url, class: 'electronic-access-link')
-      def new_tab_link(new_tab_icon) = link_to.call(new_tab_icon.call(first_text), url.to_s, target: '_blank', rel: 'noopener', class: 'electronic-access-link')
+    def link_description = texts[1]
+    def viewer_url? = url.to_s.match?(%r{(/catalog/.+?#view)})
+    def link_text = first_text == 'arks.princeton.edu' ? 'Digital content' : first_text
+    def first_text = texts.first
   end
 
   private
@@ -50,28 +45,7 @@ class Holdings::FullOnlineHoldingsComponent < ViewComponent::Base
     end
 
     def render?
-      !electronic_access_links.empty? || portfolios.any?
-    end
-
-    # Generate a block of markup for an online holding
-    # @param bib_id [String] the ID for the SolrDocument
-    # @param holding_id [String] the ID for the holding
-    # @return [String] the markup
-    def online_link(bib_id, holding_id)
-      children = helpers.content_tag(
-        :span, 'Link Missing',
-        class: 'lux-text-style gray strong'
-      )
-      # AJAX requests are made using availability.js here
-      # rubocop:disable Rails/OutputSafety
-      helpers.content_tag(:div, children.html_safe,
-                          class: 'holding-block',
-                          data: {
-                            availability_record: true,
-                            record_id: bib_id,
-                            holding_id:
-                          })
-      # rubocop:enable Rails/OutputSafety
+      electronic_access_links.any? || portfolios.any?
     end
 
     # Method for cleaning URLs
@@ -86,36 +60,13 @@ class Holdings::FullOnlineHoldingsComponent < ViewComponent::Base
       end
     end
 
-    # Generate the markup for the electronic access block based on 856 links in the record
-    # Proxy Base is added to force remote access when appropriate
-    # @return [String] the markup
-    # :reek:TooManyStatements
-    # :reek:DuplicateMethodCall
     def electronic_access_links
-      markup = ''
-
-      electronic_access = adapter.doc_electronic_access
-      # rubocop:disable Rails/OutputSafety
-      electronic_access.each do |url, electronic_texts|
-        texts = electronic_texts.flatten
-        url = clean_url(url)
-
-        link = LinkData.new(url, texts, method(:link_to)).electronic_access_link(method(:new_tab_icon))
-        link = "#{texts[1]}: " + link if texts[1]
-        link = "<li>#{link}</li>" if electronic_access.many?
-        markup += helpers.content_tag(:li, link.html_safe, class: 'electronic-access')
+      adapter.doc_electronic_access.map do |url, electronic_texts|
+        LinkData.new(clean_url(url), electronic_texts.flatten, method(:link_to))
       end
-
-      return helpers.content_tag(:ul, markup.html_safe) if electronic_access.many?
-      markup
-      # rubocop:enable Rails/OutputSafety
     end
 
-    # :reek:FeatureEnvy
-    def new_tab_icon(text)
-      # rubocop:disable Rails/OutputSafety
-      text = text.html_safe
-      # rubocop:enable Rails/OutputSafety
-      text + helpers.content_tag(:i, "", class: "fa fa-external-link new-tab-icon-padding", 'aria-label': "opens in new tab", role: "img")
+    def new_tab_icon
+      helpers.content_tag(:i, "", class: "fa fa-external-link new-tab-icon-padding", 'aria-label': "opens in new tab", role: "img")
     end
 end


### PR DESCRIPTION
Move the actual tag generation to the erb template where it is more readable.

Also, this code was previously generating a <ul> with no <li> children (it was something like `<ul><ul><li></li></ul></ul>`), now it generates a standard `<ul><li></li><li></li></ul>` format