### PR TITLE
Add more spacing between format badges and electronic access link

### DIFF
--- a/app/assets/stylesheets/components/availability.scss
+++ b/app/assets/stylesheets/components/availability.scss
@@ -247,6 +247,7 @@ a > article > div > div.call-number {
 
 li.electronic-access-clustered .link-container {
   display: flex;
+  gap: var(--space-xx-small);
   align-items: center;
   margin-top: var(--space-base);
   margin-bottom: var(--space-x-small);


### PR DESCRIPTION
This way, when the link has focus, the focus indicator does not collide with the format badge.

Helps with #6024

Before:
<img width="222" height="193" alt="Overdrive link is focused with a large orange focus indicator -- it collides with the audio format badge" src="https://github.com/user-attachments/assets/dca2b3d6-4b30-4ac8-9158-592b9d27432d" />

After:
<img width="273" height="197" alt="same situation, but there are a few pixels between the badge and the link" src="https://github.com/user-attachments/assets/4752627b-8871-4eae-9266-1be0b073f1b0" />
