### PR TITLE
Availability.js: do not request Alma status for IDs that are not Alma Ids

### DIFF
--- a/app/javascript/orangelight/availability_search_results.js
+++ b/app/javascript/orangelight/availability_search_results.js
@@ -7,6 +7,7 @@
   some available -> Available
 */
 import AvailabilityBase from './availability_base.js';
+import { isAlmaId } from './ids.js';
 
 export default class AvailabilitySearchResults extends AvailabilityBase {
   constructor() {
@@ -231,9 +232,9 @@ export default class AvailabilitySearchResults extends AvailabilityBase {
       document.querySelectorAll(
         "*[data-availability-record='true'][data-record-id]"
       )
-    ).map(function (node) {
-      return node.getAttribute('data-record-id');
-    });
+    )
+      .map((node) => node.getAttribute('data-record-id'))
+      .filter((id) => isAlmaId(id));
 
     return [...new Set(ids)];
   }

--- a/app/javascript/orangelight/ids.js
+++ b/app/javascript/orangelight/ids.js
@@ -1,0 +1,3 @@
+export function isAlmaId(id) {
+  return id.startsWith('99') && id.endsWith('06421');
+}

--- a/spec/javascript/orangelight/availability_search_results.spec.js
+++ b/spec/javascript/orangelight/availability_search_results.spec.js
@@ -7,6 +7,16 @@ global.console = {
 
 global.fetch = vi.fn();
 
+function mockSuccessfulAvailabilityFetch(jsonResponse) {
+  const mockResponse = {
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue(jsonResponse),
+  };
+
+  return vi.spyOn(global, 'fetch').mockResolvedValue(mockResponse);
+}
+
 describe('AvailabilitySearchResults', function () {
   let searchResults;
 
@@ -219,9 +229,58 @@ describe('AvailabilitySearchResults', function () {
     expect(availability_display_non_temp.textContent).toEqual('Request');
   });
 
+  test('request_availability includes correct Alma Ids', async () => {
+    document.body.innerHTML = `
+      <div class="documents-list"><div data-availability-record="true" data-record-id="9932127373506421"></div></div>
+    `;
+
+    mockSuccessfulAvailabilityFetch({});
+
+    searchResults.request_availability();
+    await new Promise(setImmediate);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('9932127373506421')
+    );
+  });
+
+  test('request_availability does not run if there are no valid Alma Ids', async () => {
+    document.body.innerHTML = `
+      <div class="documents-list"><div data-availability-record="true" data-record-id="f7a2277a-9fe6-4528-b12e-2e60b1a8bb80"></div></div>
+    `;
+
+    mockSuccessfulAvailabilityFetch({});
+
+    searchResults.request_availability();
+    await new Promise(setImmediate);
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test('request_availability only includes correct alma IDs in its fetch calls', async () => {
+    document.body.innerHTML = `
+      <div class="documents-list">
+        <div data-availability-record="true" data-record-id="9932127373506421"></div>
+        <div data-availability-record="true" data-record-id="f7a2277a-9fe6-4528-b12e-2e60b1a8bb80"></div>
+      </div>
+    `;
+
+    mockSuccessfulAvailabilityFetch({});
+
+    searchResults.request_availability();
+    await new Promise(setImmediate);
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining('9932127373506421')
+    );
+    expect(fetch).not.toHaveBeenCalledWith(
+      expect.stringContaining('f7a2277a-9fe6-4528-b12e-2e60b1a8bb80')
+    );
+  });
+
   test('request_search_results_availability handles fetch errors', async () => {
     document.body.innerHTML = `
-      <div data-availability-record="true" data-record-id="123"></div>
+      <div data-availability-record="true" data-record-id="9932127373506421"></div>
     `;
 
     fetch.mockRejectedValue(new Error('Network error'));


### PR DESCRIPTION
In the dedupe environment, we saw an issue in which a source_id was missing, so we fell back to trying to request availability for the document ID (in that case, a cluster UUID).  This caused bibdata to return an error, so no availability appeared on the search results page for any of the records.

We fixed the data in #6174, but this should protect us from this issue better in the future, by confirming that Alma IDs we send to bibdata are in the correct Alma MMS ID format.

This is a follow-up to the work in #6107 