### PR TITLE
Fix layout regression for links on search results

### DIFF
--- a/app/assets/stylesheets/components/availability.scss
+++ b/app/assets/stylesheets/components/availability.scss
@@ -98,8 +98,11 @@ a > article > div > div.call-number {
   font-size: 0.75rem;
 }
 
-.lux-card.medium, .link.medium {
+.lux-card.medium {
   display: flex;
+}
+
+.lux-card.medium, .link.medium {
   flex-direction: column;
   width: 100% !important;
   padding: var(--space-small) var(--space-x-small);


### PR DESCRIPTION
Introduced by #6155

Before this fix, the "opens external resource" icon is on a new line:
<img width="785" height="267" alt="catalog search result in Korean -- the link takes up a lot of vertical space because the icon is a line below the link" src="https://github.com/user-attachments/assets/1e0a8239-1cac-4feb-9f11-6b55b175d0ff" />

After this fix:
<img width="783" height="246" alt="the same record, the link is much more compact since the icon is next to the link text" src="https://github.com/user-attachments/assets/ab48ca69-254b-4281-aacb-bc3d9c202e55" />
