### PR TITLE
Switch to the newer lc_pipe_facet field

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -155,7 +155,7 @@ class CatalogController < ApplicationController
 
     config.add_facet_field 'instrumentation_facet', label: 'Instrumentation', limit: true, include_in_advanced_search: false
     config.add_facet_field 'publication_place_hierarchical_pipe_facet', label: 'Place of publication', component: Blacklight::Hierarchy::FacetFieldListComponent, sort: 'index', limit: 1000, include_in_advanced_search: true, checkbox_presenter: Orangelight::PipeFacetCheckboxItemPresenter
-    config.add_facet_field 'lc_facet', label: 'Classification', component: Blacklight::Hierarchy::FacetFieldListComponent, sort: 'index', limit: 1000, include_in_advanced_search: false
+    config.add_facet_field 'lc_pipe_facet', label: 'Classification', component: Blacklight::Hierarchy::FacetFieldListComponent, sort: 'index', limit: 1000, include_in_advanced_search: false
 
     config.add_facet_field 'lc_1letter_facet', label: 'Classification', limit: 25, include_in_request: false, sort: 'index'
     config.add_facet_field 'lc_rest_facet', label: 'Full call number code', limit: 25, include_in_request: false, sort: 'index'
@@ -240,12 +240,9 @@ class CatalogController < ApplicationController
     config.add_facet_fields_to_solr_request!
 
     # Config for hierarchy options
-    # TODO: Remove non-pipe options after re-index with pipe delimiter
     config.facet_display = {
       hierarchy: {
-        'lc' => [['facet'], ':'],
         'lc_pipe' => [['facet'], '|||'],
-        'publication_place_hierarchical' => [['facet'], ':'],
         'publication_place_hierarchical_pipe' => [['facet'], '|||']
       }
     }

--- a/spec/features/facets_spec.rb
+++ b/spec/features/facets_spec.rb
@@ -82,9 +82,9 @@ describe 'Facets' do
     context 'with the hierarchical classification facet' do
       it 'renders the classification facet' do
         visit '/catalog?search_field=all_fields&q='
-        expect(page).to have_selector('.blacklight-lc_facet')
+        expect(page).to have_selector('.blacklight-lc_pipe_facet')
         # Displays all 17 LC single letter classes
-        within('.blacklight-lc_facet') do
+        within('.blacklight-lc_pipe_facet') do
           expect(page.all('.h-node').length).to eq(17)
           # The A class contains two subclasses
           expect(page.first('.h-node').all('.h-leaf').length).to eq(3)


### PR DESCRIPTION
PR #5506 inadvertently kept the legacy field and stopped using the new field.  There is no change in behavior, but this allows us to remove the legacy field from our indexing and solr.