### PR TITLE
6172 Adjust margin/padding in electronic holdings card

### DIFF
--- a/app/assets/stylesheets/components/availability.scss
+++ b/app/assets/stylesheets/components/availability.scss
@@ -107,7 +107,6 @@ a > article > div > div.call-number {
 .lux-card.medium, .link.medium {
   flex-direction: column;
   width: 100% !important;
-  padding: var(--space-small) var(--space-x-small);
   border-radius: 10px;
   .lux-text-style {
     margin-top: auto;

--- a/app/assets/stylesheets/components/links.scss
+++ b/app/assets/stylesheets/components/links.scss
@@ -7,7 +7,7 @@ a.important-link {
   display: inline-block;
   font-size: 0.875rem;
   display: block;
-  padding: 0.5rem;
+  padding: var(--space-x-small);
   border: solid 2px var(--color-grayscale-lighter);
   border-radius: 8px;
   margin: 0;

--- a/app/javascript/orangelight/vue_components/online_options.vue
+++ b/app/javascript/orangelight/vue_components/online_options.vue
@@ -23,7 +23,6 @@ const link = JSON.parse(props.linkJson);
 </script>
 <style scoped>
 a {
-  margin: 10px 12px;
   display: inline-block;
   font-size: 0.875rem;
 }


### PR DESCRIPTION
closes #6172 

Adjust margin/padding in electronic holdings card
- Remove padding and margin from the electronic holdings card so
that it alligns and matches better with the physical holdings card
- give important link the same variable of the body as the lux card var(--space-x-small)