### PR TITLE
Pin json to 2.21

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'jbuilder', '~> 2.15'
 # jest tests use yarn to get jquery; if upgrading here keep that version in sync
 gem 'jquery-datatables' # used by requests (please do not remove)
 gem 'jquery-rails'
+gem "json", "~> 2.21"
 gem 'kicks'
 gem 'lcsort', '>= 0.9.1'
 gem 'library_stdnums'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -349,7 +349,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (3.0.2)
+    json (2.21.2)
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.2)
@@ -882,6 +882,7 @@ DEPENDENCIES
   jbuilder (~> 2.15)
   jquery-datatables
   jquery-rails
+  json (~> 2.21)
   kicks
   lcsort (>= 0.9.1)
   library_stdnums


### PR DESCRIPTION
the upgrade to json v3.0 causes issues
we pin to v2.21 .
The json issues was fixed and backported to rails 8-1-stable branch.

Instead of using this branch we pin to 2.21
and will update when a new release is published with the fixed json version

see: [post on son-gem-v3-0-upgrade-broke-rails-app](https://calvin.my/posts/the-json-gem-v3-0-upgrade-broke-rails-app)
https://github.com/rails/rails/pull/58601