### PR TITLE
Do not send extremely long queries to solr

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -5,6 +5,14 @@ class SearchBuilder < Blacklight::SearchBuilder
   include BlacklightRangeLimit::RangeLimitBuilder
   include BlacklightHelper
 
+  # The maximum number of words in a query
+  # At time of writing, solr is configured with a maximum of 1,024 clauses
+  # In the default OR search, each word counts as a clause -- and those clauses are repeated for
+  # every qf and pf we have defined in the query (50 at time of writing)
+  # Make sure you have some padding, that is to say MAX_WORDS * (QF_COUNT + PF_COUNT) should be less than 1,024
+  # You can see the clauses produced by a query in the solr ui: check the debugQuery box and check out the parsedquery
+  MAX_WORDS = 20
+
   default_processor_chain.delete(:add_facets_for_advanced_search_form)
   default_processor_chain.unshift(:conditionally_configure_json_query_dsl)
 
@@ -12,7 +20,7 @@ class SearchBuilder < Blacklight::SearchBuilder
                                      cjk_mm wildcard_char_strip
                                      only_home_facets prepare_left_anchor_search
                                      series_title_results pul_holdings html_facets
-                                     numismatics_advanced
+                                     numismatics_advanced truncate_long_queries
                                      adjust_mm remove_unneeded_facets remove_deftype]
 
   # mutate the solr_parameters to remove words that are
@@ -107,6 +115,10 @@ class SearchBuilder < Blacklight::SearchBuilder
     # Inlcuding a defType=lucene, as stock blacklight does, can cause our facet-only
     # advanced search results to be empty
     solr_parameters.delete('defType')
+  end
+
+  def truncate_long_queries(solr_parameters)
+    transform_queries!(solr_parameters) { |query| query.split(/\s/)[..MAX_WORDS].join(' ') }
   end
 
   private

--- a/spec/fixtures/alma/99131735570606421.json
+++ b/spec/fixtures/alma/99131735570606421.json
@@ -1,0 +1,103 @@
+{
+    "id": "99131735570606421",
+    "numeric_id_b": true,
+    "author_display": [
+        "Boorde, Andrew, 1490?-1549"
+    ],
+    "author_citation_display": [
+        "Boorde, Andrew"
+    ],
+    "author_roles_1display": "{\"primary_author\":\"Boorde, Andrew\",\"secondary_authors\":[],\"translators\":[],\"editors\":[],\"compilers\":[]}",
+    "author_s": [
+        "Boorde, Andrew, 1490?-1549"
+    ],
+    "marc_relator_display": [
+        "Author"
+    ],
+    "title_display": "The fyrst boke of the introduction of knowledge : The whych dothe teache a man to speake parte of all maner of languages, and to knowe the vsage and fashion of al maner of countreys. And for to know the moste parte of all maner of coynes of money, the whych is currant in euery region Made by Andrew Borde, of Physycke Doctor. Dedycated to the right honorable [and] gracio[us] lady Mary doughter of our souerayne lorde king Henry the eyght.",
+    "title_t": [
+        ""
+    ],
+    "title_citation_display": [
+        "The fyrst boke of the introduction of knowledge : The whych dothe teache a man to speake parte of all maner of languages, and to knowe the vsage and fashion of al maner of countreys. And for to know the moste parte of all maner of coynes of money, the whych is currant in euery region Made by Andrew Borde, of Physycke Doctor. Dedycated to the right honorable [and] gracio[us] lady Mary doughter of our souerayne lorde king Henry the eyght"
+    ],
+    "pub_created_display": [
+        "[Impryinted at London : In fleetestrete, at the signe of the Rose Garland, by me William Copland, [1555?]]"
+    ],
+    "pub_created_s": [
+        "[Impryinted at London : In fleetestrete, at the signe of the Rose Garland, by me William Copland, [1555?]]"
+    ],
+    "pub_citation_display": [
+        "Impryinted at London: In fleetestrete, at the signe of the Rose Garland, by me William Copland"
+    ],
+    "publication_location_citation_display": [
+        "Impryinted at London"
+    ],
+    "publisher_citation_display": [
+        "In fleetestrete, at the signe of the Rose Garland, by me William Copland"
+    ],
+    "pub_date_display": [
+        "1555"
+    ],
+    "pub_date_start_sort": 1555,
+    "publication_date_citation_display": [
+        "1555"
+    ],
+    "cataloged_tdt": "2019-09-07T20:19:43Z",
+    "format": [
+        "Book"
+    ],
+    "description_display": [
+        "[104] p. : ill."
+    ],
+    "description_t": [
+        "[104] p. : ill."
+    ],
+    "number_of_pages_citation_display": [
+        "[104] p."
+    ],
+    "notes_display": [
+        "Partly in verse.",
+        "Printer's name and address from colophon; publication date conjectured by STC.",
+        "Signatures: A-N⁴.",
+        "Reproduction of the original in the British Library."
+    ],
+    "language_name_display": [
+        "English"
+    ],
+    "language_facet": [
+        "English"
+    ],
+    "language_iana_s": [
+        "en"
+    ],
+    "mult_languages_iana_s": [
+        "en"
+    ],
+    "references_display": [
+        "STC (2nd ed.) 3383."
+    ],
+    "references_url_display": [
+        "STC (2nd ed.) 3383."
+    ],
+    "lc_subject_display": [
+        "Geography—Early works to 1800",
+        "Manners and customs—Early works to 1800"
+    ],
+    "subject_facet": [
+        "Geography—Early works to 1800",
+        "Manners and customs—Early works to 1800"
+    ],
+    "lc_subject_facet": [
+        "Geography",
+        "Geography—Early works to 1800",
+        "Manners and customs",
+        "Manners and customs—Early works to 1800"
+    ],
+    "name_title_browse_s": [
+        "Boorde, Andrew, 1490?-1549. The fyrst boke of the introduction of knowledge"
+    ],
+    "electronic_portfolio_s": [
+        "{\"desc\":null,\"title\":\"Early English Books Online\",\"url\":\"https://na05.alma.exlibrisgroup.com/view/uresolver/01PRI_INST/openurl?u.ignore_date_coverage=true\u0026portfolio_pid=53788726420006421\u0026Force_direct=true\",\"start\":null,\"end\":\"latest\",\"notes\":[]}"
+    ]
+}

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -266,4 +266,15 @@ RSpec.describe SearchBuilder do
       ).not_to have_key :defType
     end
   end
+  describe 'long queries' do
+    let(:blacklight_config) { CatalogController.blacklight_config }
+    it 'truncates them' do
+      solr_params = {
+        'q' => 'Call me Ishmael. Some years ago—never mind how long precisely—having little or no money in my purse, and nothing particular to interest me on shore, I thought I would sail about a little and see the watery part of the world. It is a way I have of driving off the spleen and regulating the circulation. Whenever I find myself growing grim about the mouth; whenever it is a damp, drizzly November in my soul; whenever I find myself involuntarily pausing before coffin warehouses, and bringing up the rear of every funeral I meet; and especially whenever my hypos get such an upper hand of me, that it requires a strong moral principle to prevent me from deliberately stepping into the street, and methodically knocking people’s hats off—then, I account it high time to get to sea as soon as I can.'
+      }
+      truncated = described_class.new(scope).with(solr_params).to_hash['q']
+      expect(truncated).to include 'Call me Ishmael'
+      expect(truncated).not_to include 'methodically knocking people’s hats off'
+    end
+  end
 end

--- a/spec/system/searching_spec.rb
+++ b/spec/system/searching_spec.rb
@@ -215,6 +215,14 @@ describe 'Searching', type: :system, js: false do
       expect(field_value).to include('Audio')
     end
   end
+
+  it 'does not error on a very long query' do
+    visit '/catalog?search_field=all_fields&q=The+fyrst+boke+of+the+introduction+of+knowledge+:+' \
+          'The+whych+dothe+teache+a+man+to+speake+parte+of+all+maner+of+languages,+and+to+knowe+the+vsage+and+fashion+of+al+maner+of+countreys.+' \
+          'And+for+to+know+the+moste+parte+of+all+maner+of+coynes+of+money,+the+whych+is+currant+in+euery+region+Made+by+Andrew+Borde,+of+Physycke+Doctor.+' \
+          'Dedycated+to+the+right+honorable+[and]+gracio[us]+lady+Mary+doughter+of+our+souerayne+lorde+king+Henry+the+eyght.'
+    expect(page).to have_link href: '/catalog/99131735570606421'
+  end
 end
 
 def search_results_count


### PR DESCRIPTION
Before this commit, we regularly got the error 'Query contains too many nested clauses' from Solr.

This commit truncates queries with more than 20 words, with the assumption that any query that long will be specific enough that the query will still likely provide the desired result.

It would be nice to also reduce the numbers of `qf`s and `pf`s in our default search, since they also contribute to this nested clause explosion.  Once we do that, we could probably increase this limit.

Helps with #5691